### PR TITLE
chore: update mcp-go dependency to v0.32.0 and refactor request param…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/docker/go-connections v0.5.0
 	github.com/go-openapi/runtime v0.28.0
 	github.com/go-openapi/strfmt v0.23.0
-	github.com/mark3labs/mcp-go v0.24.1
+	github.com/mark3labs/mcp-go v0.32.0
 	github.com/portainer/client-api-go/v2 v2.30.0
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mark3labs/mcp-go v0.24.1 h1:YV+5X/+W4oBdERLWgiA1uR7AIvenlKJaa5V4hqufI7E=
 github.com/mark3labs/mcp-go v0.24.1/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
+github.com/mark3labs/mcp-go v0.32.0 h1:fgwmbfL2gbd67obg57OfV2Dnrhs1HtSdlY/i5fn7MU8=
+github.com/mark3labs/mcp-go v0.32.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=

--- a/internal/mcp/access_group_test.go
+++ b/internal/mcp/access_group_test.go
@@ -95,8 +95,10 @@ func TestHandleCreateAccessGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "group1"
-				request.Params.Arguments["environmentIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"name":           "group1",
+					"environmentIds": []any{float64(1), float64(2), float64(3)},
+				}
 			},
 		},
 		{
@@ -107,8 +109,10 @@ func TestHandleCreateAccessGroup(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "group1"
-				request.Params.Arguments["environmentIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"name":           "group1",
+					"environmentIds": []any{float64(1), float64(2), float64(3)},
+				}
 			},
 		},
 		{
@@ -117,7 +121,9 @@ func TestHandleCreateAccessGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["environmentIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"environmentIds": []any{float64(1), float64(2), float64(3)},
+				}
 			},
 		},
 		{
@@ -126,8 +132,10 @@ func TestHandleCreateAccessGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "group1"
-				request.Params.Arguments["environmentIds"] = "not an array"
+				request.Params.Arguments = map[string]any{
+					"name":           "group1",
+					"environmentIds": "not an array",
+				}
 			},
 		},
 		{
@@ -136,8 +144,10 @@ func TestHandleCreateAccessGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "group1"
-				request.Params.Arguments["environmentIds"] = []any{"1", "2", "3"}
+				request.Params.Arguments = map[string]any{
+					"name":           "group1",
+					"environmentIds": []any{"1", "2", "3"},
+				}
 			},
 		},
 		{
@@ -146,8 +156,10 @@ func TestHandleCreateAccessGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "group1"
-				request.Params.Arguments["environmentIds"] = []any{float64(1), "2", float64(3)}
+				request.Params.Arguments = map[string]any{
+					"name":           "group1",
+					"environmentIds": []any{float64(1), "2", float64(3)},
+				}
 			},
 		},
 	}
@@ -210,8 +222,10 @@ func TestHandleUpdateAccessGroupName(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["name"] = "newname"
+				request.Params.Arguments = map[string]any{
+					"id":   float64(1),
+					"name": "newname",
+				}
 			},
 		},
 		{
@@ -221,8 +235,10 @@ func TestHandleUpdateAccessGroupName(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["name"] = "newname"
+				request.Params.Arguments = map[string]any{
+					"id":   float64(1),
+					"name": "newname",
+				}
 			},
 		},
 		{
@@ -231,7 +247,9 @@ func TestHandleUpdateAccessGroupName(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "newname"
+				request.Params.Arguments = map[string]any{
+					"name": "newname",
+				}
 			},
 		},
 		{
@@ -240,7 +258,9 @@ func TestHandleUpdateAccessGroupName(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+				}
 			},
 		},
 	}
@@ -577,8 +597,10 @@ func TestHandleAddEnvironmentToAccessGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["environmentId"] = float64(2)
+				request.Params.Arguments = map[string]any{
+					"id":            float64(1),
+					"environmentId": float64(2),
+				}
 			},
 		},
 		{
@@ -588,8 +610,10 @@ func TestHandleAddEnvironmentToAccessGroup(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["environmentId"] = float64(2)
+				request.Params.Arguments = map[string]any{
+					"id":            float64(1),
+					"environmentId": float64(2),
+				}
 			},
 		},
 		{
@@ -598,7 +622,9 @@ func TestHandleAddEnvironmentToAccessGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["environmentId"] = float64(2)
+				request.Params.Arguments = map[string]any{
+					"environmentId": float64(2),
+				}
 			},
 		},
 		{
@@ -607,7 +633,9 @@ func TestHandleAddEnvironmentToAccessGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+				}
 			},
 		},
 	}
