### PR TITLE
feat: add Kubernetes proxy support

### DIFF
--- a/cmd/portainer-mcp/mcp.go
+++ b/cmd/portainer-mcp/mcp.go
@@ -71,6 +71,7 @@ func main() {
 	server.AddTeamFeatures()
 	server.AddAccessGroupFeatures()
 	server.AddDockerProxyFeatures()
+	server.AddKubernetesProxyFeatures()
 
 	err = server.Start()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/docker/docker v28.0.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/mark3labs/mcp-go v0.15.0
-	github.com/portainer/client-api-go/v2 v2.28.2-0.20250414223238-5d44497603b3
+	github.com/portainer/client-api-go/v2 v2.28.2-0.20250416214744-bec9753ebee0
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/portainer/client-api-go/v2 v2.28.2-0.20250414223238-5d44497603b3 h1:FqpTUyLJ11s/QlDpD1A8zzWoJphblnw/HUJqGSKe5CU=
 github.com/portainer/client-api-go/v2 v2.28.2-0.20250414223238-5d44497603b3/go.mod h1:L0VSNt2JOgUpbFGmGH8IkbjgVaCZiRC75+COX424ulw=
+github.com/portainer/client-api-go/v2 v2.28.2-0.20250416214744-bec9753ebee0 h1:jeT37EY1Q7EjCsDazC1xICv8k/BkFVEggPq9fRyO+IM=
+github.com/portainer/client-api-go/v2 v2.28.2-0.20250416214744-bec9753ebee0/go.mod h1:L0VSNt2JOgUpbFGmGH8IkbjgVaCZiRC75+COX424ulw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/internal/mcp/kubernetes.go
+++ b/internal/mcp/kubernetes.go
@@ -1,0 +1,93 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/portainer/portainer-mcp/pkg/portainer/models"
+	"github.com/portainer/portainer-mcp/pkg/toolgen"
+)
+
+func (s *PortainerMCPServer) AddKubernetesProxyFeatures() {
+	if !s.readOnly {
+		s.addToolIfExists(ToolKubernetesProxy, s.HandleKubernetesProxy())
+	}
+}
+
+func (s *PortainerMCPServer) HandleKubernetesProxy() server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		parser := toolgen.NewParameterParser(request)
+
+		environmentId, err := parser.GetInt("environmentId", true)
+		if err != nil {
+			return nil, err
+		}
+
+		method, err := parser.GetString("method", true)
+		if err != nil {
+			return nil, err
+		}
+		if !isValidHTTPMethod(method) {
+			return nil, fmt.Errorf("invalid method: %s", method)
+		}
+
+		kubernetesAPIPath, err := parser.GetString("kubernetesAPIPath", true)
+		if err != nil {
+			return nil, err
+		}
+		if !strings.HasPrefix(kubernetesAPIPath, "/") {
+			return nil, fmt.Errorf("kubernetesAPIPath must start with a leading slash")
+		}
+
+		queryParams, err := parser.GetArrayOfObjects("queryParams", false)
+		if err != nil {
+			return nil, err
+		}
+		queryParamsMap, err := parseKeyValueMap(queryParams)
+		if err != nil {
+			return nil, fmt.Errorf("invalid query params: %w", err)
+		}
+
+		headers, err := parser.GetArrayOfObjects("headers", false)
+		if err != nil {
+			return nil, err
+		}
+		headersMap, err := parseKeyValueMap(headers)
+		if err != nil {
+			return nil, fmt.Errorf("invalid headers: %w", err)
+		}
+
+		body, err := parser.GetString("body", false)
+		if err != nil {
+			return nil, err
+		}
+
+		opts := models.KubernetesProxyRequestOptions{
+			EnvironmentID: environmentId,
+			Path:          kubernetesAPIPath,
+			Method:        method,
+			QueryParams:   queryParamsMap,
+			Headers:       headersMap,
+		}
+
+		if body != "" {
+			opts.Body = strings.NewReader(body)
+		}
+
+		response, err := s.cli.ProxyKubernetesRequest(opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to send Kubernetes API request: %w", err)
+		}
+
+		responseBody, err := io.ReadAll(response.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read Kubernetes API response: %w", err)
+		}
+
+		return mcp.NewToolResultText(string(responseBody)), nil
+	}
+}

