### PR TITLE
Add HTTP per-user Portainer API-key passthrough

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,18 @@
-# Copy to .env and fill in. Used by `make dev`.
+# Copy to .env and fill in. Used by `make dev`, which runs the HTTP transport
+# (per-user passthrough): the gate token below admits the request, and your
+# own Portainer API key travels as a client header, not an env var.
 
 # Required
 PORTAINER_URL=https://portainer.example.com
-PORTAINER_API_KEY=ptr_xxxxxxxxxxxxxxxx
 # Generate with: openssl rand -hex 32
 PORTAINER_MCP_AUTH_TOKEN=
 
+# PORTAINER_API_KEY is the stdio-only credential. Do NOT set it here: the HTTP
+# transport refuses to boot if it's present. Each client forwards its own key
+# via the `X-Portainer-API-Key` header instead (see the Makefile `dev` target).
+
 # Optional — see docs/configuration.md for the full list.
+# PORTAINER_MCP_AUTH_CACHE_TTL=60
 # PORTAINER_TLS_VERIFY=0
 # PORTAINER_PROFILES=ALL
 # PORTAINER_MCP_LOG_LEVEL=DEBUG

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,12 +75,43 @@ Key things to internalise before changing code:
   one-line summary TextContent naming the env var.
 - **HTTP transport requires a bearer token.** `auth.py` defines
   `StaticBearerVerifier` (a `fastmcp.server.auth.TokenVerifier` subclass
-  using `hmac.compare_digest`); `build_server()` wires it into
+  using `hmac.compare_digest`); `build_server()` wires a verifier into
   `FastMCP.from_openapi(..., auth=…)` only when transport=http. Stdio
   ignores `PORTAINER_MCP_AUTH_TOKEN`. Strict validation at startup
   (min 32 chars, ASCII printable, no whitespace) — loud-fail like the
   unknown-profile check. Don't relax this for "convenience"; the strict
   rule eliminates the make-dev-no-token footgun.
+- **HTTP is per-user passthrough, not a shared upstream key.** Over HTTP
+  the verifier is `auth.PassthroughVerifier` (subclass of
+  `StaticBearerVerifier`), and `PORTAINER_API_KEY` is *not* loaded — it's
+  the stdio-only credential, and `build_server()` hard-fails if it's set
+  under http (a misconfiguration, not a silent fallback). Two layered
+  checks run inside one `verify_token` so a failure 401s before any tool
+  dispatch: (1) the gate token in `Authorization` is constant-time
+  compared by the parent; (2) the caller's own key in the separate
+  `X-Portainer-API-Key` header is validated against `/users/me`
+  (`passthrough.validate`, positive-only `ValidationCache` keyed by the
+  SHA-256 of the key, TTL `PORTAINER_MCP_AUTH_CACHE_TTL` default 60).
+  The validated key is injected upstream as `X-API-KEY` by the
+  `passthrough.inject_api_key` httpx request hook, which reads *only* the
+  in-flight request (so one caller can't borrow another's key) and **fails
+  closed** — it raises rather than ever sending a keyless upstream call.
+  The two headers carry distinct credentials (gate vs per-user key), so
+  the verified token and the forwarded token are never the same value;
+  the httpx client under http therefore carries no baked `X-API-KEY`
+  (stdio still does). Audit outcomes gain `no_user_key` /
+  `invalid_user_key`. `ok` fires only on a *validation* (a cache miss that
+  hits `/users/me`), attributed with `portainer_user_id/username` — so it
+  marks a validation event (~one per key per TTL window), not every
+  admitted request; cache hits admit silently (`validate()` returns
+  `(identity, validated_now)` so the verifier knows which). The failure
+  outcomes are uncached and fire per request. The per-user key itself is
+  never logged (regression-tested). The structured request log adds the
+  `tool` name on a `tools/call` (the bare `method` is only ever
+  `tools/call`). The cache TTL is a
+  perf/DoS knob, not the authz boundary (Portainer rejects a revoked key
+  on every real call); never negative-cache (it would lock out a fresh
+  key).
 - **Two HTTP hardening layers stack on top of the bearer.** Wired in
   `build_server()` + `main()`: a contextualised `StructuredLoggingMiddleware`
   applies to every transport; `http_security.DNSRebindingMiddleware` is

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,15 @@ specs:
 	git -C $(UPSTREAM_DIR) checkout
 	uv run python spec/patch_spec.py $(UPSTREAM_DIR)/versions/ee/$(VERSION).yaml
 
-# Local dev server (HTTP transport). One-time setup:
-#   1. cp .env.example .env, fill in PORTAINER_URL + PORTAINER_API_KEY, and set
+# Local dev server (HTTP transport = per-user passthrough). One-time setup:
+#   1. cp .env.example .env, fill in PORTAINER_URL, and set
 #      PORTAINER_MCP_AUTH_TOKEN to a fresh secret: `openssl rand -hex 32`.
-#   2. Register with Claude using the same token:
+#      Do NOT set PORTAINER_API_KEY — HTTP refuses to boot with it (it's
+#      stdio-only); your Portainer key travels as a client header instead.
+#   2. Register with Claude using the gate token + your own Portainer key:
 #      claude mcp add portainer-dev --transport http http://127.0.0.1:17717/mcp \
-#        --header "Authorization: Bearer <token>"
+#        --header "Authorization: Bearer <token>" \
+#        --header "X-Portainer-API-Key: <ptr_key>"
 # Then iterate: edit code, ctrl-c, make dev again. Claude reconnects automatically.
 dev:
 	PORTAINER_MCP_TRANSPORT=http uv run --env-file .env portainer-mcp

--- a/README.md
+++ b/README.md
@@ -43,34 +43,35 @@ Contributions for other client instructions are welcome!
 
 ### Team deployment (container)
 
