### PR TITLE
Enforce a TLS posture on non-loopback HTTP binds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,15 @@ PORTAINER_MCP_AUTH_TOKEN=
 # PORTAINER_PROFILES=ALL
 # PORTAINER_MCP_LOG_LEVEL=DEBUG
 # PORTAINER_MCP_LOG_FORMAT=json
+
+# TLS posture (HTTP only). `make dev` binds 127.0.0.1, which is exempt — these
+# matter on a non-loopback bind, where the server refuses to boot unless one
+# posture is declared. Pick one:
+#   1. server-terminated TLS (uvicorn serves HTTPS; warns if cert is self-signed)
+# PORTAINER_MCP_TLS_CERT=/tls/cert.pem
+# PORTAINER_MCP_TLS_KEY=/tls/key.pem
+#   2. TLS-terminating proxy (trust its X-Forwarded-Proto from these IPs/subnets)
+# PORTAINER_MCP_TRUST_PROXY_TLS=1
+# PORTAINER_MCP_FORWARDED_ALLOW_IPS=10.0.0.0/8
+#   3. DANGER: serve plaintext (unencrypted) — trusted private networks only
+# PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,28 @@ Key things to internalise before changing code:
   localhost defaults, and the MCP spec MUSTs the check itself, not the
   configurability. Don't re-add an `ALLOWED_ORIGINS` env var unless a
   real browser-hosted client use case shows up.