@@ -670,8 +698,10 @@ func TestHandleRemoveEnvironmentFromAccessGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["environmentId"] = float64(2)
+				request.Params.Arguments = map[string]any{
+					"id":            float64(1),
+					"environmentId": float64(2),
+				}
 			},
 		},
 		{
@@ -681,8 +711,10 @@ func TestHandleRemoveEnvironmentFromAccessGroup(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["environmentId"] = float64(2)
+				request.Params.Arguments = map[string]any{
+					"id":            float64(1),
+					"environmentId": float64(2),
+				}
 			},
 		},
 		{
@@ -691,7 +723,9 @@ func TestHandleRemoveEnvironmentFromAccessGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["environmentId"] = float64(2)
+				request.Params.Arguments = map[string]any{
+					"environmentId": float64(2),
+				}
 			},
 		},
 		{
@@ -700,7 +734,9 @@ func TestHandleRemoveEnvironmentFromAccessGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+				}
 			},
 		},
 	}

--- a/internal/mcp/environment_test.go
+++ b/internal/mcp/environment_test.go
@@ -93,8 +93,10 @@ func TestHandleUpdateEnvironmentTags(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["tagIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"id":     float64(1),
+					"tagIds": []any{float64(1), float64(2), float64(3)},
+				}
 			},
 		},
 		{
@@ -104,8 +106,10 @@ func TestHandleUpdateEnvironmentTags(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["tagIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"id":     float64(1),
+					"tagIds": []any{float64(1), float64(2), float64(3)},
+				}
 			},
 		},
 		{
@@ -115,7 +119,9 @@ func TestHandleUpdateEnvironmentTags(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["tagIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"tagIds": []any{float64(1), float64(2), float64(3)},
+				}
 			},
 		},
 		{
@@ -125,7 +131,9 @@ func TestHandleUpdateEnvironmentTags(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+				}
 			},
 		},
 	}
@@ -191,10 +199,12 @@ func TestHandleUpdateEnvironmentUserAccesses(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["userAccesses"] = []any{
-					map[string]any{"id": float64(1), "access": "environment_administrator"},
-					map[string]any{"id": float64(2), "access": "standard_user"},
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+					"userAccesses": []any{
+						map[string]any{"id": float64(1), "access": "environment_administrator"},
+						map[string]any{"id": float64(2), "access": "standard_user"},
+					},
 				}
 			},
 		},
@@ -207,9 +217,11 @@ func TestHandleUpdateEnvironmentUserAccesses(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["userAccesses"] = []any{
-					map[string]any{"id": float64(1), "access": "environment_administrator"},
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+					"userAccesses": []any{
+						map[string]any{"id": float64(1), "access": "environment_administrator"},
+					},
 				}
 			},
 		},
@@ -219,8 +231,10 @@ func TestHandleUpdateEnvironmentUserAccesses(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["userAccesses"] = []any{
-					map[string]any{"id": float64(1), "access": "environment_administrator"},
+				request.Params.Arguments = map[string]any{
+					"userAccesses": []any{
+						map[string]any{"id": float64(1), "access": "environment_administrator"},
+					},
 				}
 			},
 		},
@@ -230,7 +244,9 @@ func TestHandleUpdateEnvironmentUserAccesses(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+				}
 			},
 		},
 		{
@@ -242,9 +258,11 @@ func TestHandleUpdateEnvironmentUserAccesses(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["userAccesses"] = []any{
-					map[string]any{"id": float64(1), "access": "invalid_access"},
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+					"userAccesses": []any{
+						map[string]any{"id": float64(1), "access": "invalid_access"},
+					},
 				}
 			},
 		},
@@ -314,10 +332,12 @@ func TestHandleUpdateEnvironmentTeamAccesses(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["teamAccesses"] = []any{
-					map[string]any{"id": float64(1), "access": "environment_administrator"},
-					map[string]any{"id": float64(2), "access": "standard_user"},
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+					"teamAccesses": []any{
+						map[string]any{"id": float64(1), "access": "environment_administrator"},
+						map[string]any{"id": float64(2), "access": "standard_user"},
+					},
 				}
 			},
 		},
