### PR TITLE
Windows path resolution for tools.yaml: expand %VAR% and default to executable dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,33 @@ With Claude Desktop, configure it like so:
 Replace `[IP]`, `[PORT]` and `[TOKEN]` with the IP, port and API access token associated with your Portainer instance.
 
 > [!NOTE]
-> By default, the tool looks for "tools.yaml" in the same directory as the binary. If the file does not exist, it will be created there with the default tool definitions. You may need to modify this path as described above, particularly when using AI assistants like Claude that have restricted write permissions to the working directory.
+> By default, the tool looks for `tools.yaml` in the same directory as the executable. If the file does not exist, it will be created there with the default tool definitions. You may need to modify this path as described below, particularly when using AI assistants like Claude that have restricted write permissions to the working directory.
+
+### Windows Configuration
+
+Use escaped backslashes for JSON strings and point `command` to the executable file:
+
+```
+{
+  "mcpServers": {
+    "portainer": {
+      "command": "C\\\\:\\\\projetos\\\\portainer-mcp\\\\portainer-mcp.exe",
+      "args": [
+        "-server",
+        "[IP]:[PORT]",
+        "-token",
+        "[TOKEN]",
+        "-tools",
+        "%TEMP%\\\\tools.yaml"
+      ]
+    }
+  }
+}
+```
+
+- `command` must reference the executable, not a directory.
+- `%TEMP%` expands to your Windows temp directory; you can also specify an absolute path like `C\\\\Temp\\\\tools.yaml`.
+- When using `-disable-version-check` or `-read-only`, add them to `args` as separate entries.
 
 ## Disable Version Check
 

