### PR TITLE
chore: update Portainer client API version to v2.31.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-openapi/runtime v0.28.0
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/mark3labs/mcp-go v0.32.0
-	github.com/portainer/client-api-go/v2 v2.30.0
+	github.com/portainer/client-api-go/v2 v2.31.2
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/portainer/client-api-go/v2 v2.30.0 h1:3nLhqiw08o7ucEmd3JQ362knc2PxB+BsUfD675gaZAw=
 github.com/portainer/client-api-go/v2 v2.30.0/go.mod h1:L0VSNt2JOgUpbFGmGH8IkbjgVaCZiRC75+COX424ulw=
+github.com/portainer/client-api-go/v2 v2.31.2 h1:VjcXBIJMUOXvCFdbjyIYOVrUxAzRKlOtH5Mo8A9wA3o=
+github.com/portainer/client-api-go/v2 v2.31.2/go.mod h1:L0VSNt2JOgUpbFGmGH8IkbjgVaCZiRC75+COX424ulw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -16,7 +16,7 @@ const (
 	// MinimumToolsVersion is the minimum supported version of the tools.yaml file
 	MinimumToolsVersion = "1.0"
 	// SupportedPortainerVersion is the version of Portainer that is supported by this tool
-	SupportedPortainerVersion = "2.30.0"
+	SupportedPortainerVersion = "2.31.2"
 )
 
 // PortainerClient defines the interface for the wrapper client used by the MCP server


### PR DESCRIPTION
- Upgraded the Portainer client API dependency in go.mod and go.sum from v2.30.0 to v2.31.2.
- Adjusted the SupportedPortainerVersion constant in server.go to align with the new client API version.