@@ -330,9 +350,11 @@ func TestHandleUpdateEnvironmentTeamAccesses(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["teamAccesses"] = []any{
-					map[string]any{"id": float64(1), "access": "environment_administrator"},
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+					"teamAccesses": []any{
+						map[string]any{"id": float64(1), "access": "environment_administrator"},
+					},
 				}
 			},
 		},
@@ -342,8 +364,10 @@ func TestHandleUpdateEnvironmentTeamAccesses(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["teamAccesses"] = []any{
-					map[string]any{"id": float64(1), "access": "environment_administrator"},
+				request.Params.Arguments = map[string]any{
+					"teamAccesses": []any{
+						map[string]any{"id": float64(1), "access": "environment_administrator"},
+					},
 				}
 			},
 		},
@@ -353,7 +377,9 @@ func TestHandleUpdateEnvironmentTeamAccesses(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+				}
 			},
 		},
 		{
@@ -365,9 +391,11 @@ func TestHandleUpdateEnvironmentTeamAccesses(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["teamAccesses"] = []any{
-					map[string]any{"id": float64(1), "access": "invalid_access"},
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+					"teamAccesses": []any{
+						map[string]any{"id": float64(1), "access": "invalid_access"},
+					},
 				}
 			},
 		},

--- a/internal/mcp/group_test.go
+++ b/internal/mcp/group_test.go
@@ -94,8 +94,10 @@ func TestHandleCreateEnvironmentGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "group1"
-				request.Params.Arguments["environmentIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"name":           "group1",
+					"environmentIds": []any{float64(1), float64(2), float64(3)},
+				}
 			},
 		},
 		{
@@ -106,8 +108,10 @@ func TestHandleCreateEnvironmentGroup(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "group1"
-				request.Params.Arguments["environmentIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"name":           "group1",
+					"environmentIds": []any{float64(1), float64(2), float64(3)},
+				}
 			},
 		},
 		{
@@ -116,7 +120,9 @@ func TestHandleCreateEnvironmentGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["environmentIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"environmentIds": []any{float64(1), float64(2), float64(3)},
+				}
 			},
 		},
 		{
@@ -125,7 +131,9 @@ func TestHandleCreateEnvironmentGroup(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "group1"
+				request.Params.Arguments = map[string]any{
+					"name": "group1",
+				}
 			},
 		},
 	}
@@ -188,8 +196,10 @@ func TestHandleUpdateEnvironmentGroupName(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request mcp.CallToolRequest) mcp.CallToolRequest {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["name"] = "newname"
+				request.Params.Arguments = map[string]any{
+					"id":   float64(1),
+					"name": "newname",
+				}
 				return request
 			},
 		},
@@ -200,8 +210,10 @@ func TestHandleUpdateEnvironmentGroupName(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request mcp.CallToolRequest) mcp.CallToolRequest {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["name"] = "newname"
+				request.Params.Arguments = map[string]any{
+					"id":   float64(1),
+					"name": "newname",
+				}
 				return request
 			},
 		},
@@ -211,7 +223,9 @@ func TestHandleUpdateEnvironmentGroupName(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request mcp.CallToolRequest) mcp.CallToolRequest {
-				request.Params.Arguments["name"] = "newname"
+				request.Params.Arguments = map[string]any{
+					"name": "newname",
+				}
 				return request
 			},
 		},
@@ -221,7 +235,9 @@ func TestHandleUpdateEnvironmentGroupName(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request mcp.CallToolRequest) mcp.CallToolRequest {
-				request.Params.Arguments["id"] = float64(1)
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+				}
 				return request
 			},
 		},
@@ -285,8 +301,10 @@ func TestHandleUpdateEnvironmentGroupEnvironments(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request mcp.CallToolRequest) mcp.CallToolRequest {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["environmentIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"id":             float64(1),
+					"environmentIds": []any{float64(1), float64(2), float64(3)},
+				}
 				return request
 			},
 		},
