### PR TITLE
Teach the hygiene skill to report its own gaps as issues

### DIFF
--- a/.claude/skills/portainer-mcp-release/SKILL.md
+++ b/.claude/skills/portainer-mcp-release/SKILL.md
@@ -11,7 +11,7 @@ The release pipeline itself (PyPI publish via OIDC on tag push) is documented in
 
 ## Why a skill for this
 
-Spec bumps are infrequent (one per Portainer minor — quarterly-ish) and the work spans nine files. Most of those touches are mechanical version-pin updates, but two are easy to half-do:
+Spec bumps are infrequent (one per Portainer minor — quarterly-ish) and the work spans ten files. Most of those touches are mechanical version-pin updates, but two are easy to half-do:
 
 - **Op/tag deltas in `docs/profiles.md`** — the orphan table and default-coverage numbers are derived from the spec. Upstream often adds/removes/renames tags between minors. Stale numbers here mean users get the wrong picture of what the default profiles cover.
 - **CHANGELOG entry** — a one-liner that says "bumped spec" is much less useful than naming the deltas (operation count change, dropped tags). Skim of the changelog is how users decide whether the upgrade matters to them.
@@ -103,7 +103,7 @@ Output is in two parts: per-profile coverage numbers (use these in `docs/profile
 
 ### 6. Update files
 
-Nine files to touch. Listed in roughly the order it's natural to edit them:
+Ten files to touch. Listed in roughly the order it's natural to edit them:
 
 | File | Change |
 |---|---|
@@ -113,6 +113,7 @@ Nine files to touch. Listed in roughly the order it's natural to edit them:
 | `docs/profiles.md` | New per-profile and union numbers in the "Default coverage" paragraph; new orphan table (paste from the script); update the "350+/400+ operations across 40+ tags" lead if it crossed a round number. |
 | `README.md` | `~=X.Y.0` pin in the `claude mcp add` snippet; raw URL tag in the skill curl; new row in the compat matrix (keep prior rows — the matrix is cumulative). |
 | `docs/distribution/claude-desktop.md` | Same pin + skill URL bump as README. Check for additional client docs as `docs/distribution/` grows. |
+| `skills/portainer-mcp-hygiene/SKILL.md` | Bump the `Skill version:` footer to `X.Y.0`. Issue reports filed via the skill's self-report section cite this footer — a stale value mislabels every report. |
 | `Makefile` | Update the example `VERSION=` in the `specs` comment/help text. |
 | `docs/versioning.md` | If the doc uses the old minor in prose examples (e.g. "2.41.x ↔ 2.41.x"), retarget to the new minor. |
 | `CHANGELOG.md` | Move the `[Unreleased]` block under a new `[X.Y.0] — YYYY-MM-DD` heading; leave a fresh empty `[Unreleased]` on top. The spec bump should be the lead Changed entry, naming old → new spec version and the headline deltas (op count change, any dropped/added tags). |
@@ -139,7 +140,8 @@ Adapt to what actually happened — if no tags were dropped, drop that sentence;
 
 ```bash
 git add CHANGELOG.md Makefile README.md docs/distribution/ docs/profiles.md \
-        docs/versioning.md pyproject.toml src/portainer_mcp/data/portainer-patched.yaml uv.lock
+        docs/versioning.md pyproject.toml skills/portainer-mcp-hygiene/SKILL.md \
+        src/portainer_mcp/data/portainer-patched.yaml uv.lock
 git commit -m "Release X.Y.0
 
 Bump embedded Portainer EE spec to X.Y.Z. <One-liner naming the headline

--- a/docs/distribution/claude-desktop.md
+++ b/docs/distribution/claude-desktop.md
@@ -36,7 +36,7 @@ context. Install user-wide, pinned to the same tag as the server:
 
 ```bash
 mkdir -p ~/.claude/skills/portainer-mcp-hygiene && \
-  curl -fsSL https://raw.githubusercontent.com/portainer/portainer-mcp/2.42.0/skills/portainer-mcp-hygiene/SKILL.md \
+  curl -fsSL https://raw.githubusercontent.com/portainer/portainer-mcp/2.42.5/skills/portainer-mcp-hygiene/SKILL.md \
   -o ~/.claude/skills/portainer-mcp-hygiene/SKILL.md
 ```
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -64,15 +64,20 @@ receive plain `X.Y.Z`.
 4. Move the `[Unreleased]` block in [`../CHANGELOG.md`](../CHANGELOG.md) under
    a new `[X.Y.Z] — YYYY-MM-DD` heading; leave a fresh empty `[Unreleased]`
    block on top.
-5. Commit: `Release X.Y.Z`.
-6. Tag and push:
+5. Bump the pinned tag to the new `X.Y.Z` everywhere the skill install is
+   referenced: the README curl snippet,
+   [`distribution/claude-desktop.md`](distribution/claude-desktop.md), and the
+   `Skill version:` footer in
+   [`../skills/portainer-mcp-hygiene/SKILL.md`](../skills/portainer-mcp-hygiene/SKILL.md).
+6. Commit: `Release X.Y.Z`.
+7. Tag and push:
    ```bash
    git tag X.Y.Z
    git push origin X.Y.Z
    ```
-7. The workflow verifies the tag matches `pyproject.version`, runs tests,
+8. The workflow verifies the tag matches `pyproject.version`, runs tests,
    builds, and publishes.
-8. Once green, the new version is live at
+9. Once green, the new version is live at
    `https://pypi.org/project/mcp-portainer/X.Y.Z/`.
 
 ## Recovery

--- a/skills/portainer-mcp-hygiene/SKILL.md
+++ b/skills/portainer-mcp-hygiene/SKILL.md
@@ -209,3 +209,45 @@ The exception is non-JSON endpoints (see above) — there, ignore the `select` s
 - Kubernetes things on a specific environment → either the OpenAPI-generated `GetAllKubernetes*` / `GetKubernetes*` tools (Portainer-aware, often already filtered) or `kubernetes_proxy` (raw K8s API, full flexibility). Prefer the typed tool when it exists; fall back to the proxy for paths Portainer doesn't surface natively.
 - Helm releases → `HelmList`, `HelmGet`, `HelmGetHistory`. Don't try to route Helm through the K8s proxy — Portainer's Helm tools see the release metadata the K8s API alone doesn't.
 - Mutations (POST/PUT/DELETE) → only in read-write mode. If the server is in `PORTAINER_READ_ONLY=1`, non-GET calls are rejected at the tool with a clear error. Don't retry mutations as GET when this happens — surface the read-only state to the user.
+
+## When the skill itself is wrong
+
+If reality contradicts this skill — a `select` example fails to parse, redaction behaves
+differently than described, a documented tool is missing or renamed, the truncation hint
+doesn't match what's written here — offer to file an issue on
+[`portainer/portainer-mcp`](https://github.com/portainer/portainer-mcp), the repo this
+skill ships from, so the gap gets fixed for everyone. Server misbehaviour (a tool errors
+on valid input, the cap or redaction is broken) belongs there too. That repo is the *only*
+destination this section covers: user errors, instance misconfiguration, and Portainer
+product bugs are out of scope — handle them in conversation, don't offer to file them
+anywhere.
+
+First make sure the evidence points at the skill rather than at your own expression:
+re-run the *verbatim* example from this file, not your adaptation of it. A `null`
+projection usually means an unquoted dotted key in your own expression (see the JMESPath
+notes above), not a skill gap. Only a verbatim example failing, or behaviour that
+contradicts an explicit claim in this file, is reportable.
+
+1. **Offer once per session.** One line — "this looks like a gap in the
+   portainer-mcp-hygiene skill; want me to file an issue on `portainer/portainer-mcp`?"
+   If declined, drop it for the rest of the session. If more mismatches surface later,
+   fold them into the one offer (and one issue) rather than asking per finding.
+2. **Draft and scrub.** Replace hostnames/IPs/URLs, usernames, and resource names with
+   placeholders (`<portainer-host>`, `<stack-name>`); never include tokens, env values,
+   or response dumps. Quote the failing line, not the whole response — short bodies also
+   survive the prefilled-link fallback below.
+3. **Include**: the skill version from the footer of this file; the Portainer version
+   (`systemVersion` is one cheap call) and the `mcp-portainer` server version if the user
+   knows it; a title prefixed `[portainer-mcp-hygiene]` for skill-guidance gaps (plain
+   titles for server bugs); what the skill said (quote it); the tool call made (tool name
+   + sanitized arguments including the `select` expression); what actually happened; and
+   what you expected.
+4. **Show the draft, then file on approval** — `gh issue create --repo
+   portainer/portainer-mcp --title … --body …` if `gh` is available and authenticated;
+   otherwise hand the user a prefilled link they can open themselves:
+   `https://github.com/portainer/portainer-mcp/issues/new?title=<url-encoded>&body=<url-encoded>`.
+   Never file silently.
+
+---
+
+Skill version: 2.42.5 (matches the `mcp-portainer` release tag this file shipped with).


### PR DESCRIPTION
When live behaviour contradicts the skill — a verbatim select example failing, redaction or truncation not matching the text, a documented tool missing — the model now offers (once per session, with consent, scrubbed of instance details) to file an issue on portainer/portainer-mcp. That repo is the only destination; user errors and Portainer product bugs are explicitly out of scope.

Reports lead with version data: a new Skill version footer in the file itself plus the Portainer version, since the curl-pinned install makes skill/server skew the likeliest cause of a mismatch. The footer joins the README pin as a release-time bump, now an explicit step in docs/release.md, and the stale 2.42.0 pin in claude-desktop.md is caught up to 2.42.5.