### PR TITLE
fix: robust numeric parameter parsing for MCP clients

### DIFF
--- a/internal/mcp/access_group_test.go
+++ b/internal/mcp/access_group_test.go
@@ -139,10 +139,12 @@ func TestHandleCreateAccessGroup(t *testing.T) {
 			},
 		},
 		{
-			name:        "invalid environmentIds - array with non-numbers",
+			name:        "numeric string environmentIds coerced",
 			inputName:   "group1",
+			inputEnvIDs: []int{1, 2, 3},
+			mockID:      1,
 			mockError:   nil,
-			expectError: true,
+			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
 				request.Params.Arguments = map[string]any{
 					"name":           "group1",
@@ -151,10 +153,12 @@ func TestHandleCreateAccessGroup(t *testing.T) {
 			},
 		},
 		{
-			name:        "invalid environmentIds - array with mixed types",
+			name:        "mixed numeric types environmentIds coerced",
 			inputName:   "group1",
+			inputEnvIDs: []int{1, 2, 3},
+			mockID:      1,
 			mockError:   nil,
-			expectError: true,
+			expectError: false,
 			setupParams: func(request *mcp.CallToolRequest) {
 				request.Params.Arguments = map[string]any{
 					"name":           "group1",

--- a/pkg/portainer/client/client.go
+++ b/pkg/portainer/client/client.go
@@ -108,8 +108,14 @@ func NewPortainerClient(serverURL string, token string, opts ...ClientOption) *P
 		normalizedURL = "https://" + normalizedURL
 	}
 
+	// The SDK expects a bare host:port (e.g., "myserver:9443") and applies
+	// its own scheme prefix. Strip any scheme from the URL to avoid double-prefixing.
+	sdkHost := normalizedURL
+	sdkHost = strings.TrimPrefix(sdkHost, "https://")
+	sdkHost = strings.TrimPrefix(sdkHost, "http://")
+
 	return &PortainerClient{
-		cli: client.NewPortainerClient(serverURL, token, client.WithSkipTLSVerify(options.skipTLSVerify)),
+		cli: client.NewPortainerClient(sdkHost, token, client.WithSkipTLSVerify(options.skipTLSVerify)),
 		rawCli: &rawHTTPClient{
 			serverURL: normalizedURL,
 			token:     token,

--- a/pkg/toolgen/param.go
+++ b/pkg/toolgen/param.go
@@ -1,10 +1,45 @@
 package toolgen
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
+
+// toFloat64 converts various numeric types to float64.
+// MCP transports may deliver numbers as float64, int, or json.Number.
+// LLMs sometimes send numeric strings (e.g. "90" instead of 90) so
+// string values that parse as numbers are also accepted.
+func toFloat64(value any, name string) (float64, error) {
+	switch v := value.(type) {
+	case float64:
+		return v, nil
+	case float32:
+		return float64(v), nil
+	case int:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case int32:
+		return float64(v), nil
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return 0, fmt.Errorf("%s is not a valid number: %w", name, err)
+		}
+		return f, nil
+	case string:
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, fmt.Errorf("%s must be a number, got string %q", name, v)
+		}
+		return f, nil
+	default:
+		return 0, fmt.Errorf("%s must be a number", name)
+	}
+}
 
 // ParameterParser provides methods to safely extract parameters from request arguments
 type ParameterParser struct {
@@ -36,7 +71,9 @@ func (p *ParameterParser) GetString(name string, required bool) (string, error) 
 	return strValue, nil
 }
 
-// GetNumber extracts a number parameter from the request
+// GetNumber extracts a number parameter from the request.
+// It handles float64 (standard JSON unmarshalling), int (some MCP transports),
+// and json.Number types.
 func (p *ParameterParser) GetNumber(name string, required bool) (float64, error) {
 	value, ok := p.args[name]
 	if !ok || value == nil {
@@ -46,12 +83,7 @@ func (p *ParameterParser) GetNumber(name string, required bool) (float64, error)
 		return 0, nil
 	}
 
-	numValue, ok := value.(float64)
-	if !ok {
-		return 0, fmt.Errorf("%s must be a number", name)
-	}
-
-	return numValue, nil
+	return toFloat64(value, name)
 }
 
 // GetInt extracts an integer parameter from the request
@@ -59,6 +91,9 @@ func (p *ParameterParser) GetInt(name string, required bool) (int, error) {
 	num, err := p.GetNumber(name, required)
 	if err != nil {
 		return 0, err
+	}
+	if num != float64(int(num)) {
+		return 0, fmt.Errorf("%s must be a whole number, got %v", name, num)
 	}
 	return int(num), nil
 }
@@ -128,9 +163,12 @@ func parseArrayOfIntegers(array []any) ([]int, error) {
 	result := make([]int, 0, len(array))
 
 	for _, item := range array {
-		idFloat, ok := item.(float64)
-		if !ok {
+		idFloat, err := toFloat64(item, "array element")
+		if err != nil {
 			return nil, fmt.Errorf("failed to parse '%v' as integer", item)
+		}
+		if idFloat != float64(int(idFloat)) {
+			return nil, fmt.Errorf("value '%v' is not a whole number", idFloat)
 		}
 		result = append(result, int(idFloat))
 	}

--- a/pkg/toolgen/param_test.go
+++ b/pkg/toolgen/param_test.go
@@ -1,6 +1,7 @@
 package toolgen
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -116,16 +117,56 @@ func TestGetNumber(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:     "wrong type",
+			name:     "numeric string coerced",
 			args:     map[string]any{"num": "123"},
+			param:    "num",
+			required: true,
+			want:     123,
+			wantErr:  false,
+		},
+		{
+			name:     "nil value",
+			args:     map[string]any{"num": nil},
 			param:    "num",
 			required: true,
 			want:     0,
 			wantErr:  true,
 		},
 		{
-			name:     "nil value",
-			args:     map[string]any{"num": nil},
+			name:     "int type",
+			args:     map[string]any{"num": int(42)},
+			param:    "num",
+			required: true,
+			want:     42,
+			wantErr:  false,
+		},
+		{
+			name:     "int64 type",
+			args:     map[string]any{"num": int64(99)},
+			param:    "num",
+			required: true,
+			want:     99,
+			wantErr:  false,
+		},
+		{
+			name:     "json.Number type",
+			args:     map[string]any{"num": json.Number("7")},
+			param:    "num",
+			required: true,
+			want:     7,
+			wantErr:  false,
+		},
+		{
+			name:     "numeric string accepted",
+			args:     map[string]any{"num": "90"},
+			param:    "num",
+			required: true,
+			want:     90,
+			wantErr:  false,
+		},
+		{
+			name:     "non-numeric string rejected",
+			args:     map[string]any{"num": "abc"},
 			param:    "num",
 			required: true,
 			want:     0,
@@ -349,6 +390,30 @@ func TestParseArrayOfIntegers(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name:    "fractional float rejected",
+			input:   []any{float64(1), float64(2.5), float64(3)},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "all fractional floats rejected",
+			input:   []any{float64(1.1), float64(2.9)},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "int type values accepted",
+			input:   []any{int(1), int(2), int(3)},
+			want:    []int{1, 2, 3},
+			wantErr: false,
+		},
+		{
+			name:    "mixed int and float64 accepted",
+			input:   []any{int(1), float64(2), int64(3)},
+			want:    []int{1, 2, 3},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -424,12 +489,12 @@ func TestGetInt(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:     "wrong type string",
+			name:     "numeric string coerced",
 			args:     map[string]any{"num": "123"},
 			param:    "num",
 			required: true,
-			want:     0,
-			wantErr:  true,
+			want:     123,
+			wantErr:  false,
 		},
 		{
 			name:     "wrong type boolean",
@@ -442,6 +507,62 @@ func TestGetInt(t *testing.T) {
 		{
 			name:     "nil value",
 			args:     map[string]any{"num": nil},
+			param:    "num",
+			required: true,
+			want:     0,
+			wantErr:  true,
+		},
+		{
+			name:     "fractional float rejected",
+			args:     map[string]any{"num": float64(3.14)},
+			param:    "num",
+			required: true,
+			want:     0,
+			wantErr:  true,
+		},
+		{
+			name:     "fractional float 1.5 rejected",
+			args:     map[string]any{"num": float64(1.5)},
+			param:    "num",
+			required: true,
+			want:     0,
+			wantErr:  true,
+		},
+		{
+			name:     "int type accepted",
+			args:     map[string]any{"num": int(5)},
+			param:    "num",
+			required: true,
+			want:     5,
+			wantErr:  false,
+		},
+		{
+			name:     "int64 type accepted",
+			args:     map[string]any{"num": int64(100)},
+			param:    "num",
+			required: true,
+			want:     100,
+			wantErr:  false,
+		},
+		{
+			name:     "json.Number integer accepted",
+			args:     map[string]any{"num": json.Number("42")},
+			param:    "num",
+			required: true,
+			want:     42,
+			wantErr:  false,
+		},
+		{
+			name:     "numeric string accepted",
+			args:     map[string]any{"num": "90"},
+			param:    "num",
+			required: true,
+			want:     90,
+			wantErr:  false,
+		},
+		{
+			name:     "non-numeric string rejected",
+			args:     map[string]any{"num": "abc"},
 			param:    "num",
 			required: true,
 			want:     0,
@@ -518,14 +639,14 @@ func TestGetArrayOfIntegers(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "invalid array with string",
+			name: "numeric string in array coerced",
 			args: map[string]any{"nums": []any{
 				float64(1), "2", float64(3),
 			}},
 			param:    "nums",
 			required: true,
-			want:     nil,
-			wantErr:  true,
+			want:     []int{1, 2, 3},
+			wantErr:  false,
 		},
 		{
 			name: "invalid array with boolean",


### PR DESCRIPTION
## Summary

LLMs and MCP transports frequently send numeric values in unexpected Go types — strings (`"90"` instead of `90`), `int` instead of `float64`, or `json.Number`. The current parameter parser only handles `float64`, causing valid tool calls to be rejected.

This PR adds a `toFloat64()` helper that handles all common numeric representations:
- `float64`, `float32` (standard JSON unmarshalling)
- `int`, `int32`, `int64` (some MCP transports)
- `json.Number` (when using `Decoder.UseNumber()`)
- `string` (LLMs frequently quote numbers)

Also fixes the SDK client double `https://` prefix — the SDK's `httptransport.New()` prepends its own scheme, so passing a full URL like `https://myserver:9443` resulted in `https://https://myserver:9443`.

## Changes
- `pkg/toolgen/param.go`: Add `toFloat64()` helper, update `GetNumber()`, `GetInt()`, and `parseArrayOfIntegers()`
- `pkg/toolgen/param_test.go`: Add test cases for all new type coercion paths
- `pkg/portainer/client/client.go`: Strip scheme before passing to SDK
- `internal/mcp/access_group_test.go`: Update test expectations for string coercion

## Test plan
- [x] All unit tests pass
- [x] Verified string `"90"` parses correctly as numeric parameter
- [x] Verified int/int64/json.Number types parse correctly
- [x] Verified SDK connects without double prefix
- [x] Tested end-to-end with Claude Code MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)