@@ -297,8 +315,10 @@ func TestHandleUpdateEnvironmentGroupEnvironments(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request mcp.CallToolRequest) mcp.CallToolRequest {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["environmentIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"id":             float64(1),
+					"environmentIds": []any{float64(1), float64(2), float64(3)},
+				}
 				return request
 			},
 		},
@@ -308,7 +328,9 @@ func TestHandleUpdateEnvironmentGroupEnvironments(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request mcp.CallToolRequest) mcp.CallToolRequest {
-				request.Params.Arguments["environmentIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"environmentIds": []any{float64(1), float64(2), float64(3)},
+				}
 				return request
 			},
 		},
@@ -318,8 +340,10 @@ func TestHandleUpdateEnvironmentGroupEnvironments(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request mcp.CallToolRequest) mcp.CallToolRequest {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["name"] = "group1"
+				request.Params.Arguments = map[string]any{
+					"id":   float64(1),
+					"name": "group1",
+				}
 				return request
 			},
 		},
@@ -383,8 +407,10 @@ func TestHandleUpdateEnvironmentGroupTags(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request mcp.CallToolRequest) mcp.CallToolRequest {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["tagIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"id":     float64(1),
+					"tagIds": []any{float64(1), float64(2), float64(3)},
+				}
 				return request
 			},
 		},
@@ -395,8 +421,10 @@ func TestHandleUpdateEnvironmentGroupTags(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request mcp.CallToolRequest) mcp.CallToolRequest {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["tagIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"id":     float64(1),
+					"tagIds": []any{float64(1), float64(2), float64(3)},
+				}
 				return request
 			},
 		},
@@ -406,7 +434,9 @@ func TestHandleUpdateEnvironmentGroupTags(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request mcp.CallToolRequest) mcp.CallToolRequest {
-				request.Params.Arguments["tagIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"tagIds": []any{float64(1), float64(2), float64(3)},
+				}
 				return request
 			},
 		},
@@ -416,7 +446,9 @@ func TestHandleUpdateEnvironmentGroupTags(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request mcp.CallToolRequest) mcp.CallToolRequest {
-				request.Params.Arguments["id"] = float64(1)
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+				}
 				return request
 			},
 		},

--- a/internal/mcp/stack_test.go
+++ b/internal/mcp/stack_test.go
@@ -92,7 +92,9 @@ func TestHandleGetStackFile(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+				}
 			},
 		},
 		{
@@ -102,7 +104,9 @@ func TestHandleGetStackFile(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+				}
 			},
 		},
 		{
@@ -179,9 +183,11 @@ func TestHandleCreateStack(t *testing.T) {
 			mockError:        nil,
 			expectError:      false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "test-stack"
-				request.Params.Arguments["file"] = "version: '3'\nservices:\n  web:\n    image: nginx"
-				request.Params.Arguments["environmentGroupIds"] = []any{float64(1), float64(2)}
+				request.Params.Arguments = map[string]any{
+					"name":                "test-stack",
+					"file":                "version: '3'\nservices:\n  web:\n    image: nginx",
+					"environmentGroupIds": []any{float64(1), float64(2)},
+				}
 			},
 		},
 		{
@@ -193,9 +199,11 @@ func TestHandleCreateStack(t *testing.T) {
 			mockError:        fmt.Errorf("api error"),
 			expectError:      true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "test-stack"
-				request.Params.Arguments["file"] = "version: '3'\nservices:\n  web:\n    image: nginx"
-				request.Params.Arguments["environmentGroupIds"] = []any{float64(1), float64(2)}
+				request.Params.Arguments = map[string]any{
+					"name":                "test-stack",
+					"file":                "version: '3'\nservices:\n  web:\n    image: nginx",
+					"environmentGroupIds": []any{float64(1), float64(2)},
+				}
 			},
 		},
 		{
@@ -207,8 +215,10 @@ func TestHandleCreateStack(t *testing.T) {
 			mockError:        nil,
 			expectError:      true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["file"] = "version: '3'\nservices:\n  web:\n    image: nginx"
-				request.Params.Arguments["environmentGroupIds"] = []any{float64(1), float64(2)}
+				request.Params.Arguments = map[string]any{
+					"file":                "version: '3'\nservices:\n  web:\n    image: nginx",
+					"environmentGroupIds": []any{float64(1), float64(2)},
+				}
 			},
 		},
 		{
@@ -220,8 +230,10 @@ func TestHandleCreateStack(t *testing.T) {
 			mockError:        nil,
 			expectError:      true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "test-stack"
-				request.Params.Arguments["environmentGroupIds"] = []any{float64(1), float64(2)}
+				request.Params.Arguments = map[string]any{
+					"name":                "test-stack",
+					"environmentGroupIds": []any{float64(1), float64(2)},
+				}
 			},
 		},
 		{
@@ -233,8 +245,10 @@ func TestHandleCreateStack(t *testing.T) {
 			mockError:        nil,
 			expectError:      true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "test-stack"
-				request.Params.Arguments["file"] = "version: '3'\nservices:\n  web:\n    image: nginx"
+				request.Params.Arguments = map[string]any{
+					"name": "test-stack",
+					"file": "version: '3'\nservices:\n  web:\n    image: nginx",
+				}
 			},
 		},
 	}