--- a/cmd/portainer-mcp/mcp.go
+++ b/cmd/portainer-mcp/mcp.go
@@ -1,83 +1,80 @@
 package main
 
 import (
-	"flag"
+    "flag"
 
-	"github.com/portainer/portainer-mcp/internal/mcp"
-	"github.com/portainer/portainer-mcp/internal/tooldef"
-	"github.com/rs/zerolog/log"
+    "github.com/portainer/portainer-mcp/internal/mcp"
+    "github.com/portainer/portainer-mcp/internal/tooldef"
+    "github.com/rs/zerolog/log"
 )
 
 const defaultToolsPath = "tools.yaml"
 
 var (
-	Version   string
-	BuildDate string
-	Commit    string
+    Version   string
+    BuildDate string
+    Commit    string
 )
 
 func main() {
-	log.Info().
-		Str("version", Version).
-		Str("build-date", BuildDate).
-		Str("commit", Commit).
-		Msg("Portainer MCP server")
+    log.Info().
+        Str("version", Version).
+        Str("build-date", BuildDate).
+        Str("commit", Commit).
+        Msg("Portainer MCP server")
 
-	serverFlag := flag.String("server", "", "The Portainer server URL")
-	tokenFlag := flag.String("token", "", "The authentication token for the Portainer server")
-	toolsFlag := flag.String("tools", "", "The path to the tools YAML file")
-	readOnlyFlag := flag.Bool("read-only", false, "Run in read-only mode")
-	disableVersionCheckFlag := flag.Bool("disable-version-check", false, "Disable Portainer server version check")
+    serverFlag := flag.String("server", "", "The Portainer server URL")
+    tokenFlag := flag.String("token", "", "The authentication token for the Portainer server")
+    toolsFlag := flag.String("tools", "", "The path to the tools YAML file")
+    readOnlyFlag := flag.Bool("read-only", false, "Run in read-only mode")
+    disableVersionCheckFlag := flag.Bool("disable-version-check", false, "Disable Portainer server version check")
 
-	flag.Parse()
+    flag.Parse()
 
-	if *serverFlag == "" || *tokenFlag == "" {
-		log.Fatal().Msg("Both -server and -token flags are required")
-	}
+    if *serverFlag == "" || *tokenFlag == "" {
+        log.Fatal().Msg("Both -server and -token flags are required")
+    }
 
-	toolsPath := *toolsFlag
-	if toolsPath == "" {
-		toolsPath = defaultToolsPath
-	}
+    toolsPath := tooldef.ResolveToolsPath(*toolsFlag, defaultToolsPath)
 
-	// We first check if the tools.yaml file exists
-	// We'll create it from the embedded version if it doesn't exist
-	exists, err := tooldef.CreateToolsFileIfNotExists(toolsPath)
-	if err != nil {
-		log.Fatal().Err(err).Msg("failed to create tools.yaml file")
-	}
+    // We first check if the tools.yaml file exists
+    // We'll create it from the embedded version if it doesn't exist
+    exists, err := tooldef.CreateToolsFileIfNotExists(toolsPath)
+    if err != nil {
+        log.Fatal().Err(err).Msg("failed to create tools.yaml file")
+    }
 
-	if exists {
-		log.Info().Msg("using existing tools.yaml file")
-	} else {
-		log.Info().Msg("created tools.yaml file")
-	}
+    if exists {
+        log.Info().Msg("using existing tools.yaml file")
+    } else {
+        log.Info().Msg("created tools.yaml file")
+    }
 
-	log.Info().
-		Str("portainer-host", *serverFlag).
-		Str("tools-path", toolsPath).
-		Bool("read-only", *readOnlyFlag).
-		Bool("disable-version-check", *disableVersionCheckFlag).
-		Msg("starting MCP server")
+    log.Info().
+        Str("portainer-host", *serverFlag).
+        Str("tools-path", toolsPath).
+        Bool("read-only", *readOnlyFlag).
+        Bool("disable-version-check", *disableVersionCheckFlag).
+        Msg("starting MCP server")
 
-	server, err := mcp.NewPortainerMCPServer(*serverFlag, *tokenFlag, toolsPath, mcp.WithReadOnly(*readOnlyFlag), mcp.WithDisableVersionCheck(*disableVersionCheckFlag))
-	if err != nil {
-		log.Fatal().Err(err).Msg("failed to create server")
-	}
+    server, err := mcp.NewPortainerMCPServer(*serverFlag, *tokenFlag, toolsPath, mcp.WithReadOnly(*readOnlyFlag), mcp.WithDisableVersionCheck(*disableVersionCheckFlag))
+    if err != nil {
+        log.Fatal().Err(err).Msg("failed to create server")
+    }
 
-	server.AddEnvironmentFeatures()
-	server.AddEnvironmentGroupFeatures()
-	server.AddTagFeatures()
-	server.AddStackFeatures()
-	server.AddSettingsFeatures()
-	server.AddUserFeatures()
-	server.AddTeamFeatures()
-	server.AddAccessGroupFeatures()
-	server.AddDockerProxyFeatures()
-	server.AddKubernetesProxyFeatures()
+    server.AddEnvironmentFeatures()
+    server.AddEnvironmentGroupFeatures()
+    server.AddTagFeatures()
+    server.AddStackFeatures()
+    server.AddSettingsFeatures()
+    server.AddUserFeatures()
+    server.AddTeamFeatures()
+    server.AddAccessGroupFeatures()
+    server.AddDockerProxyFeatures()
+    server.AddKubernetesProxyFeatures()
 
-	err = server.Start()
-	if err != nil {
-		log.Fatal().Err(err).Msg("failed to start server")
-	}
+    err = server.Start()
+    if err != nil {
+        log.Fatal().Err(err).Msg("failed to start server")
+    }
 }

--- a/internal/tooldef/path.go
+++ b/internal/tooldef/path.go
@@ -1,0 +1,33 @@
+package tooldef
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+func ResolveToolsPath(flagValue string, defaultName string) string {
+	s := strings.TrimSpace(flagValue)
+	if s != "" {
+		expanded := os.ExpandEnv(s)
+		if runtime.GOOS == "windows" {
+			re := regexp.MustCompile(`%([A-Za-z0-9_]+)%`)
+			expanded = re.ReplaceAllStringFunc(expanded, func(m string) string {
+				name := strings.Trim(m, "%")
+				val := os.Getenv(name)
+				if val == "" {
+					return m
+				}
+				return val
+			})
+		}
+		return expanded
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return defaultName
+	}
+	return filepath.Join(filepath.Dir(exe), defaultName)
+}