--- a/internal/mcp/kubernetes_test.go
+++ b/internal/mcp/kubernetes_test.go
@@ -1,0 +1,272 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestHandleKubernetesProxy_ParameterValidation(t *testing.T) {
+	tests := []struct {
+		name             string
+		inputParams      map[string]any
+		expectedErrorMsg string
+	}{
+		{
+			name: "invalid body type (not a string)",
+			inputParams: map[string]any{
+				"environmentId":     float64(2),
+				"kubernetesAPIPath": "/api/v1/pods",
+				"method":            "POST",
+				"body":              true, // Invalid type for body
+			},
+			expectedErrorMsg: "body must be a string",
+		},
+		{
+			name: "missing environmentId",
+			inputParams: map[string]any{
+				"kubernetesAPIPath": "/api/v1/pods",
+				"method":            "GET",
+			},
+			expectedErrorMsg: "environmentId is required",
+		},
+		{
+			name: "missing kubernetesAPIPath",
+			inputParams: map[string]any{
+				"environmentId": float64(1),
+				"method":        "GET",
+			},
+			expectedErrorMsg: "kubernetesAPIPath is required",
+		},
+		{
+			name: "missing method",
+			inputParams: map[string]any{
+				"environmentId":     float64(1),
+				"kubernetesAPIPath": "/api/v1/pods",
+			},
+			expectedErrorMsg: "method is required",
+		},
+		{
+			name: "invalid kubernetesAPIPath (no leading slash)",
+			inputParams: map[string]any{
+				"environmentId":     float64(1),
+				"kubernetesAPIPath": "api/v1/pods",
+				"method":            "GET",
+			},
+			expectedErrorMsg: "kubernetesAPIPath must start with a leading slash",
+		},
+		{
+			name: "invalid HTTP method",
+			inputParams: map[string]any{
+				"environmentId":     float64(1),
+				"kubernetesAPIPath": "/api/v1/pods",
+				"method":            "INVALID",
+			},
+			expectedErrorMsg: "invalid method: INVALID",
+		},
+		{
+			name: "invalid queryParams type (not an array)",
+			inputParams: map[string]any{
+				"environmentId":     float64(1),
+				"kubernetesAPIPath": "/api/v1/pods",
+				"method":            "GET",
+				"queryParams":       "not-an-array",
+			},
+			expectedErrorMsg: "queryParams must be an array",
+		},
+		{
+			name: "invalid queryParams content (value not string)",
+			inputParams: map[string]any{
+				"environmentId":     float64(1),
+				"kubernetesAPIPath": "/api/v1/pods",
+				"method":            "GET",
+				"queryParams":       []any{map[string]any{"key": "namespace", "value": false}},
+			},
+			expectedErrorMsg: "invalid query params: invalid value: false",
+		},
+		{
+			name: "invalid headers type (not an array)",
+			inputParams: map[string]any{
+				"environmentId":     float64(1),
+				"kubernetesAPIPath": "/api/v1/pods",
+				"method":            "GET",
+				"headers":           "header-string",
+			},
+			expectedErrorMsg: "headers must be an array",
+		},
+		{
+			name: "invalid headers content (missing value)",
+			inputParams: map[string]any{
+				"environmentId":     float64(1),
+				"kubernetesAPIPath": "/api/v1/pods",
+				"method":            "GET",
+				"headers":           []any{map[string]any{"key": "Content-Type"}},
+			},
+			expectedErrorMsg: "invalid headers: invalid value: <nil>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &PortainerMCPServer{} // No client needed for param validation
+
+			request := CreateMCPRequest(tt.inputParams)
+			handler := server.HandleKubernetesProxy()
+			result, err := handler(context.Background(), request)
+
+			assert.Error(t, err)
+			assert.ErrorContains(t, err, tt.expectedErrorMsg)
+			assert.Nil(t, result)
+		})
+	}
+}
+
+func TestHandleKubernetesProxy_ClientInteraction(t *testing.T) {
+	type testCase struct {
+		name  string
+		input map[string]any // Parameters for the MCP request
+		mock  struct {       // Details for mocking the client call
+			response *http.Response
+			err      error
+		}
+		expect struct { // Expected outcome
+			errSubstring string // Check for error containing this text (if error expected)
+			resultText   string // Expected text result (if success expected)
+		}
+	}
+
+	tests := []testCase{
+		{
+			name: "successful GET request with query params",
+			input: map[string]any{
+				"environmentId":     float64(1),
+				"kubernetesAPIPath": "/api/v1/pods",
+				"method":            "GET",
+				"queryParams": []any{
+					map[string]any{"key": "namespace", "value": "default"},
+					map[string]any{"key": "labelSelector", "value": "app=myApp"},
+				},
+			},
+			mock: struct {
+				response *http.Response
+				err      error
+			}{
+				response: createMockHttpResponse(http.StatusOK, `{"kind":"PodList","items":[]}`),
+				err:      nil,
+			},
+			expect: struct {
+				errSubstring string
+				resultText   string
+			}{
+				resultText: `{"kind":"PodList","items":[]}`,
+			},
+		},
+		{
+			name: "successful POST request with body and headers",
+			input: map[string]any{
+				"environmentId":     float64(2),
+				"kubernetesAPIPath": "/api/v1/namespaces/test/services",
+				"method":            "POST",
+				"body":              `{"apiVersion":"v1","kind":"Service","metadata":{"name":"my-service"}}`,
+				"headers": []any{
+					map[string]any{"key": "Content-Type", "value": "application/json"},
+				},
+			},
+			mock: struct {
+				response *http.Response
+				err      error
+			}{
+				response: createMockHttpResponse(http.StatusCreated, `{"metadata":{"name":"my-service"}}`),
+				err:      nil,
+			},
+			expect: struct {
+				errSubstring string
+				resultText   string
+			}{
+				resultText: `{"metadata":{"name":"my-service"}}`,
+			},
+		},
+		{
+			name: "client API error",
+			input: map[string]any{
+				"environmentId":     float64(3),
+				"kubernetesAPIPath": "/version",
+				"method":            "GET",
+			},
+			mock: struct {
+				response *http.Response
+				err      error
+			}{
+				response: nil,
+				err:      errors.New("k8s api error"),
+			},
+			expect: struct {
+				errSubstring string
+				resultText   string
+			}{
+				errSubstring: "failed to send Kubernetes API request: k8s api error",
+			},
+		},
+		{
+			name: "error reading response body",
+			input: map[string]any{
+				"environmentId":     float64(4),
+				"kubernetesAPIPath": "/healthz",
+				"method":            "GET",
+			},
+			mock: struct {
+				response *http.Response
+				err      error
+			}{
+				response: &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       &errorReader{}, // Simulate read error
+				},
+				err: nil,
+			},
+			expect: struct {
+				errSubstring string
+				resultText   string
+			}{
+				errSubstring: "failed to read Kubernetes API response: simulated read error",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := new(MockPortainerClient)
+
+			mockClient.On("ProxyKubernetesRequest", mock.AnythingOfType("models.KubernetesProxyRequestOptions")).
+				Return(tc.mock.response, tc.mock.err)
+
+			server := &PortainerMCPServer{
+				cli: mockClient,
+			}
+
+			request := CreateMCPRequest(tc.input)
+			handler := server.HandleKubernetesProxy()
+			result, err := handler(context.Background(), request)
+
+			if tc.expect.errSubstring != "" {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tc.expect.errSubstring)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Len(t, result.Content, 1)
+				textContent, ok := result.Content[0].(mcp.TextContent)
+				assert.True(t, ok)
+				assert.Equal(t, tc.expect.resultText, textContent.Text)
+			}
+
+			mockClient.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/mcp/mocks_test.go
+++ b/internal/mcp/mocks_test.go
@@ -245,3 +245,12 @@ func (m *MockPortainerClient) ProxyDockerRequest(opts models.DockerProxyRequestO
 	}
 	return args.Get(0).(*http.Response), args.Error(1)
 }
+
+// Kubernetes Proxy methods
+func (m *MockPortainerClient) ProxyKubernetesRequest(opts models.KubernetesProxyRequestOptions) (*http.Response, error) {
+	args := m.Called(opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*http.Response), args.Error(1)
+}

--- a/internal/mcp/schema.go
+++ b/internal/mcp/schema.go
@@ -37,6 +37,7 @@ const (
 	ToolUpdateEnvironmentGroupEnvironments = "updateEnvironmentGroupEnvironments"
 	ToolUpdateEnvironmentGroupTags         = "updateEnvironmentGroupTags"
 	ToolDockerProxy                        = "dockerProxy"
+	ToolKubernetesProxy                    = "kubernetesProxy"
 )
 
 // Access levels for users and teams

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -71,6 +71,9 @@ type PortainerClient interface {
 
 	// Docker Proxy methods
 	ProxyDockerRequest(opts models.DockerProxyRequestOptions) (*http.Response, error)
+
+	// Kubernetes Proxy methods
+	ProxyKubernetesRequest(opts models.KubernetesProxyRequestOptions) (*http.Response, error)
 }
 
 // PortainerMCPServer is the main server that handles MCP protocol communication

--- a/internal/tooldef/tools.yaml
+++ b/internal/tooldef/tools.yaml
@@ -459,3 +459,61 @@ tools:
           Example: {'Image': 'nginx:latest', 'Name': 'my-container'}"
         type: string
         required: false
+
+  ## Kubernetes Proxy
+  ## ------------------------------------------------------------
+  - name: kubernetesProxy
+    description: Proxy Kubernetes requests to a specific Portainer environment.
+      This tool can be used with any Kubernetes API operation as documented in the Kubernetes API specification (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/).
+    parameters:
+      - name: environmentId
+        description: The ID of the environment to proxy Kubernetes requests to
+        type: number
+        required: true
+      - name: method
+        description: The HTTP method to use to proxy the Kubernetes API operation
+        type: string
+        required: true
+        enum:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+          - HEAD
+      - name: kubernetesAPIPath
+        description: "The route of the Kubernetes API operation to proxy. Must include the leading slash. Example: /api/v1/namespaces/default/pods"
+        type: string
+        required: true
+      - name: queryParams
+        description: "The query parameters to include in the Kubernetes API operation. Must be an array of key-value pairs.
+          Example: [{key: 'watch', value: 'true'}, {key: 'fieldSelector', value: 'metadata.name=my-pod'}]"
+        type: array
+        required: false
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+              description: The key of the query parameter
+            value:
+              type: string
+              description: The value of the query parameter
+      - name: headers
+        description: "The headers to include in the Kubernetes API operation. Must be an array of key-value pairs.
+          Example: [{key: 'Content-Type', value: 'application/json'}]"
+        type: array
+        required: false
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+              description: The key of the header
+            value:
+              type: string
+              description: The value of the header
+      - name: body
+        description: "The body of the Kubernetes API operation to proxy. Must be a JSON string.
+          Example: {'apiVersion': 'v1', 'kind': 'Pod', 'metadata': {'name': 'my-pod'}}"
+        type: string
+        required: false

--- a/pkg/portainer/client/client.go
+++ b/pkg/portainer/client/client.go
@@ -37,6 +37,7 @@ type PortainerAPIClient interface {
 	UpdateUserRole(id int, role int64) error
 	GetVersion() (string, error)
 	ProxyDockerRequest(environmentId int, opts client.ProxyRequestOptions) (*http.Response, error)
+	ProxyKubernetesRequest(environmentId int, opts client.ProxyRequestOptions) (*http.Response, error)
 }
 
 // PortainerClient is a wrapper around the Portainer SDK client

--- a/pkg/portainer/client/docker_test.go
+++ b/pkg/portainer/client/docker_test.go
@@ -78,11 +78,11 @@ func TestProxyDockerRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockAPI := new(MockPortainerAPI)
 			opts := client.ProxyRequestOptions{
-				Method:        tt.opts.Method,
-				DockerAPIPath: tt.opts.Path,
-				QueryParams:   tt.opts.QueryParams,
-				Headers:       tt.opts.Headers,
-				Body:          tt.opts.Body,
+				Method:      tt.opts.Method,
+				APIPath:     tt.opts.Path,
+				QueryParams: tt.opts.QueryParams,
+				Headers:     tt.opts.Headers,
+				Body:        tt.opts.Body,
 			}
 			mockAPI.On("ProxyDockerRequest", tt.opts.EnvironmentID, opts).Return(tt.mockResponse, tt.mockError)
 

--- a/pkg/portainer/client/kubernetes.go
+++ b/pkg/portainer/client/kubernetes.go
@@ -7,15 +7,15 @@ import (
 	"github.com/portainer/portainer-mcp/pkg/portainer/models"
 )
 
-// ProxyDockerRequest proxies a Docker API request to a specific Portainer environment.
+// ProxyKubernetesRequest proxies a Kubernetes API request to a specific Portainer environment.
 //
 // Parameters:
 //   - opts: Options defining the proxied request (environmentID, method, path, query params, headers, body)
 //
 // Returns:
-//   - *http.Response: The response from the Docker API
+//   - *http.Response: The response from the Kubernetes API
 //   - error: Any error that occurred during the request
-func (c *PortainerClient) ProxyDockerRequest(opts models.DockerProxyRequestOptions) (*http.Response, error) {
+func (c *PortainerClient) ProxyKubernetesRequest(opts models.KubernetesProxyRequestOptions) (*http.Response, error) {
 	proxyOpts := client.ProxyRequestOptions{
 		Method:  opts.Method,
 		APIPath: opts.Path,
@@ -30,5 +30,5 @@ func (c *PortainerClient) ProxyDockerRequest(opts models.DockerProxyRequestOptio
 		proxyOpts.Headers = opts.Headers
 	}
 
-	return c.cli.ProxyDockerRequest(opts.EnvironmentID, proxyOpts)
+	return c.cli.ProxyKubernetesRequest(opts.EnvironmentID, proxyOpts)
 }

--- a/pkg/portainer/client/kubernetes_test.go
+++ b/pkg/portainer/client/kubernetes_test.go
@@ -1,0 +1,131 @@
+package client
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/portainer/client-api-go/v2/client"
+	"github.com/portainer/portainer-mcp/pkg/portainer/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProxyKubernetesRequest(t *testing.T) {
+	tests := []struct {
+		name             string
+		opts             models.KubernetesProxyRequestOptions
+		mockResponse     *http.Response
+		mockError        error
+		expectedError    bool
+		expectedStatus   int
+		expectedRespBody string
+	}{
+		{
+			name: "GET request with query parameters",
+			opts: models.KubernetesProxyRequestOptions{
+				EnvironmentID: 1,
+				Method:        "GET",
+				Path:          "/api/v1/pods",
+				QueryParams:   map[string]string{"namespace": "default", "labelSelector": "app=myapp"},
+			},
+			mockResponse: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"items": [{"metadata": {"name": "pod1"}}]}`)),
+			},
+			mockError:        nil,
+			expectedError:    false,
+			expectedStatus:   http.StatusOK,
+			expectedRespBody: `{"items": [{"metadata": {"name": "pod1"}}]}`,
+		},
+		{
+			name: "POST request with custom headers and body",
+			opts: models.KubernetesProxyRequestOptions{
+				EnvironmentID: 2,
+				Method:        "POST",
+				Path:          "/api/v1/namespaces/default/services",
+				Headers:       map[string]string{"X-Custom-Header": "value1", "Content-Type": "application/json"},
+				Body:          bytes.NewBufferString(`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "my-service"}}`),
+			},
+			mockResponse: &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(`{"metadata": {"name": "my-service"}}`)),
+			},
+			mockError:        nil,
+			expectedError:    false,
+			expectedStatus:   http.StatusCreated,
+			expectedRespBody: `{"metadata": {"name": "my-service"}}`,
+		},
+		{
+			name: "API error",
+			opts: models.KubernetesProxyRequestOptions{
+				EnvironmentID: 3,
+				Method:        "GET",
+				Path:          "/version",
+			},
+			mockResponse:     nil,
+			mockError:        errors.New("failed to proxy kubernetes request"),
+			expectedError:    true,
+			expectedStatus:   0,  // Not applicable
+			expectedRespBody: "", // Not applicable
+		},
+		{
+			name: "Request with no params, headers, or body",
+			opts: models.KubernetesProxyRequestOptions{
+				EnvironmentID: 4,
+				Method:        "GET",
+				Path:          "/healthz",
+			},
+			mockResponse: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("ok")),
+			},
+			mockError:        nil,
+			expectedError:    false,
+			expectedStatus:   http.StatusOK,
+			expectedRespBody: "ok",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAPI := new(MockPortainerAPI)
+			proxyOpts := client.ProxyRequestOptions{
+				Method:      tt.opts.Method,
+				APIPath:     tt.opts.Path,
+				QueryParams: tt.opts.QueryParams,
+				Headers:     tt.opts.Headers,
+				Body:        tt.opts.Body,
+			}
+			mockAPI.On("ProxyKubernetesRequest", tt.opts.EnvironmentID, proxyOpts).Return(tt.mockResponse, tt.mockError)
+
+			portainerClient := &PortainerClient{cli: mockAPI}
+
+			resp, err := portainerClient.ProxyKubernetesRequest(tt.opts)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.mockError.Error())
+				assert.Nil(t, resp)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+				assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+
+				// Read and verify the response body
+				if assert.NotNil(t, resp.Body) { // Ensure body is not nil before reading
+					defer resp.Body.Close()
+					bodyBytes, readErr := io.ReadAll(resp.Body)
+					assert.NoError(t, readErr)
+					assert.Equal(t, tt.expectedRespBody, string(bodyBytes))
+				} else if tt.expectedRespBody != "" {
+					assert.Fail(t, "Expected a response body but got nil")
+				}
+			}
+
+			mockAPI.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/portainer/client/mocks_test.go
+++ b/pkg/portainer/client/mocks_test.go
@@ -253,3 +253,12 @@ func (m *MockPortainerAPI) ProxyDockerRequest(environmentId int, opts client.Pro
 	}
 	return args.Get(0).(*http.Response), args.Error(1)
 }
+
+// ProxyKubernetesRequest mocks the ProxyKubernetesRequest method
+func (m *MockPortainerAPI) ProxyKubernetesRequest(environmentId int, opts client.ProxyRequestOptions) (*http.Response, error) {
+	args := m.Called(environmentId, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*http.Response), args.Error(1)
+}

--- a/pkg/portainer/models/kubernetes.go
+++ b/pkg/portainer/models/kubernetes.go
@@ -1,0 +1,19 @@
+package models
+
+import "io"
+
+// KubernetesProxyRequestOptions represents the options for a Kubernetes API request to a specific Portainer environment.
+type KubernetesProxyRequestOptions struct {
+	// EnvironmentID is the ID of the environment to proxy the request to.
+	EnvironmentID int
+	// Method is the HTTP method to use (GET, POST, PUT, DELETE, etc.).
+	Method string
+	// Path is the Kubernetes API endpoint path to proxy to (e.g., "/api/v1/namespaces/default/pods"). Must include the leading slash.
+	Path string
+	// QueryParams is a map of query parameters to include in the request URL.
+	QueryParams map[string]string
+	// Headers is a map of headers to include in the request.
+	Headers map[string]string
+	// Body is the request body to send (set it to nil for requests that don't have a body).
+	Body io.Reader
+}


### PR DESCRIPTION
This commit introduces a new Kubernetes proxy feature, allowing users to proxy requests to a specific Portainer environment. The implementation includes updates to the API client, server interface, and mock tests, as well as the addition of relevant documentation in the tools.yaml file. The ProxyKubernetesRequest method is now available for handling Kubernetes API operations.