### PR TITLE
chore: update Portainer MCP Server version to 0.5.1 and adjust tool c…

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -160,8 +160,8 @@ func NewPortainerMCPServer(serverURL, token, toolsPath string, options ...Server
 	return &PortainerMCPServer{
 		srv: server.NewMCPServer(
 			"Portainer MCP Server",
-			"0.1.0",
-			server.WithResourceCapabilities(true, true),
+			"0.5.1",
+			server.WithToolCapabilities(true),
 			server.WithLogging(),
 		),
 		cli:      portainerClient,


### PR DESCRIPTION
…apabilities

- Bumped the Portainer MCP Server version from 0.1.0 to 0.5.1.
- Updated server configuration to enable tool capabilities instead of resource capabilities, enhancing functionality.