### PR TITLE
fix: pass correct scheme and host to SDK client

### DIFF
--- a/pkg/portainer/client/client.go
+++ b/pkg/portainer/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"crypto/tls"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -108,8 +109,16 @@ func NewPortainerClient(serverURL string, token string, opts ...ClientOption) *P
 		normalizedURL = "https://" + normalizedURL
 	}
 
+	// Parse the server URL to extract scheme and host for the SDK client
+	scheme := "https"
+	host := serverURL
+	if parsed, err := url.Parse(normalizedURL); err == nil && parsed.Host != "" {
+		scheme = parsed.Scheme
+		host = parsed.Host
+	}
+
 	return &PortainerClient{
-		cli: client.NewPortainerClient(serverURL, token, client.WithSkipTLSVerify(options.skipTLSVerify)),
+		cli: client.NewPortainerClient(host, token, client.WithSkipTLSVerify(options.skipTLSVerify), client.WithScheme(scheme)),
 		rawCli: &rawHTTPClient{
 			serverURL: normalizedURL,
 			token:     token,


### PR DESCRIPTION
## Summary

- When `-server` is set to an `http://` URL, the SDK client (`client-api-go`) receives the full URL as a hostname and prepends `https://`, producing a malformed URL like `https://http:%2F%2Fhost:9000` which fails with a DNS lookup error
- Fix: parse the scheme and host from the server URL and pass them separately to the SDK using `client.WithScheme()`, so both `http://` and `https://` URLs work correctly
- The `rawHTTPClient` already handled this correctly; this aligns the SDK client behavior

## Reproduction

1. Run Portainer on plain HTTP (e.g. `http://10.10.11.86:9000`)
2. Configure portainer-mcp with `-server http://10.10.11.86:9000`
3. Any SDK-backed tool call (e.g. `listEnvironments`) fails with:
   ```
   Get "https://http:%2F%2F10.10.11.86:9000/api/endpoints": dial tcp: lookup http://10.10.11.86: no such host
   ```

## Test plan

- [ ] Verify `listEnvironments` works against an HTTP Portainer instance
- [ ] Verify HTTPS Portainer instances still work (default behavior preserved)
- [ ] Verify bare `host:port` without scheme defaults to HTTPS as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)