+- **TLS posture hard-fails on a non-loopback bind.** `tls.resolve_posture()`
+  in `main()` refuses to boot unless the operator declares one of three
+  shapes — server-terminated cert (`PORTAINER_MCP_TLS_CERT`/`_TLS_KEY` →
+  uvicorn `ssl_certfile`/`ssl_keyfile`), proxy attestation
+  (`PORTAINER_MCP_TRUST_PROXY_TLS=1` + `..._FORWARDED_ALLOW_IPS` →
+  `forwarded_allow_ips`), or the one loud plaintext opt-out
+  (`PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1`). Loopback binds are
+  exempt (dev). Both encrypted shapes converge on `scope["scheme"] ==
+  "https"`, enforced by `TLSRequiredMiddleware` as a backstop. Critically,
+  that middleware is installed via `PassthroughVerifier.get_middleware()`
+  (`add_pre_auth_middleware`), **not** the `server.run(middleware=[…])` list
+  — the list runs after the auth backend, but the TLS check must run *before*
+  it so a plaintext request is rejected before the per-user key is validated
+  and forwarded upstream (amplification). The loopback exemption is keyed on
+  the bind host at install time, never the per-request client IP. The
+  plaintext opt-out also flips `auth.mark_insecure_transport()`, so every
+  audit record carries `insecure_transport: true`. Self-signed certs WARN,
+  never block — the server only holds the leaf and can't judge true trust, so
+  a hard-fail would be inconsistent (it'd miss internal-CA certs) and would
+  break the legitimate mount-your-own-cert homelab path. No auto-self-signed
+  mode: real MCP clients reject self-signed certs and don't pin by
+  fingerprint.
 - **Log shape is selectable.** `PORTAINER_MCP_LOG_FORMAT=text|json`
   (default `text`, container image overrides to `json`). The `json`
   formatter merges records whose `msg` is itself a JSON object into the

--- a/README.md
+++ b/README.md
@@ -24,18 +24,17 @@ The recommended way to test the MCP server locally. Runs as a stdio process on y
 > [!NOTE]
 > `uv` must be installed and available on `PATH`.
 > See [the uv install docs](https://docs.astral.sh/uv/getting-started/installation/).
+>
+> Set `PORTAINER_TLS_VERIFY=0` if your Portainer instance uses self-signed TLS certificates.
 
 Register with Claude Code:
 
-```bash
+````bash
 claude mcp add portainer \
   -e PORTAINER_URL=https://portainer.example.com \
   -e PORTAINER_API_KEY=ptr_xxxxxxxxxxxxxxxx \
   -- uvx --from "mcp-portainer~=2.42.0" mcp-portainer
-```
-
-> [!NOTE]
-> Set `PORTAINER_TLS_VERIFY=0` if your Portainer instance uses self-signed TLS certificates.
+````
 
 For other clients, see
 [`docs/distribution/`](https://github.com/portainer/portainer-mcp/tree/main/docs/distribution).
@@ -43,46 +42,111 @@ Contributions for other client instructions are welcome!
 
 ### Team deployment (container)
 
-The recommended way to have multiple users interacting with your Portainer instance via MCP. Deployed as a [`container`](https://hub.docker.com/r/portainer/portainer-mcp) inside your infrastructure, accessed by users from their workstations over HTTP. A shared secret gates the MCP server and every client also forwards its own Portainer API key so that each user acts under their own Portainer identity.
+The recommended way to have multiple users interacting with your Portainer instance via MCP. Deployed as a [`container`](https://hub.docker.com/r/portainer/portainer-mcp) inside your infrastructure, accessed by users from their workstations over HTTPS. A shared secret gates the MCP server and every client also forwards its own Portainer API key so that each user acts under their own Portainer identity.
 
 > [!IMPORTANT]
-> The container terminates HTTP, **NOT HTTPS**. Both the gate secret and each user's Portainer API key can be intercepted on any path between client and server without TLS termination.
+> Both the gate secret and each user Portainer API key are sent across the wire. The container deployment requires you to declare a transport posture: bring your own TLS certificates, attest a TLS-terminating reverse proxy setup or explicitly opt-in to plaintext. 
 > 
-> It is **NOT** recommended to expose this MCP server on the public internet.
+> Plaintext is a deliberate, dangerous choice — see the three options below.
 > 
-> Even with a TLS-terminating reverse proxy in front, the recommendation is to host this MCP server inside your private infrastructure.
+> It is **NOT** recommended to expose this MCP server on the public internet, host it inside your private infrastructure even behind a TLS proxy.
 
-Run the MCP server as a container in your infrastructure:
+See more info below about the different deployment scenarios. For any of these scenarios:
+* Set `PORTAINER_MCP_ALLOWED_HOSTS` to the hostname or IP address that users will use to reach the MCP — otherwise the DNS-rebinding allowlist 421-rejects the request.
+* `PORTAINER_MCP_AUTH_TOKEN` is **required** in HTTP mode. It's the shared front-gate secret you distribute to your users; their MCP client sends it via the `Authorization` header. It only admits the request — what each user can *do* is governed by their own Portainer API key.
 
-```bash
+
+#### Option A - BYO certificates
+
+> [!NOTE]
+> The server will warn if using self-signed certificates. Using a private CA cert won't warn, but in both cases you will likely need to jump through some hoops to configure the MCP clients to accept it.
+
+Deploy the container to use your own set of TLS certificates:
+
+````bash
 TOKEN=$(openssl rand -hex 32)
 docker run -d --name portainer-mcp -p 17717:17717 \
-  -e PORTAINER_URL=https://portainer.example.com \
-  -e PORTAINER_MCP_AUTH_TOKEN="$TOKEN" \
-  -e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com:17717 \
-  portainer/portainer-mcp:2.42
-```
+	-v /etc/portainer-mcp/tls:/tls:ro \
+	-e PORTAINER_URL=https://portainer.example.com \
+	-e PORTAINER_MCP_AUTH_TOKEN="$TOKEN" \
+	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com:17717 \
+	-e PORTAINER_MCP_TLS_CERT=/tls/cert.pem \
+	-e PORTAINER_MCP_TLS_KEY=/tls/key.pem \
+	portainer/portainer-mcp:2.42
+````
 
-Set `PORTAINER_MCP_ALLOWED_HOSTS` to the hostname or IP address that users will use to reach the MCP — otherwise the DNS-rebinding allowlist 421-rejects the request.
+Then connect your client:
 
-`PORTAINER_MCP_AUTH_TOKEN` is **required** in HTTP mode. It's the shared front-gate secret you distribute to your users; their MCP client sends it via the `Authorization` header. It only admits the request — what each user can *do* is governed by their own Portainer API key.
+````bash
+claude mcp add portainer --transport http https://mcp.example.com:17717/mcp \
+  --header "Authorization: Bearer <gate-token>" \
+  --header "X-Portainer-API-Key: <ptr_user_key>"
+````
 
-Adding the MCP endpoint on Claude Code:
-```bash
+#### Option B - TLS-terminated reverse proxy
+
+> [!NOTE]
+> Don't publish the container port when using a reverse proxy in front of the MCP container, only the proxy should be able to reach it.
+>
+> Use your proxy exact IP if stable for `PORTAINER_MCP_FORWARDED_ALLOW_IPS`.
+>
+> Make sure that your proxy forwards the original `Host` and the `X-Forwarded-Proto: https` headers.
+
+BYO proxy and set up a TLS-terminated proxy in front of the container:
+
+````bash
+TOKEN=$(openssl rand -hex 32)
+docker run -d --name portainer-mcp \
+	-e PORTAINER_URL=https://portainer.example.com \
+	-e PORTAINER_MCP_AUTH_TOKEN="$TOKEN" \
+	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com \
+	-e PORTAINER_MCP_TRUST_PROXY_TLS=1 \
+	-e PORTAINER_MCP_FORWARDED_ALLOW_IPS=172.18.0.0/16 \
+	portainer/portainer-mcp:2.42
+````
+
+Then connect your client:
+
+````bash
+claude mcp add portainer --transport http https://mcp.example.com/mcp \
+  --header "Authorization: Bearer <gate-token>" \
+  --header "X-Portainer-API-Key: <ptr_user_key>"
+````
+
+#### Option C - Plaintext HTTP
+
+> [!WARNING]
+> It is **NOT** recommended to use this outside of a trusted private network deployment.
+
+Use the `PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1` flag to start the server with HTTP only.
+
+````bash
+TOKEN=$(openssl rand -hex 32)
+docker run -d --name portainer-mcp -p 17717:17717 \
+	-e PORTAINER_URL=https://portainer.example.com \
+	-e PORTAINER_MCP_AUTH_TOKEN="$TOKEN" \
+	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com:17717 \
+	-e PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1 \
+	portainer/portainer-mcp:2.42
+````
+
+Then connect your client:
+
+````bash
 claude mcp add portainer --transport http http://mcp.example.com:17717/mcp \
   --header "Authorization: Bearer <gate-token>" \
   --header "X-Portainer-API-Key: <ptr_user_key>"
-```
+````
 
 ### Hygiene skill (recommended)
 
 This repo ships a Claude Code skill ([`portainer-mcp-hygiene`](https://github.com/portainer/portainer-mcp/blob/main/skills/portainer-mcp-hygiene/SKILL.md)) that helps the model query the MCP efficiently and keep responses within context. Install user-wide, pinned to the same tag as the server:
 
-```bash
+````bash
 mkdir -p ~/.claude/skills/portainer-mcp-hygiene && \
   curl -fsSL https://raw.githubusercontent.com/portainer/portainer-mcp/2.42.0/skills/portainer-mcp-hygiene/SKILL.md \
   -o ~/.claude/skills/portainer-mcp-hygiene/SKILL.md
-```
+````
 
 It is recommended to re-run on each server upgrade so the skill stays in sync.
 
@@ -115,5 +179,7 @@ The MCP server exposes different capabilities such as:
 * Widen the API coverage by specifying extra tags to cover
 * Expose only read-only capabilities
 * Disable proxy capabilities
+* Tuning the transport capabilities and configuring the TLS posture
+* Logging configuration
 
 For more information about the MCP server configuration, refer to [`docs/configuration.md`](https://github.com/portainer/portainer-mcp/blob/main/docs/configuration.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,6 +140,44 @@ error. The 421 response body is also rewritten to name
 `PORTAINER_MCP_ALLOWED_HOSTS` so the operator sees the same pointer from
 the client side.
 
+### TLS posture — `tls.py`
+
+Only relevant under HTTP. The server carries two secrets on the wire (the
+gate token and each caller's permanent Portainer key), so plaintext is
+never served on a non-loopback bind by accident. `resolve_posture(host)`
+runs at startup and **refuses to boot** unless one posture is declared,
+loud-failing (like the auth-token check) on any broken declaration — it
+never silently downgrades. Operators pick one of three shapes, all
+collapsing to a single runtime signal, `scheme == "https"`:
+
+1. **Server-terminated TLS** — `PORTAINER_MCP_TLS_CERT`/`_TLS_KEY` are
+   threaded into uvicorn's `ssl_certfile`/`ssl_keyfile` via the
+   `uvicorn_config` dict, so the process speaks HTTPS directly. The server
+   holds the cert, so it can `is_self_signed()`-check it and WARN (the only
+   posture where it can inspect the cert).
+2. **TLS-terminating proxy** — `PORTAINER_MCP_TRUST_PROXY_TLS=1` (explicit
+   attestation) plus `PORTAINER_MCP_FORWARDED_ALLOW_IPS` make uvicorn trust
+   the proxy's `X-Forwarded-Proto`, which rewrites the scheme. The
+   attestation is separate from `PORTAINER_MCP_FORWARDED_ALLOW_IPS` (a functional knob)
+   so a plaintext proxy can't silently satisfy the gate.
+3. **Plaintext opt-out** — `PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1`
+   is the one loud escape hatch; it WARNs every start and sets
+   `auth.mark_insecure_transport()` so every audit record carries
+   `insecure_transport: true`.
+
+`TLSRequiredMiddleware` enforces `scheme == "https"` as a backstop (a
+direct plaintext hit that bypasses a Tier-2 proxy still 426s). It is
+installed via the verifier's `get_middleware()` — `PassthroughVerifier.
+add_pre_auth_middleware()` stacks it *ahead* of the bearer-auth backend, so
+a plaintext request is rejected before the per-user key is validated and
+forwarded upstream (the `server.run(middleware=[…])` list runs *after*
+auth, which is why DNS-rebinding sits there but the TLS check can't). The
+loopback exemption is keyed on the **bind host** at install time, never on
+the per-request client IP. There is no auto-self-signed mode: Node-based
+MCP clients reject self-signed certs and none pin by fingerprint, so it
+would be encrypted-but-unconnectable; a homelab operator mounts their own
+(warned) instead.
+
 ### Per-request context — `request_context.py`
 
 `snapshot()` returns `client_ip`, `user_agent`, and the MCP

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,12 +54,39 @@ Two controls layered on top of the bearer secret:
 
 | Var | Default | Notes |
 |---|---|---|
-| `PORTAINER_MCP_ALLOWED_HOSTS` | `127.0.0.1:*,localhost:*,[::1]:*` | Comma-separated `Host` allowlist. **Extend whenever the container is reached via a non-local hostname** — including any reverse proxy that preserves the original `Host` header. |
+| `PORTAINER_MCP_ALLOWED_HOSTS` | `127.0.0.1:*,localhost:*,[::1]:*` | Comma-separated `Host` allowlist. **Extend whenever the server is reached via a non-local hostname**, including a reverse proxy. Set it to exactly the `host:port` clients target — see note below. |
+
+> [!NOTE]
+> Match the value to the `Host` header clients actually send:
+> - standard-443 reverse proxy → bare hostname (`mcp.example.com`) — clients omit the default port
+> - custom port (direct, or a non-443 proxy) → pin it (`mcp.example.com:17717`, `mcp.example.com:8443`)
+> - port genuinely varies → `:*` wildcard
+>
+> A `base:*` entry matches **only** Hosts that include a port, so it will *not* match a bare `mcp.example.com` — don't reach for the wildcard by default. Pinning is tighter, but the DNS-rebinding boundary is the **hostname**; the port is secondary.
 
 > [!NOTE]
 > The `Origin` allowlist is not configurable and ships pinned to the localhost to provide secure defaults.
 > MCP clients such as Claude Code, Claude Desktop, etc... uses programmatic access that omits the `Origin` header
 > so these won't be impacted.
+
+## TLS posture (HTTP transport only)
+
+Over HTTP the server carries two secrets on the wire — the gate token and each
+caller's own Portainer API key (which never expires, so a captured one is
+usable until manually revoked). To avoid serving those in clear text by
+accident, **a non-loopback bind refuses to boot unless one transport posture is
+declared.** Loopback binds (`make dev`, `127.0.0.1`) are exempt. A broken
+declaration (cert without key, an unreadable cert, `PORTAINER_MCP_TRUST_PROXY_TLS`
+without `PORTAINER_MCP_FORWARDED_ALLOW_IPS`) hard-fails at startup — it never
+silently downgrades.
+
+| Var | Default | Notes |
+|---|---|---|
+| `PORTAINER_MCP_TLS_CERT` | _unset_ | PEM certificate path. Must be set together with `PORTAINER_MCP_TLS_KEY`. Server-terminated TLS — no plaintext hop exists. The server **warns** if the cert is self-signed; most MCP clients reject self-signed certs by default, so install the cert's CA on each client. |
+| `PORTAINER_MCP_TLS_KEY` | _unset_ | PEM private-key path. Must be set together with `PORTAINER_MCP_TLS_CERT`. |
+| `PORTAINER_MCP_TRUST_PROXY_TLS` | `0` | Attest that a TLS-terminating reverse proxy sits in front. When truthy, the server trusts the proxy's `X-Forwarded-Proto: https`. Requires `PORTAINER_MCP_FORWARDED_ALLOW_IPS`. It's an explicit acknowledgment — `PORTAINER_MCP_FORWARDED_ALLOW_IPS` alone (a functional knob) does **not** satisfy the TLS gate, since it could be set for a plaintext proxy. |
+| `PORTAINER_MCP_FORWARDED_ALLOW_IPS` | _unset_ | Comma-separated IPs/subnets whose `X-Forwarded-*` headers the server trusts. **Prefer the proxy's exact IP** when it's stable; widen to its **subnet** only when the proxy's address is dynamic (Docker/Kubernetes reschedule containers onto new IPs, so you can only know the network range) — and keep that subnet free of untrusted workloads, since anything on it can then spoof the scheme. A container **name won't work** (this matches the numeric source IP, not DNS): give the proxy a static container IP, or trust the user-defined network's subnet. Use `*` only when nothing but the proxy can reach the container. If the container is directly reachable (e.g. a published port) while trusting any attacker-reachable range, an attacker can spoof `X-Forwarded-Proto: https` over plaintext and defeat the TLS check — so a proxy deployment should not publish the container's port (see the Tier-2 example, which omits `-p`). Also repairs audit attribution (real client IP instead of the proxy's). |
+| `PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP` | `0` | **Danger.** The only way to serve plain HTTP on a non-loopback bind. The gate token and every Portainer key cross the wire unencrypted — acceptable only on a trusted private network you fully control. Emits a `WARNING` on every start and marks the audit log with `insecure_transport: true`. Exists because self-signed certs don't work in real MCP clients, leaving small no-CA/no-IdP deployments no other option. |
 
 ## Profiles
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
+    "cryptography>=42",
     "fastmcp>=3.4.2,<4",
     "httpx>=0.27",
     "jmespath>=1.0",

--- a/src/portainer_mcp/auth.py
+++ b/src/portainer_mcp/auth.py
@@ -15,6 +15,7 @@ import logging
 
 import httpx
 from fastmcp.server.auth import AccessToken, TokenVerifier
+from starlette.middleware import Middleware
 
 from . import passthrough, request_context
 
@@ -26,6 +27,17 @@ MIN_TOKEN_LENGTH = 32
 # server's output.
 audit_logger = logging.getLogger("portainer_mcp.audit")
 
+# Process-wide posture set once at boot. When the operator opts into plaintext
+# (PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP) every audit record carries
+# `insecure_transport: true` so the log itself records that the credentials it
+# admitted crossed the wire unencrypted.
+_insecure_transport = False
+
+
+def mark_insecure_transport() -> None:
+    global _insecure_transport
+    _insecure_transport = True
+
 
 def _audit(outcome: str, level: int, **extra: object) -> None:
     """Emit one auth audit record. The per-request context is read here so
@@ -33,11 +45,11 @@ def _audit(outcome: str, level: int, **extra: object) -> None:
     fields (e.g. the validated identity on `ok`) and must never include the
     token or per-user key.
     """
+    record: dict[str, object] = {"event": "auth", "outcome": outcome}
+    if _insecure_transport:
+        record["insecure_transport"] = True
     audit_logger.log(
-        level,
-        json.dumps(
-            {"event": "auth", "outcome": outcome, **request_context.snapshot(), **extra}
-        ),
+        level, json.dumps({**record, **request_context.snapshot(), **extra})
     )
 
 
@@ -138,6 +150,22 @@ class PassthroughVerifier(StaticBearerVerifier):
         super().__init__(token)
         self._client = client
         self._cache = cache
+        self._pre_auth_middleware: list[Middleware] = []
+
+    def add_pre_auth_middleware(self, middleware: Middleware) -> None:
+        """Stack ASGI middleware ahead of the bearer-auth backend.
+
+        FastMCP appends the `server.run(middleware=…)` list *after* the auth
+        backend, but the provider's own `get_middleware()` is extended first —
+        so anything returned here runs before `verify_token`. The TLS check
+        uses this to reject a plaintext request before the per-user key is
+        validated upstream (otherwise the no-TLS reject would land only after
+        the key had already crossed the wire to Portainer).
+        """
+        self._pre_auth_middleware.append(middleware)
+
+    def get_middleware(self) -> list:
+        return [*self._pre_auth_middleware, *super().get_middleware()]
 
     async def verify_token(self, token: str) -> AccessToken | None:
         if not self._matches(token):

--- a/src/portainer_mcp/server.py
+++ b/src/portainer_mcp/server.py
@@ -29,6 +29,14 @@ and refuses to boot if PORTAINER_API_KEY is set. Tunables:
   (127.0.0.1, localhost, [::1]); operator must extend for non-local
   deployments. The `Origin` allowlist is hardcoded to the localhost set
   (the only browser MCP client in scope is the local Inspector).
+- PORTAINER_MCP_TLS_CERT / PORTAINER_MCP_TLS_KEY — PEM cert+key; uvicorn
+  serves HTTPS directly (server-terminated TLS). Set together.
+- PORTAINER_MCP_TRUST_PROXY_TLS=1 + PORTAINER_MCP_FORWARDED_ALLOW_IPS —
+  attest a TLS-terminating proxy; trust its X-Forwarded-Proto from the
+  given IPs/subnets.
+- PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1 — serve plain HTTP
+  (unencrypted) on a non-loopback bind. The one loud opt-out; otherwise a
+  non-loopback bind refuses to boot without a TLS posture.
 """
 
 from __future__ import annotations
@@ -59,6 +67,7 @@ from portainer_mcp import (
     redaction,
     request_context,
     shaping,
+    tls,
 )
 
 SPEC_PATH = files("portainer_mcp") / "data" / "portainer-patched.yaml"
@@ -357,6 +366,25 @@ def main() -> None:
     warning = http_security.misconfig_warning(host, settings)
     if warning is not None:
         logger.warning(warning)
+
+    posture = tls.resolve_posture(host)
+    for line in posture.warnings:
+        logger.warning(line)
+    if posture.insecure_transport:
+        auth.mark_insecure_transport()
+    if posture.enforce_https:
+        # Installed via the verifier so it runs before the bearer-auth backend
+        # (not the `middleware=` list below, which Starlette appends after auth).
+        server.auth.add_pre_auth_middleware(Middleware(tls.TLSRequiredMiddleware))
+    logger.info(
+        "transport posture: %s",
+        "PLAINTEXT (insecure)"
+        if posture.insecure_transport
+        else "https enforced"
+        if posture.enforce_https
+        else "loopback (dev)",
+    )
+
     server.run(
         transport="http",
         host=host,
@@ -368,7 +396,7 @@ def main() -> None:
         # Uvicorn calls logging.config.dictConfig at server start, which
         # would overwrite the handlers we attached to uvicorn.* loggers.
         # Skip it so a single formatter owns every record.
-        uvicorn_config={"log_config": None},
+        uvicorn_config={"log_config": None, **posture.uvicorn_kwargs},
     )
 
 

--- a/src/portainer_mcp/tls.py
+++ b/src/portainer_mcp/tls.py
@@ -1,0 +1,205 @@
+"""TLS posture enforcement for the HTTP transport.
+
+Over HTTP this server carries two secrets on the wire — the shared gate
+token and each caller's own Portainer API key (which never expires, so a
+captured one is usable until manually revoked). Plaintext is therefore never
+served on a non-loopback bind by accident: the operator must declare one of
+three postures or the server refuses to boot.
+
+  - server-terminated TLS: `PORTAINER_MCP_TLS_CERT` / `_TLS_KEY` are threaded
+    into uvicorn's `ssl_certfile` / `ssl_keyfile`, so the process speaks HTTPS
+    directly and no plaintext hop exists.
+  - TLS-terminating proxy: `PORTAINER_MCP_TRUST_PROXY_TLS=1` (an explicit
+    attestation) plus `PORTAINER_MCP_FORWARDED_ALLOW_IPS` tell uvicorn to trust
+    `X-Forwarded-Proto` from the proxy, which rewrites the request scheme.
+  - plaintext opt-out: `PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1` — the
+    one loud, explicit escape hatch for trusted private networks.
+
+Both encrypted shapes converge on a single runtime signal — `scheme ==
+"https"` — which `TLSRequiredMiddleware` enforces as a backstop, installed
+before bearer-auth so a plaintext request is rejected before the per-user key
+is ever validated upstream. Loopback binds are exempt so `make dev` works
+unconfigured. There is deliberately no auto self-signed posture: real MCP
+clients reject self-signed certs by default and none support fingerprint
+pinning, so it would be "encrypted but unconnectable". A homelab operator can
+still mount their own self-signed cert (warned, not blocked) and install its
+CA on each client.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import NamedTuple
+
+from cryptography import x509
+from cryptography.exceptions import InvalidSignature
+from starlette.responses import PlainTextResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from .http_security import LOOPBACK_BINDS
+
+CERT_ENV = "PORTAINER_MCP_TLS_CERT"
+KEY_ENV = "PORTAINER_MCP_TLS_KEY"
+TRUST_PROXY_ENV = "PORTAINER_MCP_TRUST_PROXY_TLS"
+FORWARDED_IPS_ENV = "PORTAINER_MCP_FORWARDED_ALLOW_IPS"
+ALLOW_PLAINTEXT_ENV = "PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP"
+
+
+# Mirrors server.py's `_env_flag`; not shared because `server` imports this
+# module, so importing back would be circular.
+def _flag(name: str) -> bool:
+    raw = os.environ.get(name)
+    return raw is not None and raw not in {"0", "false", "False"}
+
+
+class Posture(NamedTuple):
+    """Resolved transport posture. `uvicorn_kwargs` is merged into the
+    `uvicorn_config` dict; `enforce_https` decides whether the runtime scheme
+    check is installed; `insecure_transport` marks the audit log; `warnings`
+    are operator-facing lines for `main()` to log.
+    """
+
+    uvicorn_kwargs: dict[str, str]
+    enforce_https: bool
+    insecure_transport: bool
+    warnings: tuple[str, ...]
+
+
+def is_self_signed(cert_path: str) -> bool:
+    """True if the leaf cert is self-signed (issuer name matches subject *and*
+    the signature verifies against its own public key). A cert signed by a
+    private internal CA is not flagged — the server only holds the leaf and
+    can't see the chain — so this catches the literal self-signed case only.
+
+    Loud-fails (SystemExit) on a cert that's readable but not parseable as PEM,
+    rather than letting the raw cryptography error surface — the readability
+    check ran upstream, so reaching here with garbage is a malformed cert.
+    """
+    try:
+        cert = x509.load_pem_x509_certificate(Path(cert_path).read_bytes())
+    except (OSError, ValueError) as exc:
+        raise SystemExit(
+            f"{CERT_ENV} is not a valid PEM certificate: {cert_path}"
+        ) from exc
+    if cert.issuer != cert.subject:
+        return False
+    try:
+        cert.verify_directly_issued_by(cert)
+    except (ValueError, TypeError, InvalidSignature):
+        return False
+    return True
+
+
+_PLAINTEXT_WARNING = (
+    f"{ALLOW_PLAINTEXT_ENV} is set — serving plain HTTP. The gate token and "
+    "every caller's Portainer API key cross the wire unencrypted; anyone on "
+    "the network path can capture them, and a captured Portainer key works "
+    "until manually revoked. Acceptable only on a trusted private network you "
+    "fully control."
+)
+
+
+def resolve_posture(bind_host: str) -> Posture:
+    """Validate the declared posture and return the resolved transport config.
+
+    Raises `SystemExit` (loud-fail, like the auth-token check) on any broken
+    declaration so the server never silently downgrades. On a non-loopback
+    bind it refuses to boot unless an encrypted posture or the explicit
+    plaintext opt-out is declared.
+    """
+    cert = os.environ.get(CERT_ENV)
+    key = os.environ.get(KEY_ENV)
+    trust_proxy = _flag(TRUST_PROXY_ENV)
+    forwarded_ips = os.environ.get(FORWARDED_IPS_ENV)
+    allow_plaintext = _flag(ALLOW_PLAINTEXT_ENV)
+    bind_is_loopback = bind_host in LOOPBACK_BINDS
+
+    uvicorn_kwargs: dict[str, str] = {}
+    warnings: list[str] = []
+
+    if bool(cert) != bool(key):
+        raise SystemExit(
+            f"{CERT_ENV} and {KEY_ENV} must be set together "
+            f"(one without the other is a half-configured TLS posture)"
+        )
+    if cert and key:
+        for label, path in ((CERT_ENV, cert), (KEY_ENV, key)):
+            if not os.access(path, os.R_OK):
+                raise SystemExit(f"{label} is not a readable file: {path}")
+        uvicorn_kwargs["ssl_certfile"] = cert
+        uvicorn_kwargs["ssl_keyfile"] = key
+        if is_self_signed(cert):
+            warnings.append(
+                f"{CERT_ENV} ({cert}) appears self-signed — most MCP clients "
+                "reject self-signed certs by default. For a homelab, install "
+                "this cert's CA on each client; otherwise use a CA-signed cert."
+            )
+
+    if trust_proxy and not forwarded_ips:
+        raise SystemExit(
+            f"{TRUST_PROXY_ENV}=1 requires {FORWARDED_IPS_ENV}=<proxy ip/subnet> "
+            f"so the runtime scheme check only trusts X-Forwarded-Proto from "
+            f"the proxy"
+        )
+    if forwarded_ips:
+        uvicorn_kwargs["forwarded_allow_ips"] = forwarded_ips
+
+    encrypted = bool(cert and key) or trust_proxy
+
+    if not bind_is_loopback and not encrypted and not allow_plaintext:
+        raise SystemExit(
+            f"bind host {bind_host!r} is non-loopback but no transport posture "
+            f"is declared. Set one of: {CERT_ENV} + {KEY_ENV} (server-terminated "
+            f"TLS), {TRUST_PROXY_ENV}=1 + {FORWARDED_IPS_ENV} (TLS-terminating "
+            f"proxy), or {ALLOW_PLAINTEXT_ENV}=1 (serve plaintext — unencrypted, "
+            f"trusted networks only)."
+        )
+
+    insecure_transport = allow_plaintext and not encrypted
+    if insecure_transport:
+        warnings.append(_PLAINTEXT_WARNING)
+    elif allow_plaintext and encrypted:
+        warnings.append(
+            f"{ALLOW_PLAINTEXT_ENV} is set but a TLS posture is also "
+            f"configured — serving TLS, the plaintext opt-out has no effect."
+        )
+
+    return Posture(
+        uvicorn_kwargs=uvicorn_kwargs,
+        enforce_https=encrypted and not bind_is_loopback,
+        insecure_transport=insecure_transport,
+        warnings=tuple(warnings),
+    )
+
+
+_UPGRADE_HINT = (
+    "This server requires TLS. The request arrived over plain HTTP. Terminate "
+    f"TLS in the server ({CERT_ENV}/{KEY_ENV}) or at a trusted proxy "
+    f"({TRUST_PROXY_ENV}=1 + {FORWARDED_IPS_ENV}); to serve plaintext on a "
+    f"trusted network set {ALLOW_PLAINTEXT_ENV}=1."
+)
+
+
+class TLSRequiredMiddleware:
+    """Reject any request whose scheme isn't `https`.
+
+    A backstop below the boot-time posture check: uvicorn sets the scheme from
+    real TLS (server-terminated) or from a trusted `X-Forwarded-Proto` (proxy),
+    so this one check is shape-agnostic. Installed before the bearer-auth
+    backend (via the verifier's `get_middleware`) so a plaintext request is
+    rejected before the per-user key is touched or forwarded upstream — the
+    loopback exemption is keyed on the bind host at install time, never on the
+    per-request client IP.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and scope.get("scheme") != "https":
+            await PlainTextResponse(
+                _UPGRADE_HINT, status_code=426, headers={"Upgrade": "TLS/1.2"}
+            )(scope, receive, send)
+            return
+        await self.app(scope, receive, send)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -188,7 +188,14 @@ async def test_verifier_audit_never_logs_token_bytes(caplog):
     with caplog.at_level(logging.INFO, logger="portainer_mcp.audit"):
         await verifier.verify_token(expected)
         await verifier.verify_token(attempted)
-    allowed_keys = {"event", "outcome", "client_ip", "user_agent", "session_id"}
+    allowed_keys = {
+        "event",
+        "outcome",
+        "client_ip",
+        "user_agent",
+        "session_id",
+        "insecure_transport",
+    }
     for record in caplog.records:
         payload = json.loads(record.message)
         assert set(payload).issubset(allowed_keys), (

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1,0 +1,308 @@
+"""Unit tests for `src/portainer_mcp/tls.py` and its auth wiring.
+
+Covers the boot-time posture resolution (loud-fail on every broken
+declaration, refuse-to-boot on an undeclared non-loopback bind), the
+self-signed cert warning, the runtime scheme-enforcement middleware, and the
+two auth touch-points: the pre-auth middleware hook and the `insecure_transport`
+audit mark.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+
+import httpx
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+from starlette.middleware import Middleware
+
+from portainer_mcp import auth, passthrough, tls
+
+_TLS_ENV = [
+    tls.CERT_ENV,
+    tls.KEY_ENV,
+    tls.TRUST_PROXY_ENV,
+    tls.FORWARDED_IPS_ENV,
+    tls.ALLOW_PLAINTEXT_ENV,
+]
+
+
+@pytest.fixture(autouse=True)
+def clean_tls_env(monkeypatch):
+    """Start every test from an undeclared posture so the host's real env
+    can't leak a cert path or the plaintext flag into the assertions.
+    """
+    for name in _TLS_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+
+# --- cert fixtures -----------------------------------------------------------
+
+
+def _write_cert(tmp_path, name, *, self_signed):
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, name)])
+    if self_signed:
+        issuer_name, issuer_key = subject, key
+    else:
+        ca_key = ec.generate_private_key(ec.SECP256R1())
+        issuer_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test CA")])
+        issuer_key = ca_key
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer_name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime(2020, 1, 1))
+        .not_valid_after(datetime.datetime(2035, 1, 1))
+        .sign(issuer_key, hashes.SHA256())
+    )
+    cert_path = tmp_path / f"{name}-cert.pem"
+    key_path = tmp_path / f"{name}-key.pem"
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+    return str(cert_path), str(key_path)
+
+
+# --- is_self_signed ----------------------------------------------------------
+
+
+def test_is_self_signed_true_for_self_signed(tmp_path):
+    cert, _ = _write_cert(tmp_path, "self", self_signed=True)
+    assert tls.is_self_signed(cert) is True
+
+
+def test_is_self_signed_false_for_ca_signed(tmp_path):
+    cert, _ = _write_cert(tmp_path, "ca", self_signed=False)
+    assert tls.is_self_signed(cert) is False
+
+
+def test_is_self_signed_loud_fails_on_malformed_pem(tmp_path):
+    bad = tmp_path / "garbage.pem"
+    bad.write_text("this is not a certificate")
+    with pytest.raises(SystemExit, match="not a valid PEM certificate"):
+        tls.is_self_signed(str(bad))
+
+
+# --- resolve_posture: hard fails ---------------------------------------------
+
+
+@pytest.mark.parametrize("present", [tls.CERT_ENV, tls.KEY_ENV])
+def test_cert_without_key_or_key_without_cert_fails(monkeypatch, present):
+    monkeypatch.setenv(present, "/tmp/whatever.pem")
+    with pytest.raises(SystemExit, match="must be set together"):
+        tls.resolve_posture("0.0.0.0")
+
+
+def test_unreadable_cert_fails(monkeypatch, tmp_path):
+    monkeypatch.setenv(tls.CERT_ENV, str(tmp_path / "missing-cert.pem"))
+    monkeypatch.setenv(tls.KEY_ENV, str(tmp_path / "missing-key.pem"))
+    with pytest.raises(SystemExit, match="not a readable file"):
+        tls.resolve_posture("0.0.0.0")
+
+
+def test_trust_proxy_without_forwarded_ips_fails(monkeypatch):
+    monkeypatch.setenv(tls.TRUST_PROXY_ENV, "1")
+    with pytest.raises(SystemExit, match="requires PORTAINER_MCP_FORWARDED_ALLOW_IPS"):
+        tls.resolve_posture("0.0.0.0")
+
+
+def test_non_loopback_bind_without_posture_refuses_to_boot(monkeypatch):
+    with pytest.raises(SystemExit, match="no transport posture is declared"):
+        tls.resolve_posture("0.0.0.0")
+
+
+# --- resolve_posture: accepted postures --------------------------------------
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+def test_loopback_bind_needs_no_posture(host):
+    posture = tls.resolve_posture(host)
+    assert posture.uvicorn_kwargs == {}
+    assert posture.enforce_https is False
+    assert posture.insecure_transport is False
+    assert posture.warnings == ()
+
+
+def test_server_terminated_tls_ca_cert(monkeypatch, tmp_path):
+    cert, key = _write_cert(tmp_path, "leaf", self_signed=False)
+    monkeypatch.setenv(tls.CERT_ENV, cert)
+    monkeypatch.setenv(tls.KEY_ENV, key)
+    posture = tls.resolve_posture("0.0.0.0")
+    assert posture.uvicorn_kwargs == {"ssl_certfile": cert, "ssl_keyfile": key}
+    assert posture.enforce_https is True
+    assert posture.insecure_transport is False
+    assert posture.warnings == ()
+
+
+def test_server_terminated_tls_self_signed_warns(monkeypatch, tmp_path):
+    cert, key = _write_cert(tmp_path, "selfsigned", self_signed=True)
+    monkeypatch.setenv(tls.CERT_ENV, cert)
+    monkeypatch.setenv(tls.KEY_ENV, key)
+    posture = tls.resolve_posture("0.0.0.0")
+    assert posture.enforce_https is True
+    assert any("self-signed" in w for w in posture.warnings)
+
+
+def test_proxy_attestation_posture(monkeypatch):
+    monkeypatch.setenv(tls.TRUST_PROXY_ENV, "1")
+    monkeypatch.setenv(tls.FORWARDED_IPS_ENV, "10.0.0.0/8")
+    posture = tls.resolve_posture("0.0.0.0")
+    assert posture.uvicorn_kwargs == {"forwarded_allow_ips": "10.0.0.0/8"}
+    assert posture.enforce_https is True
+    assert posture.insecure_transport is False
+
+
+def test_forwarded_ips_alone_is_not_a_posture(monkeypatch):
+    # forwarded_allow_ips is functional (audit attribution); without the
+    # explicit attestation flag it doesn't satisfy the TLS gate.
+    monkeypatch.setenv(tls.FORWARDED_IPS_ENV, "10.0.0.0/8")
+    with pytest.raises(SystemExit, match="no transport posture is declared"):
+        tls.resolve_posture("0.0.0.0")
+
+
+def test_plaintext_opt_out(monkeypatch):
+    monkeypatch.setenv(tls.ALLOW_PLAINTEXT_ENV, "1")
+    posture = tls.resolve_posture("0.0.0.0")
+    assert posture.uvicorn_kwargs == {}
+    assert posture.enforce_https is False
+    assert posture.insecure_transport is True
+    assert any("unencrypted" in w for w in posture.warnings)
+
+
+def test_plaintext_flag_ignored_when_tls_configured(monkeypatch, tmp_path):
+    cert, key = _write_cert(tmp_path, "leaf", self_signed=False)
+    monkeypatch.setenv(tls.CERT_ENV, cert)
+    monkeypatch.setenv(tls.KEY_ENV, key)
+    monkeypatch.setenv(tls.ALLOW_PLAINTEXT_ENV, "1")
+    posture = tls.resolve_posture("0.0.0.0")
+    assert posture.insecure_transport is False
+    assert posture.enforce_https is True
+    assert any("no effect" in w for w in posture.warnings)
+
+
+# --- TLSRequiredMiddleware ---------------------------------------------------
+
+
+async def _drive(scheme):
+    sent: list[dict] = []
+    passed = False
+
+    async def app(scope, receive, send):
+        nonlocal passed
+        passed = True
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    scope = {"type": "http", "scheme": scheme, "method": "POST", "headers": []}
+    await tls.TLSRequiredMiddleware(app)(scope, receive, send)
+    return passed, sent
+
+
+async def test_middleware_passes_https():
+    passed, sent = await _drive("https")
+    assert passed is True
+    assert sent == []
+
+
+async def test_middleware_rejects_http_with_426():
+    passed, sent = await _drive("http")
+    assert passed is False
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert start["status"] == 426
+    body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+    assert b"requires TLS" in body
+
+
+# --- auth wiring -------------------------------------------------------------
+
+GATE = "g" * 64
+
+
+def _passthrough_verifier():
+    client = httpx.AsyncClient(base_url="http://portainer/api")
+    return auth.PassthroughVerifier(GATE, client, passthrough.ValidationCache(ttl=60))
+
+
+def test_pre_auth_middleware_runs_before_bearer_backend():
+    verifier = _passthrough_verifier()
+    baseline = len(verifier.get_middleware())
+    mw = Middleware(tls.TLSRequiredMiddleware)
+    verifier.add_pre_auth_middleware(mw)
+    stacked = verifier.get_middleware()
+    assert stacked[0] is mw  # outermost — ahead of AuthenticationMiddleware
+    assert len(stacked) == baseline + 1
+
+
+def test_plaintext_request_rejected_before_auth_backend():
+    # The security invariant, exercised through the live ASGI chain (not just
+    # the middleware-list order above): with the TLS check stacked ahead of the
+    # bearer backend, a plaintext request 426s before `verify_token` runs — so
+    # the per-user key is never validated against / forwarded to Portainer over
+    # cleartext. Guards against a FastMCP refactor silently reordering the stack.
+    from starlette.applications import Starlette
+    from starlette.responses import PlainTextResponse
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    seen: list[str] = []
+
+    class SpyVerifier(auth.PassthroughVerifier):
+        async def verify_token(self, token):
+            seen.append(token)
+            return await super().verify_token(token)
+
+    client = httpx.AsyncClient(base_url="http://portainer/api")
+    verifier = SpyVerifier(GATE, client, passthrough.ValidationCache(ttl=60))
+    verifier.add_pre_auth_middleware(Middleware(tls.TLSRequiredMiddleware))
+
+    async def endpoint(request):
+        return PlainTextResponse("ok")
+
+    app = Starlette(
+        routes=[Route("/mcp", endpoint, methods=["POST"])],
+        middleware=verifier.get_middleware(),
+    )
+    headers = {"Authorization": f"Bearer {GATE}"}
+
+    with TestClient(app, base_url="http://testserver") as tc:
+        plaintext = tc.post("/mcp", headers=headers)
+    assert plaintext.status_code == 426
+    assert seen == []  # auth backend never reached on plaintext
+
+    with TestClient(app, base_url="https://testserver") as tc:
+        tc.post("/mcp", headers=headers)
+    assert seen  # an https request did reach verify_token
+
+
+async def test_audit_marks_insecure_transport(monkeypatch, caplog):
+    monkeypatch.setattr(auth, "_insecure_transport", True)
+    verifier = auth.StaticBearerVerifier("a" * 64)
+    with caplog.at_level(logging.INFO, logger="portainer_mcp.audit"):
+        await verifier.verify_token("a" * 64)
+    record = next(r for r in caplog.records if r.name == "portainer_mcp.audit")
+    assert json.loads(record.message)["insecure_transport"] is True
+
+
+async def test_audit_omits_insecure_transport_when_secure(caplog):
+    verifier = auth.StaticBearerVerifier("a" * 64)
+    with caplog.at_level(logging.INFO, logger="portainer_mcp.audit"):
+        await verifier.verify_token("a" * 64)
+    record = next(r for r in caplog.records if r.name == "portainer_mcp.audit")
+    assert "insecure_transport" not in json.loads(record.message)

--- a/uv.lock
+++ b/uv.lock
@@ -660,6 +660,7 @@ name = "mcp-portainer"
 version = "2.42.4"
 source = { editable = "." }
 dependencies = [
+    { name = "cryptography" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "jmespath" },
@@ -674,6 +675,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cryptography", specifier = ">=42" },
     { name = "fastmcp", specifier = ">=3.4.2,<4" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jmespath", specifier = ">=1.0" },


### PR DESCRIPTION
Over HTTP the server carries two secrets on the wire (the shared gate token and each caller's permanent Portainer API key), so it now refuses to boot on a non-loopback bind unless the operator declares one of three transport postures:

  - server-terminated TLS: PORTAINER_MCP_TLS_CERT/_TLS_KEY -> uvicorn ssl_certfile/ssl_keyfile. Self-signed leaf certs WARN (never block).
  - TLS-terminating proxy: PORTAINER_MCP_TRUST_PROXY_TLS=1 + PORTAINER_MCP_FORWARDED_ALLOW_IPS -> trusted X-Forwarded-Proto.
  - plaintext opt-out: PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1, the one loud escape hatch (WARNs every start, marks the audit log insecure_transport: true).

Both encrypted shapes converge on scheme == "https", enforced by TLSRequiredMiddleware as a backstop. It is installed via the verifier's get_middleware() so it runs before the bearer-auth backend -- a plaintext request is rejected before the per-user key is validated and forwarded upstream. Loopback binds stay exempt for dev. A broken declaration hard-fails at startup, never silently downgrades.

Adds tls.py, the auth.py wiring (pre-auth middleware hook + insecure_transport audit flag), main() resolution, tests, and docs. cryptography promoted to a direct dependency (self-signed detection).

Related to #65 and #66 