-The recommended way to have multiple users interacting with your Portainer instance via MCP. Deployed as a [`container`](https://hub.docker.com/r/portainer/portainer-mcp) inside your infrastructure, accessed by users from their workstations over HTTP, gated by a shared bearer secret.
+The recommended way to have multiple users interacting with your Portainer instance via MCP. Deployed as a [`container`](https://hub.docker.com/r/portainer/portainer-mcp) inside your infrastructure, accessed by users from their workstations over HTTP. A shared secret gates the MCP server and every client also forwards its own Portainer API key so that each user acts under their own Portainer identity.
 
 > [!IMPORTANT]
-> The container terminates HTTP, **NOT HTTPS**, and serves auth as a single shared bearer.
-> The secret can be intercepted on any path between client and server without TLS termination.
+> The container terminates HTTP, **NOT HTTPS**. Both the gate secret and each user's Portainer API key can be intercepted on any path between client and server without TLS termination.
 > 
 > It is **NOT** recommended to expose this MCP server on the public internet.
 > 
-> Even with a TLS-terminating reverse proxy in front, the recommendation is to gate this MCP server inside your private infrastructure.
+> Even with a TLS-terminating reverse proxy in front, the recommendation is to host this MCP server inside your private infrastructure.
 
 Run the MCP server as a container in your infrastructure:
 
 ```bash
+TOKEN=$(openssl rand -hex 32)
 docker run -d --name portainer-mcp -p 17717:17717 \
   -e PORTAINER_URL=https://portainer.example.com \
-  -e PORTAINER_API_KEY=ptr_xxxxxxxxxxxxxxxx \
-  -e PORTAINER_MCP_AUTH_TOKEN="$(openssl rand -hex 32)" \
+  -e PORTAINER_MCP_AUTH_TOKEN="$TOKEN" \
   -e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com:17717 \
   portainer/portainer-mcp:2.42
 ```
 
 Set `PORTAINER_MCP_ALLOWED_HOSTS` to the hostname or IP address that users will use to reach the MCP — otherwise the DNS-rebinding allowlist 421-rejects the request.
 
-`PORTAINER_MCP_AUTH_TOKEN` is **required** in HTTP mode. It provides the key to gate access to the MCP, distribute this token to the users; their MCP client will send it via the `Authorization` header.
+`PORTAINER_MCP_AUTH_TOKEN` is **required** in HTTP mode. It's the shared front-gate secret you distribute to your users; their MCP client sends it via the `Authorization` header. It only admits the request — what each user can *do* is governed by their own Portainer API key.
 
 Adding the MCP endpoint on Claude Code:
 ```bash
-claude mcp add portainer --transport http http://mcp.example.com:17717/mcp --header "Authorization: Bearer <token>"
+claude mcp add portainer --transport http http://mcp.example.com:17717/mcp \
+  --header "Authorization: Bearer <gate-token>" \
+  --header "X-Portainer-API-Key: <ptr_user_key>"
 ```
 
 ### Hygiene skill (recommended)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,8 +31,10 @@ data/portainer-patched.yaml ──► FastMCP.from_openapi ──► tag filter 
 `build_server()` loads `src/portainer_mcp/data/portainer-patched.yaml` (a
 locally-patched copy of Portainer's EE OpenAPI spec, bundled into the
 wheel and read via `importlib.resources`) and hands it to
-`FastMCP.from_openapi` with a shared `httpx.AsyncClient` carrying the
-operator's `X-API-KEY`. Each operation becomes an MCP tool.
+`FastMCP.from_openapi` with a shared `httpx.AsyncClient`. Under stdio the
+client carries the operator's `X-API-KEY` directly; under HTTP it carries no
+baked key — a per-request hook injects each caller's own key (see *HTTP auth*).
+Each operation becomes an MCP tool.
 
 ### Tag filter — `profiles.py`
 
@@ -69,21 +71,53 @@ client-side UX signal, not enforcement — the server's actual read-only
 guarantee is the `GET`/`HEAD` `RouteMap` restriction and the proxy's
 method check.
 
-### HTTP auth — `auth.py`
+### HTTP auth — `auth.py` and `passthrough.py`
 
-Only relevant when `PORTAINER_MCP_TRANSPORT=http`. `build_server()` reads
-`PORTAINER_MCP_AUTH_TOKEN`, validates it (min 32 chars, ASCII printable,
-no whitespace, loud-fail on any defect), and wires a
-`StaticBearerVerifier` — a `fastmcp.server.auth.TokenVerifier` subclass —
-into the FastMCP constructor. Every HTTP request must carry
-`Authorization: Bearer <token>`; the verifier uses `hmac.compare_digest`
-for constant-time comparison and returns `None` on mismatch, at which
-point FastMCP renders the 401 + `WWW-Authenticate` response itself. Stdio
-transport short-circuits the auth path entirely (`_get_auth_context()` in
-FastMCP). Every verify attempt — success or mismatch — emits a structured
-audit record on the `portainer_mcp.audit` sub-logger carrying the
-per-request context (see below); the attempted token bytes are never
-logged.
+Only relevant when `PORTAINER_MCP_TRANSPORT=http`. HTTP is **per-user
+passthrough**, not a shared upstream identity: there is no mode flag, and a
+shared `PORTAINER_API_KEY` over HTTP is a hard-fail misconfiguration (it's the
+stdio-only credential). Two layered checks run on every request, both inside
+`PassthroughVerifier.verify_token` so a failure 401s before any tool dispatch:
+
+1. **Front gate.** `build_server()` reads `PORTAINER_MCP_AUTH_TOKEN`, validates
+   it (min 32 chars, ASCII printable, no whitespace, loud-fail on any defect),
+   and the verifier constant-time-compares the request's `Authorization: Bearer`
+   against it (`hmac.compare_digest`). A miss returns `None` → FastMCP renders
+   401 + `WWW-Authenticate`. The gate is mandatory (no opt-out) and stops
+   credential-less floods at a cheap local 401 before they reach Portainer.
+2. **Per-user validation.** The caller's own Portainer key rides in a separate
+   `X-Portainer-API-Key` header. The verifier validates it against
+   `GET /users/me?noEndpointAuthorizations=true` (`passthrough.validate`) and
+   only on success admits the request, capturing `id/username` for the
+   audit log. Missing key → `no_user_key`; invalid/unreachable → `invalid_user_key`;
+   both 401, with no fallback to a shared key.
+
+The validated key is then injected upstream as `X-API-KEY` by an httpx request
+hook (`passthrough.inject_api_key`) that reads **only** the in-flight request,
+so one caller can never borrow another's key, and **fails closed** (raises)
+rather than ever sending a keyless upstream call. The two headers carry
+*distinct* credentials — the gate token (`Authorization`, verified, never
+forwarded) and the per-user key (`X-Portainer-API-Key`, validated, forwarded) —
+so the verified credential and the forwarded one are never the same value.
+
+Validation is cached positive-only (`ValidationCache`, keyed by the SHA-256 of
+the key, never the raw key) for `PORTAINER_MCP_AUTH_CACHE_TTL` seconds (default
+60). This collapses a session to one upstream `/users/me` per key per window;
+the front gate keeps the miss path from being an open amplifier. The TTL is a
+performance/DoS knob, not the authorization boundary — Portainer still rejects
+a revoked key on every real upstream call, so a stale entry lets a dead key
+pass the door for at most one window but never *act*. Negatives are never
+cached so a freshly minted key isn't locked out.
+
+Stdio transport short-circuits the auth path entirely (`_get_auth_context()` in
+FastMCP) and keeps the single baked `X-API-KEY`. The verifier emits structured
+audit records on the `portainer_mcp.audit` sub-logger carrying the per-request
+context (see below). `ok` fires only on a *validation* — a cache miss that
+round-trips `/users/me` — so it marks a validation event (~one per key per TTL
+window), not every admitted request; cache hits admit silently. The failure
+outcomes `mismatch` / `no_user_key` / `invalid_user_key` are uncached and fire
+on every failing request. The attempted gate-token bytes and the per-user key
+are **never** logged (regression-tested).
 
 ### HTTP security — `http_security.py`
 
@@ -111,7 +145,9 @@ the client side.
 `snapshot()` returns `client_ip`, `user_agent`, and the MCP
 `Mcp-Session-Id` for the in-flight HTTP request via
 `fastmcp.server.dependencies.get_http_request()`. Both the audit log (in
-`auth.verify_token`) and the FastMCP request log call it. Reading
+the verifier) and the FastMCP request log call it. `passthrough.py` reads
+the same live request for the per-user key (`key_from_request`) and for
+cache-only identity enrichment (`identity_audit_fields`). Reading
 directly from the live request avoids a subtle bug: MCP's
 streamable-HTTP session manager dispatches every JSON-RPC message into a
 long-lived task whose ContextVars were captured at session-creation
@@ -129,15 +165,20 @@ and merges records whose `msg` parses as a JSON object into that
 envelope, so audit and request records become first-class fields rather
 than nested strings. Two structured emitters feed it:
 
-- **Auth audit** — `StaticBearerVerifier.verify_token` emits one record
-  per attempt on `portainer_mcp.audit`, carrying outcome + per-request
-  context (`client_ip`, `user_agent`, `session_id`).
+- **Auth audit** — the verifier emits records on `portainer_mcp.audit`,
+  carrying outcome + per-request context (`client_ip`, `user_agent`,
+  `session_id`). `ok` fires only on a validation (cache miss), attributed with
+  the validated Portainer identity (`portainer_user_id`, `portainer_username`);
+  cache hits are silent. Failure outcomes fire per request.
 - **Request log** — `_ContextualStructuredLogging`, a thin subclass of
   FastMCP's `StructuredLoggingMiddleware`, adds the same per-request
   context to the before/after/error records the middleware already
-  emits. The upstream `source: "client"` field is dropped from
-  consideration as a caller distinguisher — one shared bearer means
-  every request shows the same value.
+  emits, plus the validated Portainer identity (read from the validation
+  cache, never the key) and, for a `tools/call`, the `tool` name (the
+  bare `method` is only ever `tools/call`). The upstream `source` field is
+  dropped entirely — it's a `Literal["client","server"]` that the request
+  path always stamps `"client"`, so it carries no signal; identity is what
+  distinguishes callers.
 
 `_setup_logging()` also strips pre-existing handlers from `fastmcp`,
 `httpx`, and `uvicorn.*` loggers and passes `uvicorn_config={"log_config":

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-This files document every knob that the `portainer-mcp` exposes, grouped by concern. All values are read from the process environment at startup. Defaults are sized for two documented deployment shapes: **local stdio** (local process, no auth) and **shared-secret HTTP** (multi-user, bearer-gated).
+This files document every knob that the `portainer-mcp` exposes, grouped by concern. All values are read from the process environment at startup. Defaults are sized for two documented deployment shapes: **local stdio** (local process, no auth, single baked key) and **HTTP per-user passthrough** (multi-user, shared bearer gate + each client's own Portainer key).
 
 > [!NOTE]
 > Truthy parsing: any value other than `0`, `false`, or `False` is treated as truthy.
@@ -9,10 +9,10 @@ This files document every knob that the `portainer-mcp` exposes, grouped by conc
 
 | Var | Notes |
 |---|---|
-| `PORTAINER_URL` | Base URL of the Portainer instance, e.g. `https://portainer.example.com`. |
-| `PORTAINER_API_KEY` | Portainer-issued API key, carried as `X-API-KEY` on every upstream call. |
+| `PORTAINER_URL` | Base URL of the Portainer instance, e.g. `https://portainer.example.com`. Required for every transport. |
+| `PORTAINER_API_KEY` | Portainer-issued API key, carried as `X-API-KEY` on every upstream call. **stdio only** — required under stdio. Under HTTP each client forwards its own key instead (see [HTTP per-user passthrough](#http-per-user-passthrough)), so setting it under HTTP is a misconfiguration and the server refuses to boot. |
 
-The MCP server will not start if either is missing.
+The server will not start if `PORTAINER_URL` is missing, if `PORTAINER_API_KEY` is missing under stdio, or if it is *set* under HTTP.
 
 ## Transport
 
@@ -21,9 +21,28 @@ The MCP server will not start if either is missing.
 | `PORTAINER_MCP_TRANSPORT` | `stdio` | `stdio` or `http`. The container image overrides to `http`. |
 | `PORTAINER_MCP_HTTP_HOST` | `127.0.0.1` | Bind address when `transport=http`. Container image overrides to `0.0.0.0` so it's reachable from outside the container. |
 | `PORTAINER_MCP_HTTP_PORT` | `17717` | Bind port when `transport=http`. |
-| `PORTAINER_MCP_AUTH_TOKEN` | _required for http_ | Shared bearer secret. ≥32 ASCII-printable characters, no whitespace. Generate with `openssl rand -hex 32`. Ignored under stdio. |
+| `PORTAINER_MCP_AUTH_TOKEN` | _required for http_ | Shared bearer **gate** secret. ≥32 ASCII-printable characters, no whitespace. Generate with `openssl rand -hex 32`. Ignored under stdio. Admits the request; the caller's own Portainer key is then validated and forwarded (see below). |
+| `PORTAINER_MCP_AUTH_CACHE_TTL` | `60` | Seconds to cache a validated per-user key. Positive results only; `0` disables caching (validate every request). HTTP only. |
 
 The stdio transport ignores everything in this section except `PORTAINER_MCP_TRANSPORT` itself.
+
+### HTTP per-user passthrough
+
+Over HTTP, the server does **not** carry a single shared upstream identity. Each client sends two headers:
+
+| Header | Carries | Role |
+|---|---|---|
+| `Authorization: Bearer <gate-token>` | The shared `PORTAINER_MCP_AUTH_TOKEN` | Front gate — constant-time compared; admits the request. Same for every client of this deployment. |
+| `X-Portainer-API-Key: <ptr_…>` | The caller's **own** Portainer API key | Validated against `/users/me` on first use (cached), then forwarded upstream as `X-API-KEY`. Per-user. |
+
+```bash
+claude mcp add portainer --transport http http://mcp.example.com:17717/mcp \
+  --header "Authorization: Bearer <gate-token>" \
+  --header "X-Portainer-API-Key: <ptr_user_key>"
+```
+
+A missing/invalid gate token **or** missing/invalid per-user key returns 401 — there is no fallback to a shared key. This gives each user Portainer's own RBAC and per-user attribution in both Portainer's audit log and the MCP audit log.
+
 
 ## Hardening (HTTP transport only)
 
@@ -69,50 +88,47 @@ Two controls layered on top of the bearer secret:
 In `json` mode, every line is a single JSON object: app logs carry a `msg` string; audit + request records have their fields merged into the envelope (no nested-string dance). Example, mixing audit, request, and plain startup lines:
 
 ```json
-{"ts": "2026-05-25T12:00:00+0000", "level": "INFO", "logger": "portainer_mcp", "msg": "HTTP auth: enabled (token abcd…wxyz)"}
-{"ts": "2026-05-25T12:00:01+0000", "level": "INFO", "logger": "portainer_mcp.audit", "event": "auth", "outcome": "ok", "client_ip": "203.0.113.7", "user_agent": "Claude-Code/1.2.3", "session_id": "abf3…"}
-{"ts": "2026-05-25T12:00:01+0000", "level": "INFO", "logger": "fastmcp.middleware.structured_logging", "event": "request_success", "method": "tools/call", "source": "client", "duration_ms": 42.3, "client_ip": "203.0.113.7", "user_agent": "Claude-Code/1.2.3", "session_id": "abf3…"}
+{"ts": "2026-05-25T12:00:00+0000", "level": "INFO", "logger": "portainer_mcp", "msg": "HTTP auth: per-user passthrough (gate abcd…wxyz, validation cache ttl=60s)"}
+{"ts": "2026-05-25T12:00:01+0000", "level": "INFO", "logger": "portainer_mcp.audit", "event": "auth", "outcome": "ok", "client_ip": "203.0.113.7", "user_agent": "Claude-Code/1.2.3", "portainer_user_id": 1, "portainer_username": "admin"}
+{"ts": "2026-05-25T12:00:01+0000", "level": "INFO", "logger": "fastmcp.middleware.structured_logging", "event": "request_success", "method": "tools/call", "tool": "EndpointList", "duration_ms": 42.3, "client_ip": "203.0.113.7", "user_agent": "Claude-Code/1.2.3", "session_id": "abf3…", "portainer_user_id": 1, "portainer_username": "admin"}
 ```
 
 Audit and structured-request records both carry the same per-request context fields: `client_ip` (peer address), `user_agent` (HTTP header,
 distinguishes Claude Code / Inspector / custom scripts), and `session_id` (the MCP `Mcp-Session-Id` assigned at `initialize` —
-absent on the `initialize` request itself, present on every subsequent request in the session). With a single shared bearer the audit deliberately omits `token_fp` since it would be a constant; failed attempts likewise carry no token content.
+absent on the `initialize` request itself, present on every subsequent request in the session). With a single shared gate bearer the audit deliberately omits `token_fp` since it would be a constant; failed attempts likewise carry no token content, and the per-user `X-Portainer-API-Key` is never logged.
+
+The audit `outcome` is one of `ok`, `mismatch` (wrong gate token), `no_user_key` (gate passed but no `X-Portainer-API-Key`), or `invalid_user_key` (key rejected by `/users/me` or Portainer unreachable). A successful `ok` — and every matching structured-request record — is attributed with the validated Portainer identity: `portainer_user_id`, `portainer_username`. This is the per-user attribution the passthrough model buys; the key that resolves to that identity is never recorded. Structured-request records for a `tools/call` also carry the `tool` name (the `method` field alone is just `tools/call`).
 
 ### Audit & traceability
 
-The audit log fires **once per HTTP request**, not once per JSON-RPC method call. The MCP Streamable HTTP transport turns a single user-visible action (e.g. one `tools/call`) into several HTTP requests:
+The audit log records **auth events, not every request.** Successful `ok` fires only on a *validation* — i.e. a cache miss that round-trips `/users/me` — so a key produces roughly **one `ok` per `PORTAINER_MCP_AUTH_CACHE_TTL` window** (plus one on each new session's first request), not one per HTTP request. Cache hits admit silently. Failures (`mismatch`, `no_user_key`, `invalid_user_key`) are never cached, so they fire on **every** failing request — which is what you want for alerting.
 
-- 1 POST carrying the JSON-RPC `tools/call` message → 1 audit row +
-  1 `request_start` + 1 `request_success`
-- 1 GET to open the SSE stream the response is delivered on → 1 audit
-  row, no `request_*` record
-- 1+ POST 202s for client-side notifications and responses → 1 audit
-  row each, no `request_*` records
-
-So one tool invocation typically produces ~4 audit rows but only one `request_start` / `request_success` pair. The "extra" audits aren't duplicates — they're real bearer checks on transport-level traffic that doesn't carry a JSON-RPC method, so the FastMCP middleware has nothing to log.
+The MCP Streamable HTTP transport turns a single user-visible action (e.g. one `tools/call`) into several HTTP requests — the JSON-RPC POST, a GET to open the SSE response stream, and notification/response 202s. Each is a separate auth check, but with validation caching only the first (the miss) emits an `ok`; the rest are silent hits. Per-tool-call activity instead lives in the **structured request log** (`request_start` / `request_success`), which fires once per JSON-RPC method call and carries `tool`, identity, and `session_id`.
 
 Practical consequences:
 
-- **Count tool-call volume from `request_success`, not audit rows.**  Audit counts overstate tool traffic by ~4–6×.
-- **Tune `mismatch` alerts, not `ok` rate alerts.** A single chatty agent can produce 100+ `ok` audits/minute on its own; `mismatch` is rare under normal traffic and is the signal worth paging on.
-- **For "who called this tool at time T," start from the `request_*` row.** Take its `session_id`, then grep audit rows by `session_id` to see every HTTP request that session made — useful for spotting probes of unexpected paths or a client that authenticated and then went quiet.
+- **Count tool-call volume from `request_success`, not audit `ok` rows.** An `ok` is a validation event (~one per key per TTL window), not a request counter.
+- **Read `ok` as "key K validated as user U at time T".** It's the per-user attribution + the "this credential was exercised" signal, not a request trail.
+- **Alert on the failure outcomes.** `mismatch` (wrong/probing gate token) and a burst of `invalid_user_key` from one IP are the signals worth paging on; both fire per-request, uncached.
+- **For "who called this tool at time T," start from the `request_*` row** — it has `tool`, `portainer_username`, and `session_id` directly.
 
-**`session_id` is the join key.** Every audit row and every matching `request_start` / `request_success` from the same MCP session carry the same `session_id`. To trace a specific tool call back to its caller, find the `request_*` rows for the method, take the `session_id`, and grep for matching audit rows to see every authenticated HTTP request that session made — including the SSE stream, notifications, and the initial handshake.
+**`session_id` is the join key** across `request_start` / `request_success` records (and any failure audits) within a session. Note a validation `ok` often fires on the `initialize` request, before `Mcp-Session-Id` is assigned, so it may carry no `session_id` — trace activity through the request log, which always has it once the session is established.
 
 Operator queries (`jq` against `docker logs` in JSON mode):
 
 ```bash
 # Failed-auth attempts in the last hour — alert on bursts from one IP
 docker logs --since 1h portainer-mcp | jq -c \
-  'select(.logger == "portainer_mcp.audit" and .outcome == "mismatch")'
+  'select(.logger == "portainer_mcp.audit" and (.outcome | IN("mismatch","no_user_key","invalid_user_key")))'
 
 # Every record (audit + request) for a given session
 docker logs portainer-mcp | jq -c \
   'select(.session_id == "abf3c2…")'
 
-# Spot unfamiliar User-Agents that successfully authenticated
+# Which users validated, and from where
 docker logs portainer-mcp | jq -r \
-  'select(.logger == "portainer_mcp.audit" and .outcome == "ok") | .user_agent' \
+  'select(.logger == "portainer_mcp.audit" and .outcome == "ok")
+   | "\(.portainer_username) \(.client_ip) \(.user_agent)"' \
   | sort -u
 
 # Slowest tool calls (top 10) with their caller

--- a/src/portainer_mcp/auth.py
+++ b/src/portainer_mcp/auth.py
@@ -1,7 +1,10 @@
 """HTTP bearer-token auth for the streamable-HTTP transport.
 
-A single shared secret gates the HTTP `/mcp` endpoint. Stdio transport
-is unaffected.
+A shared secret gates the HTTP `/mcp` endpoint (`StaticBearerVerifier`).
+Over HTTP that gate is layered with per-user key validation
+(`PassthroughVerifier`): the gate admits the request, then the caller's own
+Portainer key is validated before the request is trusted. Stdio transport is
+unaffected (no auth).
 """
 
 from __future__ import annotations
@@ -10,9 +13,10 @@ import hmac
 import json
 import logging
 
+import httpx
 from fastmcp.server.auth import AccessToken, TokenVerifier
 
-from . import request_context
+from . import passthrough, request_context
 
 ENV_VAR = "PORTAINER_MCP_AUTH_TOKEN"
 MIN_TOKEN_LENGTH = 32
@@ -21,6 +25,20 @@ MIN_TOKEN_LENGTH = 32
 # sink via standard logging config without touching the rest of the
 # server's output.
 audit_logger = logging.getLogger("portainer_mcp.audit")
+
+
+def _audit(outcome: str, level: int, **extra: object) -> None:
+    """Emit one auth audit record. The per-request context is read here so
+    every call site stays a single line; `extra` carries outcome-specific
+    fields (e.g. the validated identity on `ok`) and must never include the
+    token or per-user key.
+    """
+    audit_logger.log(
+        level,
+        json.dumps(
+            {"event": "auth", "outcome": outcome, **request_context.snapshot(), **extra}
+        ),
+    )
 
 
 def require_token(raw: str | None) -> str:
@@ -70,29 +88,77 @@ class StaticBearerVerifier(TokenVerifier):
         super().__init__()
         self._expected = token.encode("utf-8")
 
+    def _matches(self, token: str) -> bool:
+        return hmac.compare_digest(token.encode("utf-8"), self._expected)
+
+    def _access_token(self, token: str) -> AccessToken:
+        # Store the fingerprint, not the raw secret. AccessToken is a Pydantic
+        # model whose default __repr__ dumps all fields, so any downstream log
+        # of request.user.access_token would leak the bearer. client_id carries
+        # identity; this field isn't used for re-verification downstream.
+        return AccessToken(
+            token=fingerprint(token),
+            client_id="portainer-mcp",
+            scopes=[],
+            expires_at=None,
+        )
+
     async def verify_token(self, token: str) -> AccessToken | None:
         # With a single shared secret, fingerprinting the *expected* token
         # would just emit the same constant on every record — useless as a
         # correlator. The request-context fields (client_ip, user_agent,
         # session_id) are what actually distinguish callers here.
-        context = request_context.snapshot()
-        if hmac.compare_digest(token.encode("utf-8"), self._expected):
-            audit_logger.info(json.dumps({"event": "auth", "outcome": "ok", **context}))
-            # Store the fingerprint, not the raw secret. AccessToken is a
-            # Pydantic model whose default __repr__ dumps all fields, so
-            # any downstream log of request.user.access_token would leak
-            # the bearer. client_id carries identity; this field isn't
-            # used for re-verification downstream.
-            return AccessToken(
-                token=fingerprint(token),
-                client_id="portainer-mcp",
-                scopes=[],
-                expires_at=None,
-            )
+        if self._matches(token):
+            _audit("ok", logging.INFO)
+            return self._access_token(token)
         # Mismatch — don't fingerprint the attempted token. The forensic
         # signal worth keeping is "auth failed at time T from <ip/ua>";
         # the attacker's supplied bytes are noise.
-        audit_logger.warning(
-            json.dumps({"event": "auth", "outcome": "mismatch", **context})
-        )
+        _audit("mismatch", logging.WARNING)
         return None
+
+
+class PassthroughVerifier(StaticBearerVerifier):
+    """Gate + per-user validation for the HTTP transport.
+
+    Layer 1: the shared gate bearer in `Authorization` is constant-time
+    compared (parent). Layer 2: the caller's own Portainer key in
+    `X-Portainer-API-Key` is validated against `/users/me` (cached) before the
+    request is admitted. Either failure → 401, with no fallback to a shared
+    upstream key. The gate runs first so credential-less floods die at a cheap
+    local 401 without ever reaching Portainer.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        client: httpx.AsyncClient,
+        cache: passthrough.ValidationCache,
+    ) -> None:
+        super().__init__(token)
+        self._client = client
+        self._cache = cache
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if not self._matches(token):
+            _audit("mismatch", logging.WARNING)
+            return None
+        key = passthrough.key_from_request()
+        if not key:
+            # Gate passed but no per-user key — the request can't act as anyone.
+            _audit("no_user_key", logging.WARNING)
+            return None
+        identity, validated_now = await passthrough.validate(
+            self._client, self._cache, key
+        )
+        if identity is None:
+            _audit("invalid_user_key", logging.WARNING)
+            return None
+        # Audit `ok` marks a *validation* event, not every admitted request:
+        # it fires only when the key was actually checked against Portainer (a
+        # cache miss). Cache hits admit silently — the per-request structured
+        # log still records them with identity. Attribute by the Portainer
+        # identity the key resolves to; the key itself is never logged.
+        if validated_now:
+            _audit("ok", logging.INFO, **identity.audit_fields())
+        return self._access_token(token)

--- a/src/portainer_mcp/passthrough.py
+++ b/src/portainer_mcp/passthrough.py
@@ -1,0 +1,202 @@
+"""Per-user Portainer API-key passthrough for the HTTP transport.
+
+Under HTTP there is no shared upstream key: each client sends its own
+Portainer key in `X-Portainer-API-Key`. The gate bearer in `Authorization`
+admits the request (`auth.PassthroughVerifier`); the per-user key is then
+validated against Portainer's `/users/me` (cached, positive-only) before the
+request is trusted, and injected upstream as `X-API-KEY` by an httpx request
+hook that reads *only* the in-flight request — so one caller can never borrow
+another's key (fails closed if no request is in flight).
+
+The three credentials are deliberately distinct headers so the verified
+credential and the forwarded credential are never the same value: the gate
+token lives in `Authorization` (verified, never forwarded), the per-user key
+in `X-Portainer-API-Key` (validated, then forwarded as upstream `X-API-KEY`).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+import httpx
+from fastmcp.server.dependencies import get_http_request
+
+logger = logging.getLogger("portainer_mcp")
+
+# The client carries its own Portainer key here. Distinct from the gate bearer
+# (`Authorization`) and from the upstream header (`X-API-KEY`).
+USER_KEY_HEADER = "X-Portainer-API-Key"
+UPSTREAM_KEY_HEADER = "X-API-KEY"
+
+TTL_ENV_VAR = "PORTAINER_MCP_AUTH_CACHE_TTL"
+DEFAULT_CACHE_TTL = 60
+
+# CurrentUserInspect: one cheap user read that accepts an API key, returns
+# id/username/role, and skips the heavy per-environment authorization map.
+_VALIDATE_PATH = "/users/me"
+_VALIDATE_PARAMS = {"noEndpointAuthorizations": "true"}
+# Shorter than the shared client's 30s default: this runs inside the per-request
+# auth path, so a slow/down Portainer must not stall every cache-miss for 30s.
+_VALIDATE_TIMEOUT = 10
+
+
+@dataclass(frozen=True)
+class Identity:
+    """The fields `/users/me` returns that are worth attributing in logs.
+
+    Never holds the API key — only the upstream's view of who that key is.
+    """
+
+    user_id: int | None
+    username: str | None
+
+    def audit_fields(self) -> dict[str, object]:
+        out: dict[str, object] = {}
+        if self.user_id is not None:
+            out["portainer_user_id"] = self.user_id
+        if self.username is not None:
+            out["portainer_username"] = self.username
+        return out
+
+
+def resolve_ttl() -> int:
+    raw = os.environ.get(TTL_ENV_VAR)
+    if raw is None:
+        return DEFAULT_CACHE_TTL
+    try:
+        ttl = int(raw)
+    except ValueError:
+        raise SystemExit(
+            f"{TTL_ENV_VAR} must be an integer number of seconds (got {raw!r})"
+        )
+    if ttl < 0:
+        raise SystemExit(f"{TTL_ENV_VAR} must be >= 0 (got {ttl})")
+    return ttl
+
+
+def _digest(key: str) -> str:
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+
+class ValidationCache:
+    """Positive-only TTL cache keyed by the SHA-256 of the API key.
+
+    Caching only *valid* keys is deliberate: a negative cache would lock out a
+    freshly minted key for the TTL window. The TTL is a performance / DoS knob,
+    not the authorization boundary — Portainer still rejects a revoked key on
+    every real upstream call, so a stale entry lets a dead key pass the MCP
+    front door for at most one window but never *act*. The raw key is never
+    stored, not even as a dict key. `ttl == 0` disables caching (validate every
+    request).
+    """
+
+    def __init__(self, ttl: int) -> None:
+        self._ttl = ttl
+        self._entries: dict[str, tuple[float, Identity]] = {}
+
+    def get(self, key: str) -> Identity | None:
+        if self._ttl == 0:
+            return None
+        entry = self._entries.get(_digest(key))
+        if entry is None:
+            return None
+        expiry, identity = entry
+        if time.monotonic() >= expiry:
+            self._entries.pop(_digest(key), None)
+            return None
+        return identity
+
+    def put(self, key: str, identity: Identity) -> None:
+        if self._ttl == 0:
+            return
+        self._entries[_digest(key)] = (time.monotonic() + self._ttl, identity)
+
+
+def _parse_identity(response: httpx.Response) -> Identity:
+    try:
+        data = response.json()
+    except ValueError:
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+    return Identity(user_id=data.get("Id"), username=data.get("Username"))
+
+
+async def validate(
+    client: httpx.AsyncClient, cache: ValidationCache, key: str
+) -> tuple[Identity | None, bool]:
+    """Validate `key`, returning `(identity, validated_now)`.
+
+    `validated_now` is True when this call made the upstream `/users/me`
+    request (a cache miss), and False when the result was served from cache.
+    Callers use it to log a validation as an event without emitting one on
+    every cache hit. A cache hit returns immediately; a miss round-trips
+    `/users/me` once and caches a positive result. Any non-200 (or an
+    unreachable Portainer) is a failed validation returning `(None, True)` —
+    the cache is left untouched so a transient error or a just-created key
+    isn't pinned as invalid.
+    """
+    cached = cache.get(key)
+    if cached is not None:
+        return cached, False
+    try:
+        response = await client.get(
+            _VALIDATE_PATH,
+            params=_VALIDATE_PARAMS,
+            headers={UPSTREAM_KEY_HEADER: key},
+            timeout=_VALIDATE_TIMEOUT,
+        )
+    except httpx.HTTPError as exc:
+        logger.warning("per-user key validation could not reach Portainer: %s", exc)
+        return None, True
+    if response.status_code != 200:
+        return None, True
+    identity = _parse_identity(response)
+    cache.put(key, identity)
+    return identity, True
+
+
+def key_from_request() -> str | None:
+    """The per-user key from the in-flight HTTP request, or None outside one."""
+    try:
+        request = get_http_request()
+    except RuntimeError:
+        return None
+    return request.headers.get(USER_KEY_HEADER)
+
+
+def identity_audit_fields(cache: ValidationCache | None) -> dict[str, object]:
+    """Best-effort identity for the in-flight request, read from `cache` only.
+
+    Never probes Portainer and never returns the key — purely for enriching
+    the structured request log with whoever the verifier already validated.
+    """
+    if cache is None:
+        return {}
+    key = key_from_request()
+    if not key:
+        return {}
+    identity = cache.get(key)
+    return identity.audit_fields() if identity is not None else {}
+
+
+async def inject_api_key(request: httpx.Request) -> None:
+    """httpx request hook: forward the caller's key upstream as `X-API-KEY`.
+
+    Reads only the in-flight MCP request, so a request can never inject another
+    request's key (RA-7). The validation probe sets `X-API-KEY` explicitly and
+    is left untouched. Missing key / no request context → raise: never send an
+    upstream call without the caller's credential.
+    """
+    if request.headers.get(UPSTREAM_KEY_HEADER):
+        return
+    key = key_from_request()
+    if not key:
+        raise RuntimeError(
+            "no per-user Portainer API key in the current request context"
+        )
+    request.headers[UPSTREAM_KEY_HEADER] = key

--- a/src/portainer_mcp/server.py
+++ b/src/portainer_mcp/server.py
@@ -1,6 +1,8 @@
 """Portainer MCP server, bootstrapped from the Portainer OpenAPI spec via FastMCP.
 
-Requires PORTAINER_URL and PORTAINER_API_KEY. Tunables:
+Requires PORTAINER_URL. Stdio also requires PORTAINER_API_KEY (the single
+upstream credential); HTTP forwards each client's own key per request instead
+and refuses to boot if PORTAINER_API_KEY is set. Tunables:
 
 - PORTAINER_PROFILES (default: BASE,DOCKER,KUBERNETES) — named tag bundles.
 - PORTAINER_TAGS_EXTRA — comma-separated tags to append, escape hatch for
@@ -16,8 +18,12 @@ Requires PORTAINER_URL and PORTAINER_API_KEY. Tunables:
   for the dev workflow and the eventual remote container.
 - PORTAINER_MCP_HTTP_HOST — bind host when transport=http (default 127.0.0.1).
 - PORTAINER_MCP_HTTP_PORT — bind port when transport=http (default 17717).
-- PORTAINER_MCP_AUTH_TOKEN — shared bearer secret. Required when
-  transport=http; ignored for stdio.
+- PORTAINER_MCP_AUTH_TOKEN — shared bearer gate secret. Required when
+  transport=http; ignored for stdio. Over HTTP it admits the request; the
+  caller's own Portainer key (X-Portainer-API-Key header) is then validated
+  and forwarded upstream as X-API-KEY.
+- PORTAINER_MCP_AUTH_CACHE_TTL — seconds to cache a validated per-user key
+  (default 60, positive results only, 0 disables). HTTP only.
 - PORTAINER_MCP_ALLOWED_HOSTS — comma-separated `Host` allowlist for
   DNS-rebinding protection. Defaults to the localhost set
   (127.0.0.1, localhost, [::1]); operator must extend for non-local
@@ -47,6 +53,7 @@ from starlette.middleware import Middleware
 from portainer_mcp import (
     auth,
     http_security,
+    passthrough,
     profiles,
     proxy,
     redaction,
@@ -149,23 +156,40 @@ class _ContextualStructuredLogging(StructuredLoggingMiddleware):
     """Add per-request context (client_ip, user_agent, session_id) to every
     record. `source: "client"` from the upstream middleware just means the
     request came over the transport — useless for distinguishing callers
-    when one bearer is shared across many MCP clients.
+    when one gate bearer is shared across many MCP clients. Under HTTP
+    passthrough, also attribute the validated Portainer identity (read from
+    the validation cache; never the key itself).
     """
 
-    def _create_before_message(self, context):
-        message = super()._create_before_message(context)
+    def __init__(self, *, cache: passthrough.ValidationCache | None = None, **kwargs):
+        super().__init__(**kwargs)
+        self._cache = cache
+
+    def _enrich(self, message: dict, context) -> dict:
+        # `source` is a Literal["client","server"] the base middleware stamps,
+        # but every request-path context hard-codes "client" (server-initiated
+        # messages don't flow through here) — a constant, so drop the noise.
+        message.pop("source", None)
         message.update(request_context.snapshot())
+        message.update(passthrough.identity_audit_fields(self._cache))
+        # `method` is just "tools/call"; surface the actual tool name from the
+        # call params so a request can be read without joining to the payload.
+        if context.method == "tools/call":
+            name = getattr(context.message, "name", None)
+            if name:
+                message["tool"] = name
         return message
+
+    def _create_before_message(self, context):
+        return self._enrich(super()._create_before_message(context), context)
 
     def _create_after_message(self, context, start_time):
-        message = super()._create_after_message(context, start_time)
-        message.update(request_context.snapshot())
-        return message
+        return self._enrich(super()._create_after_message(context, start_time), context)
 
     def _create_error_message(self, context, start_time, error):
-        message = super()._create_error_message(context, start_time, error)
-        message.update(request_context.snapshot())
-        return message
+        return self._enrich(
+            super()._create_error_message(context, start_time, error), context
+        )
 
 
 def _setup_logging() -> None:
@@ -208,20 +232,44 @@ def build_server() -> FastMCP:
     _setup_logging()
 
     transport = _resolve_transport()
-    auth_provider = None
-    if transport == "http":
-        token = auth.require_token(os.environ.get(auth.ENV_VAR))
-        auth_provider = auth.StaticBearerVerifier(token)
-        logger.info("HTTP auth: enabled (token %s)", auth.fingerprint(token))
-
     base = os.environ["PORTAINER_URL"].rstrip("/") + "/api"
     verify = _env_flag("PORTAINER_TLS_VERIFY", default=True)
-    client = httpx.AsyncClient(
-        base_url=base,
-        headers={"X-API-KEY": os.environ["PORTAINER_API_KEY"]},
-        verify=verify,
-        timeout=30,
-    )
+
+    auth_provider = None
+    cache: passthrough.ValidationCache | None = None
+    if transport == "http":
+        if os.environ.get("PORTAINER_API_KEY"):
+            # HTTP is per-user passthrough: each client forwards its own key.
+            # A shared PORTAINER_API_KEY here is a misconfiguration, not a
+            # fallback — fail loudly rather than silently ignore it.
+            raise SystemExit(
+                "PORTAINER_API_KEY is only valid with PORTAINER_MCP_TRANSPORT=stdio; "
+                "the HTTP transport forwards each client's own key from the "
+                "X-Portainer-API-Key header — remove PORTAINER_API_KEY"
+            )
+        token = auth.require_token(os.environ.get(auth.ENV_VAR))
+        ttl = passthrough.resolve_ttl()
+        cache = passthrough.ValidationCache(ttl)
+        # No baked X-API-KEY: the per-request hook injects the caller's own key.
+        client = httpx.AsyncClient(
+            base_url=base,
+            verify=verify,
+            timeout=30,
+            event_hooks={"request": [passthrough.inject_api_key]},
+        )
+        auth_provider = auth.PassthroughVerifier(token, client, cache)
+        logger.info(
+            "HTTP auth: per-user passthrough (gate %s, validation cache ttl=%ds)",
+            auth.fingerprint(token),
+            ttl,
+        )
+    else:
+        client = httpx.AsyncClient(
+            base_url=base,
+            headers={passthrough.UPSTREAM_KEY_HEADER: os.environ["PORTAINER_API_KEY"]},
+            verify=verify,
+            timeout=30,
+        )
     with SPEC_PATH.open() as f:
         spec = yaml.safe_load(f)
 
@@ -272,7 +320,9 @@ def build_server() -> FastMCP:
         )
     logger.info("`select` arg present on all %d tools", len(tools))
 
-    mcp.add_middleware(_ContextualStructuredLogging(include_payload_length=True))
+    mcp.add_middleware(
+        _ContextualStructuredLogging(include_payload_length=True, cache=cache)
+    )
     logger.info("structured request logging: enabled")
 
     max_chars = int(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 import json
 import logging
 
+import httpx
 import pytest
+from fastmcp.server.http import set_http_request
+from starlette.requests import Request
 
-from portainer_mcp import auth
+from portainer_mcp import auth, passthrough
 
 
 # --- require_token -----------------------------------------------------------
@@ -186,6 +189,130 @@ async def test_verifier_audit_never_logs_token_bytes(caplog):
         await verifier.verify_token(expected)
         await verifier.verify_token(attempted)
     allowed_keys = {"event", "outcome", "client_ip", "user_agent", "session_id"}
+    for record in caplog.records:
+        payload = json.loads(record.message)
+        assert set(payload).issubset(allowed_keys), (
+            f"unexpected keys in audit payload: {set(payload) - allowed_keys}"
+        )
+
+
+# --- PassthroughVerifier -----------------------------------------------------
+
+GATE = "g" * 64
+ALICE = {"Id": 7, "Username": "alice", "Role": 1}
+
+
+def _request(headers: dict[str, str] | None = None) -> Request:
+    raw = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp",
+            "raw_path": b"/mcp",
+            "query_string": b"",
+            "client": ("203.0.113.7", 51234),
+            "headers": raw,
+        }
+    )
+
+
+def _verifier(handler=None) -> auth.PassthroughVerifier:
+    if handler is None:
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=ALICE)
+
+    client = httpx.AsyncClient(
+        base_url="http://portainer/api", transport=httpx.MockTransport(handler)
+    )
+    return auth.PassthroughVerifier(GATE, client, passthrough.ValidationCache(ttl=60))
+
+
+async def test_passthrough_rejects_gate_mismatch():
+    verifier = _verifier()
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_alice"})):
+        assert await verifier.verify_token("b" * 64) is None
+
+
+async def test_passthrough_rejects_missing_user_key(caplog):
+    verifier = _verifier()
+    with set_http_request(_request({})):  # gate ok, but no per-user key
+        with caplog.at_level(logging.WARNING, logger="portainer_mcp.audit"):
+            assert await verifier.verify_token(GATE) is None
+    outcomes = [json.loads(r.message)["outcome"] for r in caplog.records]
+    assert outcomes == ["no_user_key"]
+
+
+async def test_passthrough_rejects_invalid_user_key(caplog):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"message": "invalid token"})
+
+    verifier = _verifier(handler)
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_bad"})):
+        with caplog.at_level(logging.WARNING, logger="portainer_mcp.audit"):
+            assert await verifier.verify_token(GATE) is None
+    outcomes = [json.loads(r.message)["outcome"] for r in caplog.records]
+    assert outcomes == ["invalid_user_key"]
+
+
+async def test_passthrough_accepts_and_attributes_identity(caplog):
+    verifier = _verifier()
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_alice"})):
+        with caplog.at_level(logging.INFO, logger="portainer_mcp.audit"):
+            access = await verifier.verify_token(GATE)
+    assert access is not None
+    assert access.client_id == "portainer-mcp"
+    assert access.token == auth.fingerprint(GATE)
+    payload = json.loads(caplog.records[0].message)
+    assert payload["outcome"] == "ok"
+    assert payload["portainer_user_id"] == 7
+    assert payload["portainer_username"] == "alice"
+    assert payload["client_ip"] == "203.0.113.7"
+
+
+async def test_passthrough_ok_fires_only_on_validation_not_cache_hits(caplog):
+    # The audit `ok` marks a validation event (cache miss → upstream call), not
+    # every admitted request. The first request validates and logs; subsequent
+    # cache hits admit silently.
+    handler_calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        handler_calls["n"] += 1
+        return httpx.Response(200, json=ALICE)
+
+    verifier = _verifier(handler)
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_alice"})):
+        with caplog.at_level(logging.INFO, logger="portainer_mcp.audit"):
+            assert await verifier.verify_token(GATE) is not None  # miss → ok
+            assert await verifier.verify_token(GATE) is not None  # hit → silent
+            assert await verifier.verify_token(GATE) is not None  # hit → silent
+    oks = [r for r in caplog.records if r.name == "portainer_mcp.audit"]
+    assert len(oks) == 1
+    assert json.loads(oks[0].message)["outcome"] == "ok"
+    assert handler_calls["n"] == 1  # only the cache miss hit Portainer
+
+
+async def test_passthrough_never_logs_the_user_key(caplog):
+    # The forwarded credential must never reach any audit record — only the
+    # identity it resolves to.
+    secret = "ptr_super_secret_value_that_must_not_leak"
+    verifier = _verifier()
+    with set_http_request(_request({"X-Portainer-API-Key": secret})):
+        with caplog.at_level(logging.INFO, logger="portainer_mcp.audit"):
+            await verifier.verify_token(GATE)  # ok
+            await verifier.verify_token("b" * 64)  # gate mismatch
+    for record in caplog.records:
+        assert secret not in record.message
+    allowed_keys = {
+        "event",
+        "outcome",
+        "client_ip",
+        "user_agent",
+        "session_id",
+        "portainer_user_id",
+        "portainer_username",
+    }
     for record in caplog.records:
         payload = json.loads(record.message)
         assert set(payload).issubset(allowed_keys), (

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -1,0 +1,242 @@
+"""Unit tests for `src/portainer_mcp/passthrough.py`.
+
+Covers the validation cache (positive-only, TTL), the `/users/me` probe, the
+per-request key reader, and the upstream-injection hook's fail-closed
+isolation. The live FastMCP integration (verifier → tool → upstream) needs a
+running server and is not exercised here.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastmcp.server.http import set_http_request
+from starlette.requests import Request
+
+from portainer_mcp import passthrough
+from portainer_mcp.passthrough import (
+    Identity,
+    ValidationCache,
+    identity_audit_fields,
+    inject_api_key,
+    key_from_request,
+    resolve_ttl,
+    validate,
+)
+
+ALICE = {"Id": 7, "Username": "alice", "Role": 1}
+
+
+def _request(headers: dict[str, str] | None = None) -> Request:
+    raw = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp",
+            "raw_path": b"/mcp",
+            "query_string": b"",
+            "client": ("203.0.113.7", 51234),
+            "headers": raw,
+        }
+    )
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        base_url="http://portainer/api", transport=httpx.MockTransport(handler)
+    )
+
+
+# --- resolve_ttl ------------------------------------------------------------
+
+
+def test_resolve_ttl_default(monkeypatch):
+    monkeypatch.delenv(passthrough.TTL_ENV_VAR, raising=False)
+    assert resolve_ttl() == passthrough.DEFAULT_CACHE_TTL
+
+
+def test_resolve_ttl_reads_env(monkeypatch):
+    monkeypatch.setenv(passthrough.TTL_ENV_VAR, "120")
+    assert resolve_ttl() == 120
+
+
+def test_resolve_ttl_zero_allowed(monkeypatch):
+    monkeypatch.setenv(passthrough.TTL_ENV_VAR, "0")
+    assert resolve_ttl() == 0
+
+
+@pytest.mark.parametrize("bad", ["-1", "abc", "1.5"])
+def test_resolve_ttl_rejects_invalid(monkeypatch, bad):
+    monkeypatch.setenv(passthrough.TTL_ENV_VAR, bad)
+    with pytest.raises(SystemExit):
+        resolve_ttl()
+
+
+# --- ValidationCache --------------------------------------------------------
+
+
+def test_cache_roundtrip():
+    cache = ValidationCache(ttl=60)
+    identity = Identity(user_id=7, username="alice")
+    assert cache.get("ptr_key") is None
+    cache.put("ptr_key", identity)
+    assert cache.get("ptr_key") == identity
+
+
+def test_cache_ttl_zero_disables(monkeypatch):
+    cache = ValidationCache(ttl=0)
+    cache.put("ptr_key", Identity(7, "alice"))
+    assert cache.get("ptr_key") is None
+
+
+def test_cache_expires(monkeypatch):
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(passthrough.time, "monotonic", lambda: clock["t"])
+    cache = ValidationCache(ttl=60)
+    cache.put("ptr_key", Identity(7, "alice"))
+    clock["t"] += 59
+    assert cache.get("ptr_key") is not None
+    clock["t"] += 2  # now 61s elapsed
+    assert cache.get("ptr_key") is None
+
+
+def test_cache_does_not_store_raw_key():
+    # The raw key must never appear in the cache's internal state, not even
+    # as a dict key — only its digest.
+    cache = ValidationCache(ttl=60)
+    cache.put("ptr_super_secret", Identity(7, "alice"))
+    assert "ptr_super_secret" not in cache._entries
+    assert all("ptr_super_secret" not in k for k in cache._entries)
+
+
+# --- validate ---------------------------------------------------------------
+
+
+async def test_validate_success_caches():
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        assert request.headers["X-API-KEY"] == "ptr_alice"
+        assert request.url.path == "/api/users/me"
+        assert request.url.params["noEndpointAuthorizations"] == "true"
+        return httpx.Response(200, json=ALICE)
+
+    cache = ValidationCache(ttl=60)
+    client = _client(handler)
+    identity, validated_now = await validate(client, cache, "ptr_alice")
+    assert identity == Identity(user_id=7, username="alice")
+    assert validated_now is True  # cache miss → upstream call made
+    # Second call is served from cache — no second upstream hit, and it reports
+    # that it did not re-validate.
+    again, validated_now = await validate(client, cache, "ptr_alice")
+    assert again == identity
+    assert validated_now is False
+    assert calls["n"] == 1
+
+
+async def test_validate_rejects_non_200_and_does_not_cache():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"message": "invalid token"})
+
+    cache = ValidationCache(ttl=60)
+    assert await validate(_client(handler), cache, "ptr_bad") == (None, True)
+    assert cache.get("ptr_bad") is None  # negatives are never cached
+
+
+async def test_validate_handles_unreachable_portainer():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    cache = ValidationCache(ttl=60)
+    assert await validate(_client(handler), cache, "ptr_alice") == (None, True)
+
+
+# --- key_from_request -------------------------------------------------------
+
+
+def test_key_from_request_reads_header():
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_alice"})):
+        assert key_from_request() == "ptr_alice"
+
+
+def test_key_from_request_none_without_header():
+    with set_http_request(_request({})):
+        assert key_from_request() is None
+
+
+def test_key_from_request_none_outside_request():
+    assert key_from_request() is None
+
+
+# --- identity_audit_fields --------------------------------------------------
+
+
+def test_identity_audit_fields_from_cache():
+    cache = ValidationCache(ttl=60)
+    cache.put("ptr_alice", Identity(user_id=7, username="alice"))
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_alice"})):
+        assert identity_audit_fields(cache) == {
+            "portainer_user_id": 7,
+            "portainer_username": "alice",
+        }
+
+
+def test_identity_audit_fields_empty_when_uncached():
+    cache = ValidationCache(ttl=60)
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_alice"})):
+        assert identity_audit_fields(cache) == {}
+
+
+def test_identity_audit_fields_empty_without_cache():
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_alice"})):
+        assert identity_audit_fields(None) == {}
+
+
+# --- inject_api_key (the upstream hook) -------------------------------------
+
+
+async def test_inject_sets_upstream_key_from_request():
+    request = httpx.Request("GET", "http://portainer/api/endpoints")
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_alice"})):
+        await inject_api_key(request)
+    assert request.headers["X-API-KEY"] == "ptr_alice"
+
+
+async def test_inject_leaves_existing_upstream_key():
+    # The validation probe sets X-API-KEY explicitly; the hook must not clobber
+    # it with the inbound header (they're the same key, but the probe owns it).
+    request = httpx.Request(
+        "GET", "http://portainer/api/users/me", headers={"X-API-KEY": "ptr_probe"}
+    )
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_other"})):
+        await inject_api_key(request)
+    assert request.headers["X-API-KEY"] == "ptr_probe"
+
+
+async def test_inject_fails_closed_without_request_context():
+    # No in-flight request → never send a keyless upstream call.
+    request = httpx.Request("GET", "http://portainer/api/endpoints")
+    with pytest.raises(RuntimeError, match="no per-user Portainer API key"):
+        await inject_api_key(request)
+
+
+async def test_inject_fails_closed_without_header():
+    request = httpx.Request("GET", "http://portainer/api/endpoints")
+    with set_http_request(_request({})):
+        with pytest.raises(RuntimeError, match="no per-user Portainer API key"):
+            await inject_api_key(request)
+
+
+async def test_inject_isolation_one_request_cannot_borrow_another():
+    # Two concurrent-style requests with different keys: each injection sees
+    # only its own in-flight request's header, never the other's.
+    req_a = httpx.Request("GET", "http://portainer/api/endpoints")
+    req_b = httpx.Request("GET", "http://portainer/api/endpoints")
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_alice"})):
+        await inject_api_key(req_a)
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_bob"})):
+        await inject_api_key(req_b)
+    assert req_a.headers["X-API-KEY"] == "ptr_alice"
+    assert req_b.headers["X-API-KEY"] == "ptr_bob"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,48 @@
+"""Unit tests for the wiring bits in `src/portainer_mcp/server.py` that are
+cheap to exercise without booting a full FastMCP server.
+
+The `tool`-name extraction is unit-tested against the real
+`CallToolRequestParams` shape; the live middleware dispatch (which feeds that
+context) is covered by FastMCP itself.
+"""
+
+from __future__ import annotations
+
+from mcp.types import CallToolRequestParams, InitializeRequestParams
+
+from portainer_mcp.server import _ContextualStructuredLogging
+
+
+class _Ctx:
+    def __init__(self, method, message):
+        self.method = method
+        self.message = message
+
+
+def _mw() -> _ContextualStructuredLogging:
+    # cache=None → identity enrichment is a no-op (the path stdio takes).
+    return _ContextualStructuredLogging(include_payload_length=True, cache=None)
+
+
+def test_enrich_adds_tool_name_for_tools_call():
+    ctx = _Ctx("tools/call", CallToolRequestParams(name="docker_proxy", arguments={}))
+    assert _mw()._enrich({}, ctx)["tool"] == "docker_proxy"
+
+
+def test_enrich_omits_tool_for_non_tools_call():
+    ctx = _Ctx(
+        "initialize",
+        InitializeRequestParams(
+            protocolVersion="2025-03-26",
+            capabilities={},
+            clientInfo={"name": "x", "version": "1"},
+        ),
+    )
+    assert "tool" not in _mw()._enrich({}, ctx)
+
+
+def test_enrich_drops_constant_source_field():
+    ctx = _Ctx("tools/call", CallToolRequestParams(name="EndpointList", arguments={}))
+    # The base middleware stamps source="client" on every record; it's a
+    # constant in our request path, so the enriched record omits it.
+    assert "source" not in _mw()._enrich({"source": "client"}, ctx)


### PR DESCRIPTION
Over HTTP the server no longer carries a single shared upstream identity. Selecting transport=http is selecting per-user passthrough (no mode flag): a shared bearer gate (PORTAINER_MCP_AUTH_TOKEN, Authorization header) admits the request, then each client's own Portainer key (X-Portainer-API-Key header) is validated against GET /users/me and injected upstream as X-API-KEY by a per-request httpx hook. stdio keeps its single baked PORTAINER_API_KEY, which is now a hard-fail misconfiguration under HTTP.

- passthrough.py: positive-only TTL ValidationCache (SHA-256 keyed, never the raw key; PORTAINER_MCP_AUTH_CACHE_TTL, default 60), validate() against /users/me (10s probe timeout), and inject_api_key — an httpx request hook that reads only the in-flight request (per-request isolation) and fails closed rather than ever sending a keyless upstream call.
- auth.py: PassthroughVerifier (gate compare, then per-user validation); shared _audit() helper. Audit `ok` fires only on a validation (cache miss) and is attributed with portainer_user_id/username; the per-user key is never logged. New outcomes: no_user_key, invalid_user_key.
- server.py: keyless HTTP client + hook + verifier; structured request log enriched with the validated identity and the tool name, drops the constant `source` field.

Breaking change: existing shared-key HTTP deployments must migrate — every HTTP user now supplies their own Portainer key. TLS enforcement lands separately.

Related to #65 