### PR TITLE
Redact env values from tool responses (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ the MCP server.
 
 ## [Unreleased]
 
+### Added
+
+- **Env value redaction on every response.** Stack, container, and
+  Kubernetes env values are rewritten to `[REDACTED]` before leaving the
+  MCP tool boundary so secrets don't leak into the model's context just
+  because a tool happened to include them. The redaction runs *before*
+  JMESPath `select`, so a projection like `select="Env[0].value"` lands
+  on the sentinel. The response carries a one-line summary naming the
+  toggle. Set `PORTAINER_EXPOSE_ENV_VALUES=1` to disclose; the posture
+  is logged at startup. Covers Portainer `Env`/`EnvVars` pairs, Docker
+  `"KEY=VAL"` strings, and Kubernetes `env[].value`; K8s `valueFrom`
+  references are preserved.
+  See [#61](https://github.com/portainer/portainer-mcp/issues/61).
+
+### Changed
+
+- Proxy responses (`docker_proxy`, `kubernetes_proxy`) are now re-serialised
+  through `json.dumps` whenever they're JSON and the redaction posture is
+  active (i.e. by default). Output is byte-identical for the model but no
+  longer preserves upstream whitespace or key ordering. Non-JSON bodies
+  (logs, stats, error pages) still pass through verbatim.
+
 ## [2.42.1] — 2026-05-26
 
 Targets Portainer 2.42.x. First build to ship a container image alongside

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,16 @@ Key things to internalise before changing code:
   OpenAPI responses as `{"result": …}` to fit MCP's structured-content
   schema. `_select_wrapper` unwraps that single-key envelope before
   projecting, so callers write `[].Id` rather than `result[].Id`.
+- **Env values redacted before projection.** `redaction.redact_envs()`
+  walks the parsed response in `_select_wrapper` and in the proxy tools
+  *before* JMESPath `select` runs — so `select="Env[0].value"` lands on
+  the `[REDACTED]` sentinel rather than the real value. The walker is
+  field-name driven (`env` / `envvars`, case-insensitive) and handles
+  Shapes A/F/G (list of `{name, value}` dicts) and Shape C (Docker
+  `"KEY=VAL"` strings); K8s `valueFrom` references are preserved.
+  Disabled with `PORTAINER_EXPOSE_ENV_VALUES=1`; logged at startup so
+  the posture is greppable. When redaction fires, the response carries a
+  one-line summary TextContent naming the env var.
 - **HTTP transport requires a bearer token.** `auth.py` defines
   `StaticBearerVerifier` (a `fastmcp.server.auth.TokenVerifier` subclass
   using `hmac.compare_digest`); `build_server()` wires it into

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The MCP server comes with the following capabilities enabled by default:
 * Docker operation support
 * Kubernetes operation support
 * Docker and Kubernetes proxy support
+* Redacting environment variables values (enabled by default)
 
 For restricting or expanding this set of capabilities, see [`docs/profiles.md`](https://github.com/portainer/portainer-mcp/blob/main/docs/profiles.md).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,9 @@ data/portainer-patched.yaml ──► FastMCP.from_openapi ──► tag filter 
                                                   SelectArgTransform (per tool)
                                                                       │
                                                                       ▼
+                                                  redact_envs (before projection)
+                                                                      │
+                                                                      ▼
                                                   ResponseCapMiddleware (per call)
                                                                       │
                                                                       ▼
@@ -124,9 +127,9 @@ than nested strings. Two structured emitters feed it:
 None}` to `server.run()`, so a single formatter owns every record
 regardless of which library installed handlers first.
 
-### Response shaping — `shaping.py`
+### Response shaping — `shaping.py` and `redaction.py`
 
-Two cooperating layers, applied to every tool the server exposes:
+Three cooperating layers, applied to every tool the server exposes:
 
 1. **`SelectArgTransform`** injects an optional `select` parameter on
    every tool. The caller passes a JMESPath expression; the server
@@ -134,15 +137,35 @@ Two cooperating layers, applied to every tool the server exposes:
    trims noisy Portainer payloads (snapshots, K8s `managedFields`, etc.)
    server-side instead of dragging them into context.
 
-2. **`ResponseCapMiddleware`** is the final safety valve. If a tool
+2. **`redact_envs`** walks the parsed response and rewrites env values to
+   the sentinel `[REDACTED]` before `select` runs, so that a JMESPath
+   expression like `select="Env[0].value"` lands on the sentinel rather
+   than the real secret. The walker is field-name driven (`env` /
+   `envvars`, case-insensitive) and dispatches on value shape — list of
+   `{name, value}` dicts (Portainer `Env`/`EnvVars`, K8s `env`), or list
+   of `"KEY=VAL"` strings (Docker-native). K8s `valueFrom` references
+   are preserved — they're references to a Secret/ConfigMap, not the
+   secret material itself. When redaction fires, the response carries a
+   one-line summary `TextContent` naming `PORTAINER_EXPOSE_ENV_VALUES`
+   so the caller knows how to disclose. Disabled with
+   `PORTAINER_EXPOSE_ENV_VALUES=1`; the posture is logged at startup
+   (`env value redaction: enabled` or `DISABLED (env values exposed)`).
+
+3. **`ResponseCapMiddleware`** is the final safety valve. If a tool
    result exceeds `PORTAINER_MAX_RESPONSE_CHARS` (default 50 000), the
    middleware truncates and appends a hint that names `select` with a
    concrete example. The cap is sized to fire *before* Claude Code's
    own MCP output cap (~62k chars for dense JSON), so our hint reaches
    the model instead of Claude Code's generic "saved to file" message.
 
-`select` narrows first (cheaper bodies); the cap catches whatever still
-slips through.
+Redaction runs first on every JSON-shaped response (`select` and the
+cap can't bypass it), `select` narrows next (cheaper bodies), and the
+cap catches whatever still slips through. Both projection sites — the
+wrapper around OpenAPI-generated tools (`_select_wrapper`) and the
+proxy tools (`_apply_select`) — call `redact_envs` before applying the
+JMESPath. Non-JSON proxy bodies (Docker logs / stats / error pages)
+pass through unchanged: the walker is field-name driven and has
+nothing to match.
 
 ## Why this shape
 
@@ -150,9 +173,14 @@ slips through.
   FastMCP generate the tools so spec bumps are mostly a regen.
 - **Filter at the spec layer.** Profiles reduce the visible surface
   without touching individual tools.
-- **Universal shaping.** `select` and the cap apply to every tool —
-  generated and hand-written alike — so the model learns one pattern
-  that works everywhere.
+- **Universal shaping.** `select`, redaction, and the cap apply to
+  every tool — generated and hand-written alike — so the model learns
+  one pattern that works everywhere.
+- **Safe-by-default disclosure.** Env values in JSON responses are
+  redacted on the server before they reach the model, instead of
+  relying on the model to ask the right `select`. The toggle is global
+  and operator-controlled, so exposure is an explicit decision rather
+  than a per-tool oversight.
 
 ## Pointers
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,7 @@ Two controls layered on top of the bearer secret:
 | `PORTAINER_NO_PROXY` | `0` | When truthy, skips registration of the `docker_proxy` and `kubernetes_proxy` escape-hatch tools. |
 | `PORTAINER_TLS_VERIFY` | `1` | When falsy, skips TLS verification on the upstream Portainer client. |
 | `PORTAINER_MAX_RESPONSE_CHARS` | `50000` | Tool-response cap. Sized to fire before Claude Code's MCP output cap so the truncation hint (which names `select` with examples) reaches the model. |
+| `PORTAINER_EXPOSE_ENV_VALUES` | `0` | When truthy, env values in stack / container / Kubernetes responses are returned as-is. Default redacts them to `[REDACTED]` and appends a one-line summary naming this variable. Redaction runs *before* `select`, so a JMESPath projection lands on the sentinel rather than the real value. |
 
 ## Logging
 

--- a/skills/portainer-mcp-hygiene/SKILL.md
+++ b/skills/portainer-mcp-hygiene/SKILL.md
@@ -55,7 +55,7 @@ kubernetes_proxy(path="/apis/apps/v1/deployments", select="items[].{name:metadat
 The OpenAPI-generated `GetAllKubernetesApplications`, `GetAllKubernetesConfigMaps`, `GetAllKubernetesIngresses`, etc. return arrays where each element carries its full object body. Same rules as the proxy: project to the named fields you need.
 
 **`StackList` and `StackInspect` — config and env vars.**
-Stacks carry the full compose/manifest content plus environment variable dictionaries. If the user asked "which stacks exist?", project to `{id, name, type, status}`. If they asked about a specific stack's config, fetch it directly and only then look at the body.
+Stacks carry the full compose/manifest content plus environment variable dictionaries. If the user asked "which stacks exist?", project to `{id, name, type, status}`. If they asked about a specific stack's config, fetch it directly and only then look at the body. Env *values* come back redacted by default — see *Env values are redacted by default* below.
 
 **Snapshot inspects (`snapshotInspect`, `snapshotContainersList`, etc.) — entire snapshots.**
 These return the *whole* snapshot blob by design. Always project.
@@ -65,6 +65,14 @@ These return the *whole* snapshot blob by design. Always project.
 
 **`EndpointGetCharts`, `dockerDashboard`, `EndpointSummaryCounts` — already aggregated.**
 These are the lightweight "summary" tools. Prefer them over `EndpointList` + projection when the user's question is purely a count or rollup — fewer characters, less work, more accurate (server-side aggregation).
+
+**Env values are redacted by default.**
+Stack, container, and Kubernetes env values come back as `[REDACTED]`. The response also carries a one-line summary: `[N env value(s) redacted; set PORTAINER_EXPOSE_ENV_VALUES=1 on the MCP server to disclose]`.
+
+- Don't waste a tool call fishing for them via `select` — the projection runs *after* redaction, so any field path lands on the sentinel.
+- If the user genuinely needs an env value (troubleshooting a deploy), tell them to set `PORTAINER_EXPOSE_ENV_VALUES=1` on the MCP server and reconnect. Don't invoke the toggle yourself.
+- The sentinel `[REDACTED]` is a literal placeholder — never quote it back to the user as if it were the real value.
+- Redaction covers `Env` / `EnvVars` shapes (stack `Env` pairs, Docker `KEY=VAL` strings, K8s `env[].value`). K8s `valueFrom` references are preserved — they're references to a Secret/ConfigMap, not the secret material itself.
 
 ## Patterns for common questions
 

--- a/spec/patch_spec.py
+++ b/spec/patch_spec.py
@@ -25,6 +25,23 @@ EXCLUDED_OPERATION_IDS = {
     "provisionCluster",
 }
 
+# Edge-agent-only callbacks under `/endpoints/{id}/edge/*` that 403 outside
+# an agent context. Tagged with `endpoints` upstream, so they leak into the
+# default profile and surface as tools that can never succeed for a non-agent
+# MCP caller.
+#
+# Two of them have no operationId in the spec (FastMCP names them from
+# `summary` instead), so the existing operationId-based filter can't catch
+# them — match on (method, path) instead.
+EXCLUDED_PATH_METHODS = frozenset(
+    {
+        ("get", "/endpoints/{id}/edge/stacks/{stackId}"),
+        ("get", "/endpoints/{id}/edge/status"),
+        ("post", "/endpoints/{id}/edge/alerts"),
+        ("post", "/endpoints/{id}/edge/jobs/{jobID}/logs"),
+    }
+)
+
 EXCLUDED_PATH_PREFIXES = ("/websocket",)
 
 ENUM_STRIPS = (
@@ -56,8 +73,15 @@ def patch(spec: dict) -> dict:
             continue
         for method in list(paths[path]):
             op = paths[path][method]
-            if isinstance(op, dict) and op.get("operationId") in EXCLUDED_OPERATION_IDS:
+            if not isinstance(op, dict):
+                continue
+            if op.get("operationId") in EXCLUDED_OPERATION_IDS:
                 paths[path].pop(method)
+                continue
+            if (method.lower(), path) in EXCLUDED_PATH_METHODS:
+                paths[path].pop(method)
+        if not paths[path]:
+            paths.pop(path)
 
     schemas = spec.get("components", {}).get("schemas", {})
     for trail in ENUM_STRIPS:

--- a/src/portainer_mcp/data/portainer-patched.yaml
+++ b/src/portainer_mcp/data/portainer-patched.yaml
@@ -488,8 +488,6 @@ paths:
       summary: Fetch the status of the last scheduled backup run
       tags:
       - backup
-  /cloud/{provider}/info: {}
-  /cloud/{provider}/provision: {}
   /cloud/amazon/provision:
     post:
       description: 'Provision a new KaaS cluster and create an environment.
@@ -762,7 +760,6 @@ paths:
       summary: Create Shared Git Credential
       tags:
       - cloud_credentials
-  /cloud/gitcredentials/{id}: {}
   /cloud/gke/provision:
     post:
       description: 'Provision a new KaaS cluster and create an environment.
@@ -4055,42 +4052,6 @@ paths:
       summary: fetch docker pull limits
       tags:
       - endpoints
-  /endpoints/{id}/edge/alerts:
-    post:
-      description: Authorized only if the request is made by a trusted Edge environment(endpoint)
-      operationId: EndpointEdgeAlertsReceive
-      parameters:
-      - description: Environment(Endpoint) identifier
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              items:
-                $ref: '#/components/schemas/models.PostableAlert'
-              type: array
-        description: Alertmanager alert batch
-        required: true
-      responses:
-        '204':
-          description: No Content
-        '400':
-          description: Bad Request
-        '403':
-          description: Forbidden
-        '500':
-          description: Internal Server Error
-      security:
-      - ApiKeyAuth: []
-      - jwt: []
-      summary: Receive Alertmanager-compatible alerts from an Edge agent
-      tags:
-      - edge
-      - endpoints
   /endpoints/{id}/edge/alerts/state:
     get:
       description: 'Returns the latest alert rule evaluation state reported by an
@@ -4191,108 +4152,6 @@ paths:
       - ApiKeyAuth: []
       - jwt: []
       summary: Update environment(endpoint) policy chart installation statuses
-      tags:
-      - endpoints
-  /endpoints/{id}/edge/jobs/{jobID}/logs:
-    post:
-      description: Authorized only if the request is done by an Edge Environment(Endpoint)
-      parameters:
-      - description: Environment(Endpoint) Id
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      - description: Job Id
-        in: path
-        name: jobID
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          description: OK
-        '400':
-          description: Bad Request
-        '403':
-          description: Forbidden
-        '500':
-          description: Internal Server Error
-      summary: Update the logs collected from an Edge Job
-      tags:
-      - edge
-      - endpoints
-  /endpoints/{id}/edge/stacks/{stackId}:
-    get:
-      description: '**Access policy**: public'
-      parameters:
-      - description: Environment(Endpoint) Id
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      - description: EdgeStack Id
-        in: path
-        name: stackId
-        required: true
-        schema:
-          type: integer
-      - description: Stack file version maintained by Portainer
-        in: query
-        name: version
-        schema:
-          type: integer
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/edge.StackPayload'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-        '500':
-          description: Internal Server Error
-      summary: Inspect an Edge Stack for an Environment(Endpoint)
-      tags:
-      - edge
-      - endpoints
-      - edge_stacks
-  /endpoints/{id}/edge/status:
-    get:
-      description: 'environment(endpoint) for edge agent to check status of environment(endpoint)
-
-        **Access policy**: restricted only to Edge environments(endpoints)'
-      operationId: EndpointEdgeStatusInspect
-      parameters:
-      - description: Environment(Endpoint) identifier
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          description: Success
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/endpointedge.endpointEdgeStatusInspectResponse'
-        '400':
-          description: Invalid request
-        '403':
-          description: Permission denied to access environment(endpoint)
-        '404':
-          description: Environment(Endpoint) not found
-        '500':
-          description: Server error
-      security:
-      - ApiKeyAuth: []
-      - jwt: []
-      summary: Get environment(endpoint) status
       tags:
       - endpoints
   /endpoints/{id}/forceupdateservice:

--- a/src/portainer_mcp/proxy.py
+++ b/src/portainer_mcp/proxy.py
@@ -15,6 +15,7 @@ import httpx
 from fastmcp import FastMCP
 from pydantic import Field
 
+from portainer_mcp import redaction
 from portainer_mcp.shaping import SELECT_DESCRIPTION, project
 
 logger = logging.getLogger("portainer_mcp")
@@ -26,13 +27,24 @@ _BLOCKED_HEADERS = frozenset({"x-api-key", "authorization", "cookie", "host"})
 
 
 def _apply_select(text: str, select: str | None) -> str:
-    if not select:
+    expose = redaction.is_expose_enabled()
+    if expose and not select:
         return text
     try:
         data = json.loads(text)
     except json.JSONDecodeError:
         return text  # not JSON (plain text, binary, error page); pass through
-    return json.dumps(project(data, select))
+
+    redaction_count = 0
+    if not expose:
+        data, redaction_count = redaction.redact_envs(data)
+    if select:
+        data = project(data, select)
+
+    out = json.dumps(data)
+    if redaction_count:
+        out = f"{out}\n\n{redaction.hint(redaction_count)}"
+    return out
 
 
 def _validate_path(path: str) -> None:

--- a/src/portainer_mcp/redaction.py
+++ b/src/portainer_mcp/redaction.py
@@ -1,0 +1,78 @@
+"""Redact env values from tool responses.
+
+Walks parsed JSON in place and replaces env values with a sentinel. The
+walker is field-name driven (`env` / `envvars`, case-insensitive) and
+dispatches on value shape — list of {name, value} dicts or list of
+KEY=VAL strings. K8s `valueFrom` references are preserved (they're
+references, not secrets).
+
+Called *before* JMESPath projection so callers can't bypass redaction
+with `select="Env"` etc. Returns (data, count) so the caller can emit
+a single summary message naming PORTAINER_EXPOSE_ENV_VALUES.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+SENTINEL = "[REDACTED]"
+EXPOSE_ENV_VAR = "PORTAINER_EXPOSE_ENV_VALUES"
+_ENV_KEYS = frozenset({"env", "envvars"})
+_KEY_VAL_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=")
+
+
+def is_expose_enabled() -> bool:
+    raw = os.environ.get(EXPOSE_ENV_VAR)
+    return raw is not None and raw not in {"0", "false", "False"}
+
+
+def redact_envs(data: Any) -> tuple[Any, int]:
+    """Mutate `data` in place, redacting env values; return (data, count)
+    for one-line caller use."""
+    return data, _walk(data)
+
+
+def hint(count: int) -> str:
+    return (
+        f"[{count} env value(s) redacted; "
+        f"set {EXPOSE_ENV_VAR}=1 on the MCP server to disclose]"
+    )
+
+
+def _walk(node: Any) -> int:
+    if isinstance(node, dict):
+        count = 0
+        for key, value in node.items():
+            if isinstance(key, str) and key.lower() in _ENV_KEYS and isinstance(value, list):
+                count += _redact_list(value)
+            else:
+                count += _walk(value)
+        return count
+    if isinstance(node, list):
+        return sum(_walk(item) for item in node)
+    return 0
+
+
+def _redact_list(items: list) -> int:
+    count = 0
+    for i, item in enumerate(items):
+        if isinstance(item, dict):
+            # Shapes A, F, G — {name, value} / {Name, Value}. Skip valueFrom
+            # (K8s reference, not a secret) and `default` (Template variable
+            # placeholder, surfaced verbatim in the Portainer UI — not a
+            # runtime secret). Only one casing of value is present per item;
+            # the loop covers both without a branch.
+            for key in ("value", "Value"):
+                if key in item:
+                    item[key] = SENTINEL
+                    count += 1
+                    break
+        elif isinstance(item, str):
+            # Shape C — Docker-native "KEY=VAL" string list.
+            match = _KEY_VAL_RE.match(item)
+            if match:
+                items[i] = f"{match.group(0)}{SENTINEL}"
+                count += 1
+    return count

--- a/src/portainer_mcp/server.py
+++ b/src/portainer_mcp/server.py
@@ -46,6 +46,7 @@ from portainer_mcp import (
     http_security,
     profiles,
     proxy,
+    redaction,
     request_context,
     shaping,
 )
@@ -264,6 +265,10 @@ def build_server() -> FastMCP:
     )
     mcp.add_middleware(shaping.ResponseCapMiddleware(max_chars))
     logger.info("response cap: %d chars", max_chars)
+    logger.info(
+        "env value redaction: %s",
+        "DISABLED (env values exposed)" if redaction.is_expose_enabled() else "enabled",
+    )
     return mcp
 
 

--- a/src/portainer_mcp/shaping.py
+++ b/src/portainer_mcp/shaping.py
@@ -30,6 +30,8 @@ from fastmcp.tools.tool import ToolResult
 from mcp.types import TextContent
 from pydantic import Field
 
+from portainer_mcp import redaction
+
 logger = logging.getLogger("portainer_mcp")
 
 # Must fire before Claude Code's MCP output cap (~25k tokens, ~62k chars
@@ -96,45 +98,67 @@ class ResponseCapMiddleware(Middleware):
         return result
 
 
+def _parse_for_shaping(result: ToolResult, select: str | None) -> Any:
+    """Return parsed JSON body of `result`, or `None` if there's nothing
+    to shape. Raises `ValueError` only when `select` was asked for but the
+    body isn't JSON — the redaction-only path passes through quietly.
+    """
+    data = result.structured_content
+    if data is not None:
+        return data
+    text_blocks = [
+        getattr(c, "text", None) for c in result.content if hasattr(c, "text")
+    ]
+    candidate = next((t for t in text_blocks if isinstance(t, str) and t), None)
+    if candidate is None:
+        return None
+    try:
+        return json.loads(candidate)
+    except json.JSONDecodeError as exc:
+        if select:
+            raise ValueError(
+                f"response was not JSON; cannot apply `select`: {exc}"
+            ) from exc
+        return None
+
+
 async def _select_wrapper(
     select: Annotated[str | None, Field(description=SELECT_DESCRIPTION)] = None,
     **kwargs: Any,
 ) -> ToolResult:
-    """Call the parent tool, then project its result via JMESPath."""
+    """Call the parent tool, redact env values, then project via JMESPath."""
     result = await forward(**kwargs)
-    if not select:
-        return result
+    expose = redaction.is_expose_enabled()
+    if expose and not select:
+        return result  # nothing to do; preserve the existing fast path
 
-    data: Any = result.structured_content
+    data = _parse_for_shaping(result, select)
     if data is None:
-        text_blocks = [
-            getattr(c, "text", None) for c in result.content if hasattr(c, "text")
-        ]
-        candidate = next(
-            (t for t in text_blocks if isinstance(t, str) and t), None
-        )
-        if candidate is None:
-            return result  # nothing projectable (no text, no structured)
-        try:
-            data = json.loads(candidate)
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"response was not JSON; cannot apply `select`: {exc}"
-            ) from exc
+        return result
 
     # FastMCP wraps non-dict OpenAPI responses as `{"result": ...}` so they
     # fit MCP's structured_content schema (which must be an object). Unwrap
-    # before applying JMESPath so callers write against the natural API
+    # before redacting / projecting so callers write against the natural API
     # shape — e.g. `[].Id` against a list endpoint — rather than
-    # `result[].Id`.
+    # `result[].Id`, and so the env walker reaches list-of-objects bodies.
     if isinstance(data, dict) and set(data.keys()) == {"result"}:
         data = data["result"]
 
-    projected = project(data, select)
+    redaction_count = 0
+    if not expose:
+        data, redaction_count = redaction.redact_envs(data)
+    if select:
+        data = project(data, select)
+
+    content = [TextContent(type="text", text=json.dumps(data))]
+    if redaction_count:
+        content.append(
+            TextContent(type="text", text=redaction.hint(redaction_count))
+        )
     return ToolResult(
-        content=[TextContent(type="text", text=json.dumps(projected))],
+        content=content,
         # MCP structured_content must be a dict; drop it for lists/scalars.
-        structured_content=projected if isinstance(projected, dict) else None,
+        structured_content=data if isinstance(data, dict) else None,
     )
 
 

--- a/tests/test_patch_spec.py
+++ b/tests/test_patch_spec.py
@@ -32,7 +32,21 @@ def test_excluded_operation_ids_are_removed():
         }
     )
     patch(spec)
-    assert spec["paths"]["/git/{id}"] == {}
+    # Path is removed entirely once all its methods drop out.
+    assert "/git/{id}" not in spec["paths"]
+
+
+def test_partial_method_drop_keeps_path():
+    spec = _spec(
+        paths={
+            "/git/{id}": {
+                "get": {"operationId": "SharedGitGet"},
+                "post": {"operationId": "KeepMe"},
+            },
+        }
+    )
+    patch(spec)
+    assert spec["paths"]["/git/{id}"] == {"post": {"operationId": "KeepMe"}}
 
 
 def test_unrelated_operations_are_kept():
@@ -61,6 +75,65 @@ def test_websocket_paths_are_dropped():
     )
     patch(spec)
     assert set(spec["paths"]) == {"/endpoints"}
+
+
+# --- EXCLUDED_PATH_METHODS (edge-agent-only callbacks) ----------------------
+
+
+def test_edge_agent_callbacks_dropped_even_without_operation_id():
+    # Two of the four agent-callback ops have no operationId in the spec —
+    # FastMCP names them from `summary`. The path-method filter catches them.
+    spec = _spec(
+        paths={
+            "/endpoints/{id}/edge/stacks/{stackId}": {
+                "get": {"summary": "Inspect an Edge Stack for an Environment(Endpoint)"},
+            },
+            "/endpoints/{id}/edge/status": {
+                "get": {"operationId": "EndpointEdgeStatusInspect"},
+            },
+            "/endpoints/{id}/edge/alerts": {
+                "post": {"operationId": "EndpointEdgeAlertsReceive"},
+            },
+            "/endpoints/{id}/edge/jobs/{jobID}/logs": {
+                "post": {"summary": "Update the logs collected from an Edge Job"},
+            },
+        }
+    )
+    patch(spec)
+    # All four paths had a single method each; after the drop the path
+    # itself is removed by the empty-path cleanup.
+    assert spec["paths"] == {}
+
+
+def test_edge_admin_tools_are_kept():
+    # `EdgeStackList` / `EdgeStackInspect` are admin-facing edge tools that
+    # do *not* require the agent header. They share the `edge` / `edge_stacks`
+    # tags with the callbacks but live on different paths — they must survive.
+    spec = _spec(
+        paths={
+            "/edge_stacks": {"get": {"operationId": "EdgeStackList"}},
+            "/edge_stacks/{id}": {"get": {"operationId": "EdgeStackInspect"}},
+        }
+    )
+    patch(spec)
+    assert set(spec["paths"]) == {"/edge_stacks", "/edge_stacks/{id}"}
+
+
+def test_path_with_remaining_methods_is_kept():
+    # If a future spec adds a non-agent method to one of the edge paths,
+    # the path must survive — only the targeted method is dropped.
+    spec = _spec(
+        paths={
+            "/endpoints/{id}/edge/status": {
+                "get": {"operationId": "EndpointEdgeStatusInspect"},
+                "put": {"operationId": "HypotheticalAdminWrite"},
+            },
+        }
+    )
+    patch(spec)
+    assert spec["paths"]["/endpoints/{id}/edge/status"] == {
+        "put": {"operationId": "HypotheticalAdminWrite"},
+    }
 
 
 # --- ENUM_STRIPS ------------------------------------------------------------

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -7,9 +7,18 @@ isn't covered here.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from portainer_mcp.proxy import _apply_select, _validate_headers, _validate_path
+from portainer_mcp.redaction import EXPOSE_ENV_VAR, SENTINEL
+
+
+@pytest.fixture(autouse=True)
+def _redact_by_default(monkeypatch):
+    """Default to the redacted posture; individual tests opt in to expose."""
+    monkeypatch.delenv(EXPOSE_ENV_VAR, raising=False)
 
 
 # --- _validate_path ---------------------------------------------------------
@@ -64,12 +73,13 @@ def test_validate_headers_rejects_blocked(header: str):
 # --- _apply_select ----------------------------------------------------------
 
 
-def test_apply_select_passthrough_when_no_select():
+def test_apply_select_passthrough_when_no_select_and_exposed(monkeypatch):
+    monkeypatch.setenv(EXPOSE_ENV_VAR, "1")
     assert _apply_select('{"k": "v"}', None) == '{"k": "v"}'
     assert _apply_select("plain text", None) == "plain text"
 
 
-def test_apply_select_projects_valid_json():
+def test_apply_select_projects_valid_json_with_no_env_to_redact():
     text = '[{"Id": "a"}, {"Id": "b"}]'
     assert _apply_select(text, "[].Id") == '["a", "b"]'
 
@@ -78,3 +88,48 @@ def test_apply_select_passes_through_non_json():
     # Plain text / binary / Docker error pages reach here; the proxy must
     # not raise — the model sees the upstream body as-is.
     assert _apply_select("not json at all", "[].Id") == "not json at all"
+
+
+# --- redaction in proxy ----------------------------------------------------
+
+
+def test_apply_select_redacts_env_without_select():
+    text = json.dumps({"Config": {"Env": ["FOO=bar"]}})
+    out = _apply_select(text, None)
+    body, _, hint_text = out.partition("\n\n")
+    assert json.loads(body) == {"Config": {"Env": [f"FOO={SENTINEL}"]}}
+    assert "1 env value(s) redacted" in hint_text
+    assert EXPOSE_ENV_VAR in hint_text
+
+
+def test_apply_select_redacts_env_then_projects():
+    # Projection runs *after* redaction — `select` landing on env values
+    # lands on the sentinel, not the real secret.
+    text = json.dumps({"Config": {"Env": ["FOO=bar"]}})
+    out = _apply_select(text, "Config.Env")
+    body, _, _ = out.partition("\n\n")
+    assert json.loads(body) == [f"FOO={SENTINEL}"]
+    assert "1 env value(s) redacted" in out
+
+
+def test_apply_select_no_hint_when_no_env(monkeypatch):
+    text = json.dumps({"Id": "abc"})
+    out = _apply_select(text, None)
+    # Redaction posture is on but nothing matched; the wrapper still parses
+    # + re-serialises (compact form), but no hint should be appended.
+    assert "redacted" not in out
+    assert json.loads(out) == {"Id": "abc"}
+
+
+def test_apply_select_exposes_when_toggle_set(monkeypatch):
+    monkeypatch.setenv(EXPOSE_ENV_VAR, "1")
+    text = json.dumps({"Config": {"Env": ["FOO=bar"]}})
+    out = _apply_select(text, None)
+    # Fast path: no select + exposed = pass-through verbatim.
+    assert out == text
+
+
+def test_apply_select_non_json_passes_through_under_redaction():
+    # Even with redaction on, non-JSON bodies (logs, stats text) must pass
+    # through unchanged.
+    assert _apply_select("not json at all", None) == "not json at all"

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,167 @@
+"""Unit tests for `src/portainer_mcp/redaction.py`.
+
+Covers the pure recursive walker — every supported env shape, nested
+locations, case-insensitive key match, K8s `valueFrom` preservation,
+and the negative shapes the rule must leave alone.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from portainer_mcp.redaction import (
+    EXPOSE_ENV_VAR,
+    SENTINEL,
+    hint,
+    is_expose_enabled,
+    redact_envs,
+)
+
+
+# --- redact_envs ------------------------------------------------------------
+
+
+def test_shape_a_list_of_name_value_dicts():
+    data = {"Env": [{"name": "DB_URL", "value": "postgres://secret"}]}
+    out, count = redact_envs(data)
+    assert out == {"Env": [{"name": "DB_URL", "value": SENTINEL}]}
+    assert count == 1
+
+
+def test_shape_c_docker_native_key_val_strings():
+    data = {"Env": ["FOO=bar", "BAZ=qux", "MALFORMED"]}
+    out, count = redact_envs(data)
+    assert out == {"Env": [f"FOO={SENTINEL}", f"BAZ={SENTINEL}", "MALFORMED"]}
+    assert count == 2
+
+
+def test_shape_f_k8s_value_and_value_from():
+    data = {
+        "env": [
+            {"name": "X", "value": "y"},
+            {"name": "Z", "valueFrom": {"secretKeyRef": {"name": "s", "key": "k"}}},
+        ]
+    }
+    out, count = redact_envs(data)
+    assert out["env"][0]["value"] == SENTINEL
+    assert out["env"][1] == {
+        "name": "Z",
+        "valueFrom": {"secretKeyRef": {"name": "s", "key": "k"}},
+    }
+    assert count == 1
+
+
+def test_shape_g_envvars_capitalised_value():
+    data = {"EnvVars": [{"Name": "K", "Value": "v"}]}
+    out, count = redact_envs(data)
+    assert out == {"EnvVars": [{"Name": "K", "Value": SENTINEL}]}
+    assert count == 1
+
+
+def test_case_insensitive_key_match():
+    data = {"ENV": [{"name": "K", "value": "v"}]}
+    out, count = redact_envs(data)
+    assert out["ENV"][0]["value"] == SENTINEL
+    assert count == 1
+
+
+def test_nested_swarm_taskspec_env():
+    data = {
+        "Spec": {
+            "TaskTemplate": {
+                "ContainerSpec": {
+                    "Env": ["DB=secret", "API_KEY=secret"],
+                }
+            }
+        }
+    }
+    out, count = redact_envs(data)
+    env = out["Spec"]["TaskTemplate"]["ContainerSpec"]["Env"]
+    assert env == [f"DB={SENTINEL}", f"API_KEY={SENTINEL}"]
+    assert count == 2
+
+
+def test_list_root_with_multiple_objects():
+    data = [
+        {"Env": [{"name": "A", "value": "1"}]},
+        {"Env": ["B=2"]},
+    ]
+    out, count = redact_envs(data)
+    assert out[0]["Env"][0]["value"] == SENTINEL
+    assert out[1]["Env"] == [f"B={SENTINEL}"]
+    assert count == 2
+
+
+def test_negative_template_variables_unchanged():
+    # CustomTemplate's `Variables[].defaultValue` is intentionally out of
+    # scope — template-author metadata, surfaced in the UI.
+    data = {"Variables": [{"name": "X", "defaultValue": "y"}]}
+    out, count = redact_envs(data)
+    assert out == {"Variables": [{"name": "X", "defaultValue": "y"}]}
+    assert count == 0
+
+
+def test_negative_field_named_environment_id_unchanged():
+    data = {"environment_id": 5, "EnvironmentName": "prod"}
+    out, count = redact_envs(data)
+    assert out == {"environment_id": 5, "EnvironmentName": "prod"}
+    assert count == 0
+
+
+def test_no_env_present_count_zero():
+    data = {"Id": 1, "Name": "alpha", "children": [{"k": "v"}]}
+    out, count = redact_envs(data)
+    assert out == {"Id": 1, "Name": "alpha", "children": [{"k": "v"}]}
+    assert count == 0
+
+
+def test_in_place_mutation():
+    data = {"Env": [{"name": "A", "value": "b"}]}
+    out, _ = redact_envs(data)
+    assert out is data
+    assert data["Env"][0]["value"] == SENTINEL
+
+
+def test_scalar_root_count_zero():
+    out, count = redact_envs("just a string")
+    assert out == "just a string"
+    assert count == 0
+
+
+def test_malformed_env_string_passes_through():
+    # Strings inside an env list that don't match KEY=VAL pass through.
+    data = {"Env": ["NOEQUALS", "123=numeric-prefix-ok"]}
+    out, count = redact_envs(data)
+    # "123=…" has a digit-leading key — doesn't match `[A-Za-z_]…`, so
+    # both pass through unchanged.
+    assert out == {"Env": ["NOEQUALS", "123=numeric-prefix-ok"]}
+    assert count == 0
+
+
+# --- is_expose_enabled -----------------------------------------------------
+
+
+def test_expose_default_off(monkeypatch):
+    monkeypatch.delenv(EXPOSE_ENV_VAR, raising=False)
+    assert is_expose_enabled() is False
+
+
+@pytest.mark.parametrize("falsey", ["0", "false", "False"])
+def test_expose_falsey_values(monkeypatch, falsey: str):
+    monkeypatch.setenv(EXPOSE_ENV_VAR, falsey)
+    assert is_expose_enabled() is False
+
+
+@pytest.mark.parametrize("truthy", ["1", "true", "yes", "anything"])
+def test_expose_truthy_values(monkeypatch, truthy: str):
+    monkeypatch.setenv(EXPOSE_ENV_VAR, truthy)
+    assert is_expose_enabled() is True
+
+
+# --- hint ------------------------------------------------------------------
+
+
+def test_hint_mentions_env_var_and_count():
+    h = hint(3)
+    assert "3 env value(s) redacted" in h
+    assert EXPOSE_ENV_VAR in h

--- a/tests/test_shaping.py
+++ b/tests/test_shaping.py
@@ -1,17 +1,26 @@
 """Unit tests for `src/portainer_mcp/shaping.py`.
 
 Covers the pure-data layers: `project()` and `ResponseCapMiddleware`.
-`_select_wrapper` and `SelectArgTransform` need a live FastMCP runtime
-and aren't covered here.
+`SelectArgTransform` needs a live FastMCP runtime and isn't covered here;
+`_select_wrapper` is exercised by stubbing `fastmcp.tools.forward`.
 """
 
 from __future__ import annotations
+
+import json
 
 import pytest
 from fastmcp.tools.tool import ToolResult
 from mcp.types import TextContent
 
+from portainer_mcp import shaping
+from portainer_mcp.redaction import EXPOSE_ENV_VAR, SENTINEL
 from portainer_mcp.shaping import ResponseCapMiddleware, project
+
+
+@pytest.fixture(autouse=True)
+def _redact_by_default(monkeypatch):
+    monkeypatch.delenv(EXPOSE_ENV_VAR, raising=False)
 
 
 # --- project() --------------------------------------------------------------
@@ -60,3 +69,66 @@ async def test_cap_truncates_and_clears_structured():
     assert "truncated: response was 50 chars" in text
     assert "capped at 10" in text
     assert out.structured_content is None
+
+
+# --- _select_wrapper redaction ---------------------------------------------
+
+
+def _stub_forward(monkeypatch, payload):
+    """Replace `forward` so calling `_select_wrapper` returns `payload`."""
+
+    async def fake_forward(**kwargs):
+        return ToolResult(
+            content=[TextContent(type="text", text=json.dumps(payload))],
+            structured_content=payload if isinstance(payload, dict) else None,
+        )
+
+    monkeypatch.setattr(shaping, "forward", fake_forward)
+
+
+async def test_wrapper_redacts_without_select_and_emits_hint(monkeypatch):
+    _stub_forward(monkeypatch, {"Env": [{"name": "DB", "value": "secret"}]})
+    result = await shaping._select_wrapper()
+    body = json.loads(result.content[0].text)
+    assert body == {"Env": [{"name": "DB", "value": SENTINEL}]}
+    assert "1 env value(s) redacted" in result.content[1].text
+    assert result.structured_content == body
+
+
+async def test_wrapper_redacts_before_select(monkeypatch):
+    # `select="Env[0].value"` must land on the sentinel — the env walker
+    # runs before JMESPath projection, so callers can't bypass redaction.
+    _stub_forward(monkeypatch, {"Env": [{"name": "DB", "value": "secret"}]})
+    result = await shaping._select_wrapper(select="Env[0].value")
+    assert json.loads(result.content[0].text) == SENTINEL
+    # Hint is still present.
+    assert "redacted" in result.content[1].text
+
+
+async def test_wrapper_exposes_when_toggle_set(monkeypatch):
+    monkeypatch.setenv(EXPOSE_ENV_VAR, "1")
+    payload = {"Env": [{"name": "DB", "value": "secret"}]}
+    _stub_forward(monkeypatch, payload)
+    # Without select, no shaping happens at all — the upstream ToolResult
+    # is returned verbatim, with the real value.
+    result = await shaping._select_wrapper()
+    assert result.structured_content == payload
+    assert len(result.content) == 1
+
+
+async def test_wrapper_no_hint_when_no_env(monkeypatch):
+    _stub_forward(monkeypatch, {"Id": 1, "Name": "alpha"})
+    result = await shaping._select_wrapper(select="Name")
+    assert json.loads(result.content[0].text) == "alpha"
+    # Only the projected body — no hint TextContent.
+    assert len(result.content) == 1
+
+
+async def test_wrapper_unwraps_result_envelope_then_redacts(monkeypatch):
+    # FastMCP wraps list responses as `{"result": [...]}` for the schema.
+    # The walker must reach into the unwrapped list.
+    _stub_forward(monkeypatch, {"result": [{"Env": ["FOO=bar"]}]})
+    result = await shaping._select_wrapper()
+    body = json.loads(result.content[0].text)
+    assert body == [{"Env": [f"FOO={SENTINEL}"]}]
+    assert "1 env value(s) redacted" in result.content[1].text


### PR DESCRIPTION
Stack, container, and Kubernetes env values are rewritten to `[REDACTED]` before leaving the MCP tool boundary, with a one-line summary appended to the response. Redaction runs before JMESPath `select`, so a projection like `select="Env[0].value"` lands on the sentinel rather than the real value. Toggle disclosure via `PORTAINER_EXPOSE_ENV_VALUES=1`; the posture is logged at startup.

Also drops four edge-agent-only callbacks (`/endpoints/{id}/edge/...`) from the spec patcher — they 403 outside an agent context and were surfacing as tools that can never succeed for a non-agent MCP caller. Matched on (method, path) since two of them have no operationId.

Closes #61 