--- a/internal/tooldef/path_test.go
+++ b/internal/tooldef/path_test.go
@@ -1,0 +1,49 @@
+package tooldef
+
+import (
+    "os"
+    "path/filepath"
+    "runtime"
+    "strings"
+    "testing"
+)
+
+func TestResolveToolsPath_DefaultToExeDir(t *testing.T) {
+    got := ResolveToolsPath("", "tools.yaml")
+    exe, err := os.Executable()
+    if err != nil {
+        t.Fatalf("executable path error: %v", err)
+    }
+    wantDir := filepath.Dir(exe)
+    if filepath.Dir(got) != wantDir || filepath.Base(got) != "tools.yaml" {
+        t.Fatalf("unexpected path: got %q, want dir %q and base tools.yaml", got, wantDir)
+    }
+}
+
+func TestResolveToolsPath_EnvExpansion(t *testing.T) {
+    tmp, err := os.MkdirTemp("", "mcp-tools-*")
+    if err != nil {
+        t.Fatalf("temp dir error: %v", err)
+    }
+    defer os.RemoveAll(tmp)
+
+    var flagPath string
+    var want string
+    if runtime.GOOS == "windows" {
+        os.Setenv("TEMP", tmp)
+        flagPath = "%TEMP%\\tools.yaml"
+        want = filepath.Join(tmp, "tools.yaml")
+    } else {
+        os.Setenv("TMPDIR", tmp)
+        flagPath = "$TMPDIR/tools.yaml"
+        want = filepath.Join(tmp, "tools.yaml")
+    }
+
+    got := ResolveToolsPath(flagPath, "tools.yaml")
+    if got != want {
+        t.Fatalf("unexpected expanded path: got %q, want %q", got, want)
+    }
+    if runtime.GOOS == "windows" && !strings.Contains(got, "\\") {
+        t.Fatalf("windows path should contain backslashes: %q", got)
+    }
+}


### PR DESCRIPTION
Summary

This PR improves cross-platform path handling for the `-tools` flag and default tools file location, with a focus on Windows compatibility.

Changes
- Add `ResolveToolsPath` helper that:
  - Expands environment variables on Windows using the `%VAR%` syntax (e.g., `%TEMP%\\tools.yaml`)
  - Expands environment variables on Unix via `os.ExpandEnv`
  - Defaults `tools.yaml` to the executable directory when `-tools` is not provided
- Use `ResolveToolsPath` in `cmd/portainer-mcp/mcp.go`
- Add unit tests covering Windows and Unix expansion
- Update README with a Windows configuration section clarifying the `command` must point to the executable and showing a valid `-tools` example using `%TEMP%\\tools.yaml`

Motivation
On Windows, users often configure MCP via JSON where the process working directory is read-only or unpredictable. The previous code passed `-tools` through verbatim and defaulted `tools.yaml` to a relative path, leading to failures when the file could not be created or when `%TEMP%`-style variables were used. This change makes Windows configuration frictionless and mirrors Unix behavior.

Details
- `internal/tooldef/path.go` introduces `ResolveToolsPath(flagValue, defaultName)`:
  - Trims input, expands env vars (`%VAR%` on Windows; `$VAR` on Unix), and falls back to `filepath.Dir(os.Executable())/defaultName`
- `cmd/portainer-mcp/mcp.go` now calls `ResolveToolsPath(*toolsFlag, "tools.yaml")`
- Tests in `internal/tooldef/path_test.go` verify both default behavior and env expansion
- README adds a Windows-specific example with escaped backslashes appropriate for JSON strings

Notes
- No changes to tool names or schemas
- No behavioral changes for non-Windows platforms other than defaulting to the executable directory when `-tools` is omitted

Thanks!