@@ -299,9 +313,11 @@ func TestHandleUpdateStack(t *testing.T) {
 			mockError:        nil,
 			expectError:      false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["file"] = "version: '3'\nservices:\n  web:\n    image: nginx"
-				request.Params.Arguments["environmentGroupIds"] = []any{float64(1), float64(2)}
+				request.Params.Arguments = map[string]any{
+					"id":                  float64(1),
+					"file":                "version: '3'\nservices:\n  web:\n    image: nginx",
+					"environmentGroupIds": []any{float64(1), float64(2)},
+				}
 			},
 		},
 		{
@@ -312,9 +328,11 @@ func TestHandleUpdateStack(t *testing.T) {
 			mockError:        fmt.Errorf("api error"),
 			expectError:      true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["file"] = "version: '3'\nservices:\n  web:\n    image: nginx"
-				request.Params.Arguments["environmentGroupIds"] = []any{float64(1), float64(2)}
+				request.Params.Arguments = map[string]any{
+					"id":                  float64(1),
+					"file":                "version: '3'\nservices:\n  web:\n    image: nginx",
+					"environmentGroupIds": []any{float64(1), float64(2)},
+				}
 			},
 		},
 		{
@@ -325,8 +343,10 @@ func TestHandleUpdateStack(t *testing.T) {
 			mockError:        nil,
 			expectError:      true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["file"] = "version: '3'\nservices:\n  web:\n    image: nginx"
-				request.Params.Arguments["environmentGroupIds"] = []any{float64(1), float64(2)}
+				request.Params.Arguments = map[string]any{
+					"file":                "version: '3'\nservices:\n  web:\n    image: nginx",
+					"environmentGroupIds": []any{float64(1), float64(2)},
+				}
 			},
 		},
 		{
@@ -337,8 +357,10 @@ func TestHandleUpdateStack(t *testing.T) {
 			mockError:        nil,
 			expectError:      true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["environmentGroupIds"] = []any{float64(1), float64(2)}
+				request.Params.Arguments = map[string]any{
+					"id":                  float64(1),
+					"environmentGroupIds": []any{float64(1), float64(2)},
+				}
 			},
 		},
 		{
@@ -349,8 +371,10 @@ func TestHandleUpdateStack(t *testing.T) {
 			mockError:        nil,
 			expectError:      true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["file"] = "version: '3'\nservices:\n  web:\n    image: nginx"
+				request.Params.Arguments = map[string]any{
+					"id":   float64(1),
+					"file": "version: '3'\nservices:\n  web:\n    image: nginx",
+				}
 			},
 		},
 	}

--- a/internal/mcp/tag_test.go
+++ b/internal/mcp/tag_test.go
@@ -129,7 +129,9 @@ func TestHandleCreateEnvironmentTag(t *testing.T) {
 			// Create request with parameters
 			request := CreateMCPRequest(map[string]any{})
 			if tt.inputName != "" {
-				request.Params.Arguments["name"] = tt.inputName
+				request.Params.Arguments = map[string]any{
+					"name": tt.inputName,
+				}
 			}
 
 			// Call handler

--- a/internal/mcp/team_test.go
+++ b/internal/mcp/team_test.go
@@ -27,7 +27,9 @@ func TestHandleCreateTeam(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "test-team"
+				request.Params.Arguments = map[string]any{
+					"name": "test-team",
+				}
 			},
 		},
 		{
@@ -37,7 +39,9 @@ func TestHandleCreateTeam(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "test-team"
+				request.Params.Arguments = map[string]any{
+					"name": "test-team",
+				}
 			},
 		},
 		{
@@ -175,8 +179,10 @@ func TestHandleUpdateTeamName(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["name"] = "new-name"
+				request.Params.Arguments = map[string]any{
+					"id":   float64(1),
+					"name": "new-name",
+				}
 			},
 		},
 		{
@@ -186,8 +192,10 @@ func TestHandleUpdateTeamName(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["name"] = "new-name"
+				request.Params.Arguments = map[string]any{
+					"id":   float64(1),
+					"name": "new-name",
+				}
 			},
 		},
 		{
@@ -197,7 +205,9 @@ func TestHandleUpdateTeamName(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["name"] = "new-name"
+				request.Params.Arguments = map[string]any{
+					"name": "new-name",
+				}
 			},
 		},
 		{
@@ -207,7 +217,9 @@ func TestHandleUpdateTeamName(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+				}
 			},
 		},
 	}
@@ -270,8 +282,10 @@ func TestHandleUpdateTeamMembers(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["userIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"id":      float64(1),
+					"userIds": []any{float64(1), float64(2), float64(3)},
+				}
 			},
 		},
 		{
@@ -281,8 +295,10 @@ func TestHandleUpdateTeamMembers(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["userIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"id":      float64(1),
+					"userIds": []any{float64(1), float64(2), float64(3)},
+				}
 			},
 		},
 		{
@@ -292,7 +308,9 @@ func TestHandleUpdateTeamMembers(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["userIds"] = []any{float64(1), float64(2), float64(3)}
+				request.Params.Arguments = map[string]any{
+					"userIds": []any{float64(1), float64(2), float64(3)},
+				}
 			},
 		},
 		{
@@ -302,7 +320,9 @@ func TestHandleUpdateTeamMembers(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+				}
 			},
 		},
 	}

--- a/internal/mcp/user_test.go
+++ b/internal/mcp/user_test.go
@@ -95,8 +95,10 @@ func TestHandleUpdateUserRole(t *testing.T) {
 			mockError:   nil,
 			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["role"] = "admin"
+				request.Params.Arguments = map[string]any{
+					"id":   float64(1),
+					"role": "admin",
+				}
 			},
 		},
 		{
@@ -106,8 +108,10 @@ func TestHandleUpdateUserRole(t *testing.T) {
 			mockError:   fmt.Errorf("api error"),
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["role"] = "admin"
+				request.Params.Arguments = map[string]any{
+					"id":   float64(1),
+					"role": "admin",
+				}
 			},
 		},
 		{
@@ -117,7 +121,9 @@ func TestHandleUpdateUserRole(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["role"] = "admin"
+				request.Params.Arguments = map[string]any{
+					"role": "admin",
+				}
 			},
 		},
 		{
@@ -127,7 +133,9 @@ func TestHandleUpdateUserRole(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
+				request.Params.Arguments = map[string]any{
+					"id": float64(1),
+				}
 			},
 		},
 		{
@@ -137,8 +145,10 @@ func TestHandleUpdateUserRole(t *testing.T) {
 			mockError:   nil,
 			expectError: true,
 			setupParams: func(request *mcp.CallToolRequest) {
-				request.Params.Arguments["id"] = float64(1)
-				request.Params.Arguments["role"] = "invalid_role"
+				request.Params.Arguments = map[string]any{
+					"id":   float64(1),
+					"role": "invalid_role",
+				}
 			},
 		},
 	}

--- a/internal/mcp/utils.go
+++ b/internal/mcp/utils.go
@@ -72,13 +72,7 @@ func isValidHTTPMethod(method string) bool {
 // CreateMCPRequest creates a new MCP tool request with the given arguments
 func CreateMCPRequest(args map[string]any) mcp.CallToolRequest {
 	return mcp.CallToolRequest{
-		Params: struct {
-			Name      string         `json:"name"`
-			Arguments map[string]any `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Arguments: args,
 		},
 	}

--- a/pkg/toolgen/param.go
+++ b/pkg/toolgen/param.go
@@ -14,7 +14,7 @@ type ParameterParser struct {
 // NewParameterParser creates a new parameter parser for the given request
 func NewParameterParser(request mcp.CallToolRequest) *ParameterParser {
 	return &ParameterParser{
-		args: request.Params.Arguments,
+		args: request.GetArguments(),
 	}
 }
 

--- a/pkg/toolgen/param_test.go
+++ b/pkg/toolgen/param_test.go
@@ -10,13 +10,7 @@ import (
 // Helper function to create a ParameterParser with given arguments
 func newTestParser(args map[string]any) *ParameterParser {
 	return NewParameterParser(mcp.CallToolRequest{
-		Params: struct {
-			Name      string         `json:"name"`
-			Arguments map[string]any `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Arguments: args,
 		},
 	})

--- a/pkg/toolgen/yaml.go
+++ b/pkg/toolgen/yaml.go
@@ -120,10 +120,10 @@ func convertToolDefinition(def ToolDefinition) (mcp.Tool, error) {
 func convertAnnotation(annotation Annotations) mcp.ToolOption {
 	return mcp.WithToolAnnotation(mcp.ToolAnnotation{
 		Title:           annotation.Title,
-		ReadOnlyHint:    annotation.ReadOnlyHint,
-		DestructiveHint: annotation.DestructiveHint,
-		IdempotentHint:  annotation.IdempotentHint,
-		OpenWorldHint:   annotation.OpenWorldHint,
+		ReadOnlyHint:    &annotation.ReadOnlyHint,
+		DestructiveHint: &annotation.DestructiveHint,
+		IdempotentHint:  &annotation.IdempotentHint,
+		OpenWorldHint:   &annotation.OpenWorldHint,
 	})
 }
 

--- a/pkg/toolgen/yaml_test.go
+++ b/pkg/toolgen/yaml_test.go
@@ -289,10 +289,10 @@ func TestConvertToolDefinition(t *testing.T) {
 			wantErr: false,
 			want: &mcp.ToolAnnotation{
 				Title:           "Valid Title",
-				ReadOnlyHint:    true,
-				DestructiveHint: false,
-				IdempotentHint:  true,
-				OpenWorldHint:   false,
+				ReadOnlyHint:    &validAnnotations.ReadOnlyHint,
+				DestructiveHint: &validAnnotations.DestructiveHint,
+				IdempotentHint:  &validAnnotations.IdempotentHint,
+				OpenWorldHint:   &validAnnotations.OpenWorldHint,
 			},
 		},
 		{
@@ -343,10 +343,10 @@ func TestConvertToolDefinition(t *testing.T) {
 			wantErr: false,
 			want: &mcp.ToolAnnotation{
 				Title:           "Valid Title",
-				ReadOnlyHint:    true,
-				DestructiveHint: false,
-				IdempotentHint:  true,
-				OpenWorldHint:   false,
+				ReadOnlyHint:    &validAnnotations.ReadOnlyHint,
+				DestructiveHint: &validAnnotations.DestructiveHint,
+				IdempotentHint:  &validAnnotations.IdempotentHint,
+				OpenWorldHint:   &validAnnotations.OpenWorldHint,
 			},
 		},
 	}
@@ -594,10 +594,10 @@ func TestConvertAnnotation(t *testing.T) {
 	}
 	want := mcp.ToolAnnotation{
 		Title:           "Test Title",
-		ReadOnlyHint:    true,
-		DestructiveHint: true,
-		IdempotentHint:  false,
-		OpenWorldHint:   false,
+		ReadOnlyHint:    &input.ReadOnlyHint,
+		DestructiveHint: &input.DestructiveHint,
+		IdempotentHint:  &input.IdempotentHint,
+		OpenWorldHint:   &input.OpenWorldHint,
 	}
 
 	dummyTool := &mcp.Tool{}


### PR DESCRIPTION
…eter handling

- Upgraded github.com/mark3labs/mcp-go from v0.24.1 to v0.32.0 in go.mod and updated go.sum to reflect the changes in dependencies.
- Refactored request parameter handling in various test files to use a consistent map initialization for arguments, improving code clarity and maintainability.