### PR TITLE
Release 2.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ the MCP server.
 
 ## [Unreleased]
 
+## [2.43.0] — 2026-06-29
+
+Targets Portainer 2.43.x.
+
+### Changed
+
+- **Embedded spec bumped to Portainer EE 2.43.0** (was 2.42.0). Total
+  operations 409 → 412. Default `BASE,DOCKER,KUBERNETES` coverage moves
+  193 → 190 and the five-profile union 334 → 329: upstream resolved a
+  long-standing tagging defect by moving the Edge-agent callbacks
+  (heartbeat/status, async poll, alert + chart status, edge stack/job sync)
+  off the `endpoints` tag onto a new dedicated `edge_agent` tag, so they no
+  longer leak into the DOCKER profile as tools that can never succeed for a
+  non-agent caller. New `allowlist` tag (2 ops, URL allow list) added to the
+  orphan list in [`docs/profiles.md`](docs/profiles.md).
+- **Edge-agent callback exclusion is now tag-based.** `spec/patch_spec.py`
+  drops every operation carrying the new `edge_agent` tag (eight callbacks
+  that 403 for any caller without `X-PortainerAgent-EdgeID`), replacing the
+  previous four-op `(method, path)` matcher — possible because 2.43.0 also
+  gave 15 of 16 previously-unnamed operations an `operationId` (webhooks,
+  endpoint-group create, docker browse-put, edge key generate, the edge
+  callbacks, and the websocket ops).
+
 ## [2.42.6] — 2026-06-18
 
 Targets Portainer 2.42.x.

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ UPSTREAM_DIR  := spec/upstream
 .PHONY: specs dev
 
 # Refresh src/portainer_mcp/data/portainer-patched.yaml from upstream
-# Usage: make specs VERSION=2.42.0
+# Usage: make specs VERSION=2.43.0
 specs:
 	@if [ -z "$(VERSION)" ]; then \
-		echo "VERSION is required, e.g. make specs VERSION=2.42.0" >&2; \
+		echo "VERSION is required, e.g. make specs VERSION=2.43.0" >&2; \
 		exit 1; \
 	fi
 	@if [ -d $(UPSTREAM_DIR)/.git ]; then \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Official MCP server for Portainer, generated from the Portainer OpenAPI spec via
 
 This MCP server exposes the Portainer REST API as MCP tools: list and inspect environments, manage GitOps workflows, troubleshoot Docker and Kubernetes resources. It also supports proxying requests to the underlying Docker and K8s APIs of each environment.
 
-Match the MCP server's minor version to your Portainer instance's minor — e.g. MCP server 2.42.x with Portainer 2.42.x. See [Version compatibility](#version-compatibility) for details.
+Match the MCP server's minor version to your Portainer instance's minor — e.g. MCP server 2.43.x with Portainer 2.43.x. See [Version compatibility](#version-compatibility) for details.
 
 ## Getting started
 
@@ -44,7 +44,7 @@ Register with Claude Code:
 claude mcp add portainer \
   -e PORTAINER_URL=https://portainer.example.com \
   -e PORTAINER_API_KEY=ptr_xxxxxxxxxxxxxxxx \
-  -- uvx --from "mcp-portainer~=2.42.0" mcp-portainer
+  -- uvx --from "mcp-portainer~=2.43.0" mcp-portainer
 ````
 
 For other clients, see
@@ -82,7 +82,7 @@ docker run -d --name portainer-mcp -p 17717:17717 \
 	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com:17717 \
 	-e PORTAINER_MCP_TLS_CERT=/tls/cert.pem \
 	-e PORTAINER_MCP_TLS_KEY=/tls/key.pem \
-	portainer/portainer-mcp:2.42
+	portainer/portainer-mcp:2.43
 ````
 
 Then connect your client:
@@ -112,7 +112,7 @@ docker run -d --name portainer-mcp \
 	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com \
 	-e PORTAINER_MCP_TRUST_PROXY_TLS=1 \
 	-e PORTAINER_MCP_FORWARDED_ALLOW_IPS=172.18.0.0/16 \
-	portainer/portainer-mcp:2.42
+	portainer/portainer-mcp:2.43
 ````
 
 Then connect your client:
@@ -137,7 +137,7 @@ docker run -d --name portainer-mcp -p 17717:17717 \
 	-e PORTAINER_MCP_AUTH_TOKEN="$TOKEN" \
 	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com:17717 \
 	-e PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1 \
-	portainer/portainer-mcp:2.42
+	portainer/portainer-mcp:2.43
 ````
 
 Then connect your client:
@@ -165,6 +165,7 @@ For restricting or expanding this set of capabilities, see [`docs/profiles.md`](
 
 | Server version | Portainer (CE / EE) |
 | -------------- | ------------------- |
+| `2.43.x`       | `2.43.x`            |
 | `2.42.x`       | `2.42.x`            |
 | `2.41.x`       | `2.41.x`            |
 

--- a/docs/distribution/claude-desktop.md
+++ b/docs/distribution/claude-desktop.md
@@ -22,7 +22,7 @@ Claude Desktop > Settings > Developer > Edit Config and choose one of the path b
   "mcpServers": {
     "portainer": {
       "command": "uvx",
-      "args": ["--from", "mcp-portainer~=2.42.0", "mcp-portainer"],
+      "args": ["--from", "mcp-portainer~=2.43.0", "mcp-portainer"],
       "env": {
         "PORTAINER_URL": "https://portainer.example.com",
         "PORTAINER_API_KEY": "ptr_xxxxxxxxxxxxxxxx"

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -39,15 +39,16 @@ when you need them, or switch to `ALL`:
 
 | Count | Tag | Notes |
 |---:|---|---|
+| 15 | `gitops` | GitOps configuration surface. |
 | 15 | `observability` | Container/pod logs, metrics, stats. |
-| 12 | `omni` | Talos Kubernetes cluster management. |
+| 13 | `omni` | Talos Kubernetes cluster management. |
 | 10 | `custom_templates` | User-defined app templates. |
-| 9 | `gitops` | GitOps configuration surface. |
-| 8 | `cloud_credentials` | Cloud provider credentials. |
+| 6 | `cloud_credentials` | Cloud provider credentials. |
 | 6 | `webhooks` | Webhook management. |
 | 4 | `kaas` | Kubernetes-as-a-Service provisioning. |
 | 4 | `useractivity` | Audit log. |
 | 3 | `support` | Support bundles / diagnostics. |
+| 2 | `allowlist` | URL allow list. |
 | 2 | `recommendations` | Recommendation engine. |
 | 2 | `ssl` | Server TLS certificates. |
 | 2 | `templates` | App template library. |

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -3,14 +3,14 @@
 **Major+minor tracks the Portainer API; patch is the MCP server's to spend.**
 
 - Tag format: `<portainer-major>.<portainer-minor>.<mcp-patch>`.
-- Compatibility statement: **"MCP 2.42.x ↔ Portainer 2.42.x"** — minor
+- Compatibility statement: **"MCP 2.43.x ↔ Portainer 2.43.x"** — minor
   granularity.
 - Spec cadence: regenerate `src/portainer_mcp/data/portainer-patched.yaml` against the
   **latest patch** of the targeted Portainer minor (e.g. `make specs
-  VERSION=2.42.1` when 2.42.1 is current).
+  VERSION=2.43.0` when 2.43.0 is current).
 - MCP-internal iterations (shaping fixes, new profiles, transform changes,
-  dep bumps, doc-only changes) burn the patch slot — e.g. `2.42.1` is an
-  MCP-only release still targeting Portainer 2.42.x.
+  dep bumps, doc-only changes) burn the patch slot — e.g. `2.43.1` is an
+  MCP-only release still targeting Portainer 2.43.x.
 
 ## What does *not* bump the minor
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-portainer"
-version = "2.42.6"
+version = "2.43.0"
 description = "Portainer MCP server — manage Docker, Kubernetes, stacks, and Helm via the Model Context Protocol."
 readme = "README.md"
 license = "MIT"

--- a/skills/portainer-mcp-hygiene/SKILL.md
+++ b/skills/portainer-mcp-hygiene/SKILL.md
@@ -312,4 +312,4 @@ contradicts an explicit claim in this file, is reportable.
 
 ---
 
-Skill version: 2.42.6 (matches the `mcp-portainer` release tag this file shipped with).
+Skill version: 2.43.0 (matches the `mcp-portainer` release tag this file shipped with).

--- a/spec/patch_spec.py
+++ b/spec/patch_spec.py
@@ -17,38 +17,25 @@ from pathlib import Path
 import yaml
 
 EXCLUDED_OPERATION_IDS = {
-    "SharedGitGet",
-    "SharedGitUpdate",
-    "SharedGitDelete",
     "UpdateKubernetesNamespaceDeprecated",
     "providerInfo",
     "provisionCluster",
 }
 
-# Edge-agent-only callbacks under `/endpoints/{id}/edge/*` that 403 outside
-# an agent context. Tagged with `endpoints` upstream, so they leak into the
-# default profile and surface as tools that can never succeed for a non-agent
-# MCP caller.
-#
-# Two of them have no operationId in the spec (FastMCP names them from
-# `summary` instead), so the existing operationId-based filter can't catch
-# them — match on (method, path) instead.
-EXCLUDED_PATH_METHODS = frozenset(
-    {
-        ("get", "/endpoints/{id}/edge/stacks/{stackId}"),
-        ("get", "/endpoints/{id}/edge/status"),
-        ("post", "/endpoints/{id}/edge/alerts"),
-        ("post", "/endpoints/{id}/edge/jobs/{jobID}/logs"),
-    }
-)
+# Edge-agent-only callbacks under `/endpoints/{id}/edge/*` (heartbeat/status,
+# async poll, alert + chart status, edge stack/job sync). They 403 for any
+# caller that isn't an Edge agent presenting `X-PortainerAgent-EdgeID`, so they
+# can never succeed for an MCP caller. 2.43 gave them a dedicated `edge_agent`
+# tag — before that they were mis-tagged `endpoints` and leaked into the DOCKER
+# profile, and we matched four of them by (method, path). Now we drop every op
+# carrying the tag: it catches all of them (not an arbitrary subset), and one
+# (`EndpointEdgeStackInspect`) also carries `edge_stacks`, so it would otherwise
+# surface in the EDGE profile.
+EXCLUDED_TAGS = frozenset({"edge_agent"})
 
 EXCLUDED_PATH_PREFIXES = ("/websocket",)
 
-ENUM_STRIPS = (
-    ("os.FileMode",),
-    ("policies.PolicyType",),
-    ("v1.Duration", "properties", "time.Duration"),
-)
+ENUM_STRIPS = (("policies.PolicyType",),)
 
 DEFAULT_OUTPUT = (
     Path(__file__).resolve().parents[1]
@@ -75,10 +62,9 @@ def patch(spec: dict) -> dict:
             op = paths[path][method]
             if not isinstance(op, dict):
                 continue
-            if op.get("operationId") in EXCLUDED_OPERATION_IDS:
-                paths[path].pop(method)
-                continue
-            if (method.lower(), path) in EXCLUDED_PATH_METHODS:
+            if op.get("operationId") in EXCLUDED_OPERATION_IDS or (
+                EXCLUDED_TAGS.intersection(op.get("tags") or ())
+            ):
                 paths[path].pop(method)
         if not paths[path]:
             paths.pop(path)

--- a/src/portainer_mcp/data/portainer-patched.yaml
+++ b/src/portainer_mcp/data/portainer-patched.yaml
@@ -31,11 +31,81 @@ info:
     \ JSON string in the request header. The header parameter name is `X-Registry-Auth`\
     \ and the value should encode the following structure: \u2018{\"registryId\":\\\
     <registryId\\>}\u2019 where `<registryId>` is the ID of the registry where the\
-    \ repository was created.\n \nExample encoded value:\n\n```\neyJyZWdpc3RyeUlkIjoxfQ==\n\
+    \ repository was created.\n\nExample encoded value:\n\n```\neyJyZWdpc3RyeUlkIjoxfQ==\n\
     ```\n"
   title: PortainerEE API
-  version: 2.42.0
+  version: 2.43.0
 paths:
+  /allowlist/{id}:
+    get:
+      description: 'Retrieve the list of allowed URLs for outbound proxy requests.
+
+        **Access policy**: administrator'
+      operationId: AllowListInspect
+      parameters:
+      - description: AllowList ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/portainer.AllowList'
+        '400':
+          description: Invalid request
+        '403':
+          description: Permission denied
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+      - jwt: []
+      summary: Retrieve the URL allow list
+      tags:
+      - allowlist
+    put:
+      description: 'Update the list of allowed URLs for outbound proxy requests.
+
+        **Access policy**: administrator'
+      operationId: AllowListUpdate
+      parameters:
+      - description: AllowList ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/allowlist.allowListUpdatePayload'
+        description: URL allow list
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/portainer.AllowList'
+        '400':
+          description: Invalid request
+        '403':
+          description: Permission denied
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+      - jwt: []
+      summary: Update the URL allow list
+      tags:
+      - allowlist
   /auth:
     post:
       description: '**Access policy**: public
@@ -185,8 +255,16 @@ paths:
       - backup
   /backup/azure/restore:
     post:
-      description: '**Access policy**: public'
+      description: '**Access policy**: public (requires the X-Setup-Token header on
+        an uninitialized instance unless --no-setup-token is set)'
       operationId: RestoreFromAzureBlob
+      parameters:
+      - description: Setup token (required when instance is uninitialized and --no-setup-token
+          is not set)
+        in: header
+        name: X-Setup-Token
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -199,6 +277,8 @@ paths:
           description: Success
         '400':
           description: Invalid request
+        '403':
+          description: Access denied - invalid or missing setup token
         '500':
           description: Server error
       summary: Restore system state from an Azure Blob Storage backup
@@ -407,8 +487,16 @@ paths:
     post:
       description: 'Triggers a system restore using details of s3 backup
 
-        **Access policy**: public'
+        **Access policy**: public (requires the X-Setup-Token header on an uninitialized
+        instance unless --no-setup-token is set)'
       operationId: RestoreFromS3
+      parameters:
+      - description: Setup token (required when instance is uninitialized and --no-setup-token
+          is not set)
+        in: header
+        name: X-Setup-Token
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -420,6 +508,8 @@ paths:
           description: Success
         '400':
           description: Invalid request
+        '403':
+          description: Access denied - invalid or missing setup token
         '500':
           description: Server error
       summary: Triggers a system restore using details of s3 backup
@@ -721,45 +811,6 @@ paths:
       summary: Upgrade the cluster to the next stable kubernetes version.
       tags:
       - kaas
-  /cloud/gitcredentials:
-    get:
-      description: 'Get shared git credentials
-
-        **Access policy**: Administrator only.'
-      operationId: SharedGitGetAll
-      responses:
-        '201':
-          description: Success
-        '401':
-          description: Unauthorized
-        '500':
-          description: Server error
-      security:
-      - ApiKeyAuth: []
-        jwt: []
-      summary: Get Shared Git Credentials
-      tags:
-      - cloud_credentials
-    post:
-      description: 'Create a shared git credential
-
-        **Access policy**: Administrator only.'
-      operationId: SharedGitCreate
-      responses:
-        '201':
-          description: Success
-        '400':
-          description: Invalid request payload
-        '401':
-          description: Unauthorized
-        '500':
-          description: Server error
-      security:
-      - ApiKeyAuth: []
-        jwt: []
-      summary: Create Shared Git Credential
-      tags:
-      - cloud_credentials
   /cloud/gke/provision:
     post:
       description: 'Provision a new KaaS cluster and create an environment.
@@ -957,7 +1008,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/customtemplates.customTemplateUpdatePayload'
+              $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_customtemplates.customTemplateUpdatePayload'
         description: Template details
         required: true
       responses:
@@ -1001,7 +1052,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/customtemplates.fileResponse'
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_customtemplates.fileResponse'
         '400':
           description: Invalid request
         '404':
@@ -1034,7 +1085,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/customtemplates.fileResponse'
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_customtemplates.fileResponse'
         '400':
           description: Invalid request
         '404':
@@ -1136,7 +1187,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/customtemplates.customTemplateFromGitRepositoryPayload'
+              $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_customtemplates.customTemplateFromGitRepositoryPayload'
         description: Required when using method=repository
         required: true
       responses:
@@ -1166,7 +1217,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/customtemplates.customTemplateFromFileContentPayload'
+              $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_customtemplates.customTemplateFromFileContentPayload'
         description: body
         required: true
       responses:
@@ -1301,7 +1352,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/docker.dashboardResponse'
+                $ref: '#/components/schemas/docker.dashboardData'
         '400':
           description: Bad request
         '500':
@@ -3223,7 +3274,7 @@ paths:
       operationId: EndpointGroupList
       parameters:
       - description: If true, each environment(endpoint) group will include the number
-          of environments(endpoints) associated to it
+          of environments(endpoints) associated to it and breakdown by type
         in: query
         name: size
         schema:
@@ -3249,11 +3300,12 @@ paths:
       description: 'Create a new environment(endpoint) group.
 
         **Access policy**: administrator'
+      operationId: EndpointGroupCreate
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/endpointgroups.endpointGroupCreatePayload'
+              $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_endpointgroups.endpointGroupCreatePayload'
         description: Environment(Endpoint) Group details
         required: true
       responses:
@@ -3302,7 +3354,7 @@ paths:
       tags:
       - endpoint_groups
     get:
-      description: 'Retrieve details abont an environment(endpoint) group.
+      description: 'Retrieve details about an environment(endpoint) group.
 
         **Access policy**: administrator'
       parameters:
@@ -3312,13 +3364,19 @@ paths:
         required: true
         schema:
           type: integer
+      - description: If true, include the number of environments and breakdown by
+          type
+        in: query
+        name: size
+        schema:
+          type: boolean
       responses:
         '200':
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/endpointgroups.decoratedEndpointGroup'
+                $ref: '#/components/schemas/endpointgroups.endpointGroupResponse'
         '400':
           description: Invalid request
         '404':
@@ -3347,7 +3405,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/endpointgroups.endpointGroupUpdatePayload'
+              $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_endpointgroups.endpointGroupUpdatePayload'
         description: EndpointGroup details
         required: true
       responses:
@@ -3509,7 +3567,7 @@ paths:
         in: query
         name: order
         schema:
-          type: integer
+          type: string
       - description: If true, an `X-Update-Available` header will be added to the
           response to indicate if an update is available
         in: query
@@ -3549,6 +3607,44 @@ paths:
       - description: List environments(endpoints) of this type
         in: query
         name: types
+        style: form
+        explode: false
+        schema:
+          type: array
+          items:
+            enum:
+            - 0
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+            - 6
+            - 7
+            type: integer
+      - description: Filter environments by platform type
+        in: query
+        name: platformTypes
+        style: form
+        explode: false
+        schema:
+          type: array
+          items:
+            enum:
+            - 0
+            - 1
+            - 2
+            - 3
+            - 4
+            type: integer
+      - description: If true, return only environments with an outdated agent
+        in: query
+        name: outdated
+        schema:
+          type: boolean
+      - description: Exclude environments of these groups
+        in: query
+        name: excludeGroupIds
         style: form
         explode: false
         schema:
@@ -3637,12 +3733,32 @@ paths:
         name: nameFilter
         schema:
           type: string
+      - description: will return the environments of the specified edge stack
+        in: query
+        name: edgeStackId
+        schema:
+          type: integer
       - description: only applied when edgeStackId exists. Filter the returned environments
           based on their deployment status in the stack (not the environment status!)
         in: query
         name: edgeStackStatus
         schema:
-          type: string
+          type: integer
+          enum:
+          - 0
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          - 11
+          - 12
+          - 13
       - description: List environments(endpoints) of these edge groups
         in: query
         name: edgeGroupIds
@@ -3684,6 +3800,12 @@ paths:
         schema:
           type: array
           items:
+            enum:
+            - applied
+            - failed
+            - in_progress
+            - warning
+            - not_supported
             type: string
       responses:
         '200':
@@ -3692,7 +3814,7 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/portaineree.Endpoint'
+                  $ref: '#/components/schemas/endpoints.endpointResponse'
                 type: array
         '500':
           description: Server error
@@ -3724,6 +3846,14 @@ paths:
                     environment), 4 (Edge agent environment) or 5 (Local Kubernetes
                     Environment)'
                   type: integer
+                  enum:
+                  - 0
+                  - 1
+                  - 2
+                  - 3
+                  - 4
+                  - 5
+                  - 6
                 ContainerEngine:
                   description: 'Container engine used by the environment(endpoint).
                     Value must be one of: ''docker'' or ''podman'''
@@ -3779,11 +3909,9 @@ paths:
                     type is set to 3
                   type: string
                 TagIds:
-                  description: List of tag identifiers to which this environment(endpoint)
-                    is associated
-                  type: array
-                  items:
-                    type: integer
+                  description: JSON-parsable array of tag identifiers to which this
+                    environment(endpoint) is associated
+                  type: string
                 EdgeCheckinInterval:
                   description: The check in interval for edge agent (in seconds)
                   type: integer
@@ -3796,6 +3924,30 @@ paths:
                 EdgeAsyncMode:
                   description: Enable async mode for edge agent
                   type: boolean
+                EdgePingInterval:
+                  description: The ping interval for edge agent (in seconds)
+                  type: integer
+                EdgeSnapshotInterval:
+                  description: The snapshot interval for edge agent (in seconds)
+                  type: integer
+                EdgeCommandInterval:
+                  description: The command interval for edge agent (in seconds)
+                  type: integer
+                CustomTemplateID:
+                  description: 'KaaS: custom template identifier to deploy on environment
+                    creation'
+                  type: integer
+                CustomTemplateContent:
+                  description: 'KaaS: custom template content to deploy on environment
+                    creation'
+                  type: string
+                StackName:
+                  description: 'KaaS: stack name for the custom template deployment'
+                  type: string
+                KubeConfig:
+                  description: Kubernetes configuration file content (base64 encoded).
+                    Required when EndpointCreationType is set to 6 (KubeConfigEnvironment)
+                  type: string
                 Gpus:
                   description: List of GPUs - json stringified array of {name, value}
                     structs
@@ -3969,6 +4121,7 @@ paths:
       description: 'Use this environment(endpoint) to upload TLS files.
 
         **Access policy**: administrator'
+      operationId: EndpointDockerBrowsePut
       parameters:
       - description: Environment(Endpoint) identifier
         in: path
@@ -4052,84 +4205,13 @@ paths:
       summary: fetch docker pull limits
       tags:
       - endpoints
-  /endpoints/{id}/edge/alerts/state:
-    get:
-      description: 'Returns the latest alert rule evaluation state reported by an
-        edge agent
-
-        **Access policy**: authenticated'
-      operationId: EndpointEdgeAlertState
-      parameters:
-      - description: Environment(Endpoint) identifier
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          description: Success
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/metrics.EdgeAlertState'
-        '400':
-          description: Invalid request
-        '500':
-          description: Server error
-      security:
-      - ApiKeyAuth: []
-      - jwt: []
-      summary: Get edge agent alert evaluation state
-      tags:
-      - endpoints
-  /endpoints/{id}/edge/charts:
-    get:
-      description: 'environment(endpoint) for edge agent to get contents of requested
-        Helm charts environment(endpoint)
-
-        **Access policy**: restricted only to Edge environments(endpoints)'
-      operationId: EndpointGetCharts
-      parameters:
-      - description: Environment(Endpoint) identifier
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      - description: JSON encoded list of charts to install
-        in: query
-        name: chartNames
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Success
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/endpointedge.endpointGetChartsResponse'
-        '400':
-          description: Invalid request
-        '403':
-          description: Permission denied to access environment(endpoint)
-        '404':
-          description: Environment(Endpoint) not found
-        '500':
-          description: Server error
-      security:
-      - ApiKeyAuth: []
-      - jwt: []
-      summary: Get environment(endpoint) charts to install
-      tags:
-      - endpoints
-  /endpoints/{id}/edge/charts/statuses:
+  /endpoints/{id}/edge/policies/statuses:
     put:
-      description: 'environment(endpoint) for edge agent to report back installation
-        statuses of Helm charts
+      description: 'environment(endpoint) for edge agent to report back per-policy
+        reconciliation statuses
 
         **Access policy**: restricted only to Edge environments(endpoints)'
-      operationId: EndpointUpdateChartStatuses
+      operationId: EndpointSetPolicyStatuses
       parameters:
       - description: Environment(Endpoint) identifier
         in: path
@@ -4137,6 +4219,13 @@ paths:
         required: true
         schema:
           type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/endpointedge.policyStatusesPayload'
+        description: Per-policy statuses
+        required: true
       responses:
         '204':
           description: Success
@@ -4151,7 +4240,7 @@ paths:
       security:
       - ApiKeyAuth: []
       - jwt: []
-      summary: Update environment(endpoint) policy chart installation statuses
+      summary: Report per-policy status from an edge agent
       tags:
       - endpoints
   /endpoints/{id}/forceupdateservice:
@@ -4892,38 +4981,12 @@ paths:
       summary: Remove multiple environments
       tags:
       - endpoints
-  /endpoints/edge/async:
-    post:
-      description: 'Environment(Endpoint) for edge agent to check status of environment(endpoint)
-
-        **Access policy**: restricted only to Edge environments(endpoints)'
-      operationId: endpointEdgeAsync
-      responses:
-        '200':
-          description: Success
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/endpointedge.EdgeAsyncResponse'
-        '400':
-          description: Invalid request
-        '403':
-          description: Permission denied to access environment(endpoint)
-        '404':
-          description: Environment(Endpoint) not found
-        '500':
-          description: Server error
-      security:
-      - ApiKeyAuth: []
-      - jwt: []
-      summary: Get environment(endpoint) status
-      tags:
-      - endpoints
   /endpoints/edge/generate-key:
     post:
       description: 'Generates a general edge key
 
         **Access policy**: admin'
+      operationId: EndpointEdgeGenerateKey
       requestBody:
         content:
           application/json:
@@ -4941,7 +5004,6 @@ paths:
       summary: Generate an EdgeKey
       tags:
       - edge
-      - endpoints
   /endpoints/edge/trust:
     post:
       description: 'Associate one or more Edge environments, currently in the waiting
@@ -5082,6 +5144,8 @@ paths:
                 $ref: '#/components/schemas/gitops.fileResponse'
         '400':
           description: Invalid request
+        '404':
+          description: Source not found
         '500':
           description: Server error
       security:
@@ -5152,6 +5216,8 @@ paths:
                 $ref: '#/components/schemas/gitops.helmValuesPreviewResponse'
         '400':
           description: Invalid request
+        '404':
+          description: Source not found
         '500':
           description: Server error
       security:
@@ -5205,7 +5271,7 @@ paths:
       description: 'Returns a deduplicated list of git repositories used across all
         GitOps workflows.
 
-        **Access policy**: admin'
+        **Access policy**: authenticated'
       operationId: GitOpsSourcesList
       parameters:
       - description: Search term (matches URL)
@@ -5269,19 +5335,51 @@ paths:
       tags:
       - gitops
   /gitops/sources/{id}:
-    get:
-      description: 'Returns a single GitOps source with its connection settings and
-        linked workflows.
+    delete:
+      description: 'Deletes an existing GitOps source. Returns 409 if the source is
+        referenced by any workflow or custom template.
 
-        **Access policy**: admin'
-      operationId: GitOpsSourceGet
+        **Access policy**: authenticated'
+      operationId: GitOpsSourcesDelete
       parameters:
-      - description: Source ID
+      - description: Source identifier
         in: path
         name: id
         required: true
         schema:
-          type: string
+          type: integer
+      responses:
+        '204':
+          description: Source deleted
+        '400':
+          description: Invalid request
+        '403':
+          description: Access denied
+        '404':
+          description: Source not found
+        '409':
+          description: Source is in use by one or more workflows or custom templates
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+      - jwt: []
+      summary: Delete a source
+      tags:
+      - gitops
+    get:
+      description: 'Returns a single GitOps source with its connection settings and
+        linked workflows.
+
+        **Access policy**: authenticated'
+      operationId: GitOpsSourceGet
+      parameters:
+      - description: Source identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
       responses:
         '200':
           description: OK
@@ -5289,6 +5387,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/sources.SourceDetail'
+        '400':
+          description: Invalid request
         '403':
           description: Access denied
         '404':
@@ -5301,11 +5401,170 @@ paths:
       summary: Get a GitOps source by ID
       tags:
       - gitops
+    put:
+      description: 'Updates an existing GitOps source backed by a Git repository.
+
+        **Access policy**: authenticated'
+      operationId: GitOpsSourcesUpdateGit
+      parameters:
+      - description: Source identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/sources.GitSourceUpdatePayload'
+        description: Git source details
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/portainer.Source'
+        '400':
+          description: Invalid request payload
+        '403':
+          description: Access denied
+        '404':
+          description: Source not found
+        '409':
+          description: A source with this URL and credentials already exists
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+      - jwt: []
+      summary: Update a Git source
+      tags:
+      - gitops
+  /gitops/sources/{id}/access:
+    put:
+      description: 'Updates the access control settings for an existing GitOps source.
+
+        **Access policy**: administrator'
+      operationId: GitOpsSourcesUpdateAccess
+      parameters:
+      - description: Source identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/sources.SourceAccessUpdatePayload'
+        description: Source access control
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/portainer.Source'
+        '400':
+          description: Invalid request payload
+        '403':
+          description: Access denied
+        '404':
+          description: Source not found
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+      - jwt: []
+      summary: Update a GitOps source's access control
+      tags:
+      - gitops
+  /gitops/sources/{id}/test:
+    post:
+      description: 'Tests connectivity for a GitOps source, applying optional overrides
+        to the stored configuration.
+
+        **Access policy**: authenticated'
+      operationId: GitOpsSourcesTestById
+      parameters:
+      - description: Source identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/sources.GitSourceUpdatePayload'
+        description: Optional connection overrides; omitted fields fall back to stored
+          values
+      responses:
+        '200':
+          description: Connection test result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/sources.ConnectionTestResult'
+        '400':
+          description: Invalid request payload
+        '403':
+          description: Access denied
+        '404':
+          description: Source not found
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+      - jwt: []
+      summary: Test the connection of a stored source
+      tags:
+      - gitops
+  /gitops/sources/git:
+    post:
+      description: 'Creates a new GitOps source backed by a Git repository.
+
+        **Access policy**: authenticated'
+      operationId: GitOpsSourcesCreateGit
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/sources.GitSourceCreatePayload'
+        description: Git source details
+        required: true
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/portainer.Source'
+        '400':
+          description: Invalid request payload
+        '403':
+          description: Access denied
+        '409':
+          description: A source with this URL and credentials already exists
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+      - jwt: []
+      summary: Create a Git source
+      tags:
+      - gitops
   /gitops/sources/summary:
     get:
       description: 'Returns a count of sources per status.
 
-        **Access policy**: admin'
+        **Access policy**: authenticated'
       operationId: GitOpsSourcesSummary
       responses:
         '200':
@@ -5322,6 +5581,39 @@ paths:
       - ApiKeyAuth: []
       - jwt: []
       summary: Summarize GitOps source status counts
+      tags:
+      - gitops
+  /gitops/sources/test:
+    post:
+      description: 'Tests connectivity for Git connection details that have not been
+        persisted yet.
+
+        **Access policy**: authenticated'
+      operationId: GitOpsSourcesTest
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/sources.GitSourceCreatePayload'
+        description: Git connection details
+        required: true
+      responses:
+        '200':
+          description: Connection test result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/sources.ConnectionTestResult'
+        '400':
+          description: Invalid request payload
+        '403':
+          description: Access denied
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+      - jwt: []
+      summary: Test a Git source connection
       tags:
       - gitops
   /gitops/workflows:
@@ -6972,7 +7264,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1beta1.NodeMetrics'
+                $ref: '#/components/schemas/v1beta1.NodeMetricsList'
         '400':
           description: Invalid request payload, such as missing required fields or
             fields not meeting validation criteria.
@@ -8492,6 +8784,43 @@ paths:
         environment.
       tags:
       - kubernetes
+  /kubernetes/{id}/nodes:
+    get:
+      description: 'Returns the list of Kubernetes nodes for the selected environment.
+
+        **Access policy**: Authenticated user.'
+      operationId: GetKubernetesNodes
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesNodeResponse'
+                type: array
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource.
+        '500':
+          description: Server error occurred while attempting to retrieve the list
+            of nodes.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Get Kubernetes cluster nodes
+      tags:
+      - kubernetes
   /kubernetes/{id}/nodes/{name}/drain:
     post:
       description: 'Drain a Kubernetes node by safely evicting all pods from the node,
@@ -9884,7 +10213,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/licenses.attachResponse'
+                $ref: '#/components/schemas/licenses.attachData'
       security:
       - ApiKeyAuth: []
       - jwt: []
@@ -10595,7 +10924,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/omni.getClusterResponse'
+                $ref: '#/components/schemas/omni.clusterData'
         '400':
           description: Invalid request
         '500':
@@ -10783,6 +11112,44 @@ paths:
       summary: Update an Omni cluster
       tags:
       - omni
+  /omni/{credentialID}/cluster/validate:
+    post:
+      description: 'Run an Omni dry-run sync of the provided cluster configuration
+        without creating any
+
+        resources in Omni or Portainer. Used by the cluster creation wizard to surface
+
+        configuration errors before provisioning.
+
+        **Access policy**: administrator'
+      operationId: OmniValidateCluster
+      parameters:
+      - description: Cloud credential identifier
+        in: path
+        name: credentialID
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/omni.validateClusterPayload'
+        description: Cluster validation request
+        required: true
+      responses:
+        '204':
+          description: Cluster configuration is valid
+        '400':
+          description: Invalid request or cluster configuration
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Validate an Omni cluster configuration
+      tags:
+      - omni
   /omni/{credentialID}/cluster/version/talos:
     get:
       description: 'Retrieve all supported Talos versions and their compatible Kubernetes
@@ -10839,7 +11206,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/omni.getMachineResponse'
+                $ref: '#/components/schemas/omni.machineData'
         '400':
           description: Invalid request
         '500':
@@ -10917,7 +11284,7 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/omni.getMachineResponse'
+                  $ref: '#/components/schemas/omni.machineData'
                 type: array
         '400':
           description: Invalid request
@@ -11198,6 +11565,34 @@ paths:
       - ApiKeyAuth: []
       - jwt: []
       summary: Get policy metadata
+      tags:
+      - policies
+  /policies/observability-k8s/test:
+    post:
+      description: 'Validates that the supplied OneUptime URL, API key and project
+        ID are accepted by the OneUptime API.
+
+        **Access policy**: administrator'
+      operationId: PolicyTestObservabilityConnection
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policies.testObservabilityConnectionPayload'
+        description: Connection details
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policies.testObservabilityConnectionResponse'
+        '400':
+          description: Invalid payload
+        '500':
+          description: Server error
+      summary: Test OneUptime connection
       tags:
       - policies
   /policies/templates:
@@ -11776,8 +12171,16 @@ paths:
     post:
       description: 'Triggers a system restore using provided backup file
 
-        **Access policy**: public'
+        **Access policy**: public (requires the X-Setup-Token header on an uninitialized
+        instance unless --no-setup-token is set)'
       operationId: Restore
+      parameters:
+      - description: Setup token (required when instance is uninitialized and --no-setup-token
+          is not set)
+        in: header
+        name: X-Setup-Token
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -11790,6 +12193,8 @@ paths:
           description: Success
         '400':
           description: Invalid request
+        '403':
+          description: Access denied - invalid or missing setup token
         '500':
           description: Server error
       summary: Triggers a system restore using provided backup file
@@ -12442,7 +12847,8 @@ paths:
   /stacks/{id}/git:
     post:
       description: 'Update the Git settings in a stack, e.g., RepositoryReferenceName
-        and AutoUpdate
+        and AutoUpdate. When SourceID is set, URL/auth/TLS are taken from the referenced
+        Source.
 
         **Access policy**: authenticated'
       operationId: StackUpdateGit
@@ -12473,7 +12879,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/portaineree.Stack'
+                $ref: '#/components/schemas/stacks.stackResponse'
         '400':
           description: Invalid request
         '403':
@@ -12669,7 +13075,7 @@ paths:
       - stacks
   /stacks/{id}/stop:
     post:
-      description: 'Stops a stopped Stack.
+      description: 'Stop a running Stack.
 
         **Access policy**: authenticated'
       operationId: StackStop
@@ -12706,7 +13112,7 @@ paths:
       security:
       - ApiKeyAuth: []
       - jwt: []
-      summary: Stops a stopped Stack
+      summary: Stop a running Stack
       tags:
       - stacks
   /stacks/create/kubernetes/repository:
@@ -14463,201 +14869,6 @@ paths:
       summary: Inspect a user's effective access on every environment
       tags:
       - users
-  /users/{id}/gitcredentials:
-    get:
-      description: 'Gets all saved git credentials for a user.
-
-        Only the calling user can retrieve git credentials
-
-        **Access policy**: authenticated'
-      operationId: UserGetGitCredentials
-      parameters:
-      - description: User identifier
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: '#/components/schemas/portaineree.GitCredential'
-                type: array
-        '400':
-          description: Invalid request
-        '403':
-          description: Permission denied
-        '404':
-          description: User not found
-        '500':
-          description: Server error
-      security:
-      - ApiKeyAuth: []
-      - jwt: []
-      summary: Get all saved git credentials for a user
-      tags:
-      - users
-    post:
-      description: 'Store a Git Credential for a user.
-
-        Only the calling user can store a git credential for themselves.
-
-        **Access policy**: restricted'
-      operationId: UserCreateGitCredential
-      parameters:
-      - description: User identifier
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/users.userGitCredentialCreatePayload'
-        description: details
-        required: true
-      responses:
-        '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/users.gitCredentialResponse'
-        '400':
-          description: Invalid request
-        '401':
-          description: Unauthorized
-        '403':
-          description: Permission denied
-        '500':
-          description: Server error
-      security:
-      - jwt: []
-      summary: Store a Git Credential for a user
-      tags:
-      - users
-  /users/{id}/gitcredentials/{credentialID}:
-    delete:
-      description: 'Remove a git-credential associated to a user..
-
-        Only the calling user can remove git-credential
-
-        **Access policy**: authenticated'
-      operationId: UserRemoveGitCredential
-      parameters:
-      - description: User identifier
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      - description: Git Credential identifier
-        in: path
-        name: credentialID
-        required: true
-        schema:
-          type: integer
-      responses:
-        '204':
-          description: Success
-        '400':
-          description: Invalid request
-        '403':
-          description: Permission denied
-        '404':
-          description: Not found
-        '500':
-          description: Server error
-      security:
-      - ApiKeyAuth: []
-      - jwt: []
-      summary: Remove a git-credential associated to a user
-      tags:
-      - users
-    get:
-      description: 'Gets the specific saved git credential for a user.
-
-        Only the calling user can retrieve git credential
-
-        **Access policy**: authenticated'
-      operationId: UserGetGitCredential
-      parameters:
-      - description: User identifier
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      - description: Git Credential identifier
-        in: path
-        name: credentialID
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/portaineree.GitCredential'
-        '400':
-          description: Invalid request
-        '403':
-          description: Permission denied
-        '404':
-          description: User not found
-        '500':
-          description: Server error
-      security:
-      - ApiKeyAuth: []
-      - jwt: []
-      summary: Get the specific saved git credential for a user
-      tags:
-      - users
-    put:
-      description: 'Update a git-credential associated to a user..
-
-        Only the calling user can update git-credential
-
-        **Access policy**: authenticated'
-      operationId: UserUpdateGitCredential
-      parameters:
-      - description: User identifier
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      - description: Git Credential identifier
-        in: path
-        name: credentialID
-        required: true
-        schema:
-          type: integer
-      responses:
-        '204':
-          description: Success
-        '400':
-          description: Invalid request
-        '403':
-          description: Permission denied
-        '404':
-          description: Not found
-        '500':
-          description: Server error
-      security:
-      - ApiKeyAuth: []
-      - jwt: []
-      summary: Update a git-credential associated to a user
-      tags:
-      - users
   /users/{id}/helm/repositories:
     get:
       description: 'Inspect a user helm repositories.
@@ -14790,6 +15001,51 @@ paths:
       - ApiKeyAuth: []
       - jwt: []
       summary: Inspect a user memberships
+      tags:
+      - users
+  /users/{id}/memberships/sync:
+    post:
+      description: 'Refresh the target user''s team memberships by querying the configured
+        LDAP/AD or
+
+        OAuth (Microsoft Entra ID) provider. Requires the instance to be configured
+        with
+
+        an external authentication provider. Administrators may sync any user; standard
+
+        users may only sync their own memberships.
+
+        **Access policy**: restricted (admin or self)'
+      operationId: UserMembershipsSync
+      parameters:
+      - description: User identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Updated team memberships
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/portainer.TeamMembership'
+                type: array
+        '400':
+          description: Invalid request or authentication method not eligible for sync
+        '403':
+          description: Permission denied
+        '404':
+          description: User not found
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+      - jwt: []
+      summary: Synchronise a user's team memberships from the configured authentication
+        provider
       tags:
       - users
   /users/{id}/namespaces:
@@ -15003,8 +15259,16 @@ paths:
     post:
       description: 'Initialize the ''admin'' user account.
 
-        **Access policy**: public'
+        **Access policy**: public (requires the X-Setup-Token header on an uninitialized
+        instance unless --no-setup-token is set)'
       operationId: UserAdminInit
+      parameters:
+      - description: Setup token (required when instance is uninitialized and --no-setup-token
+          is not set)
+        in: header
+        name: X-Setup-Token
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -15021,6 +15285,8 @@ paths:
                 $ref: '#/components/schemas/portaineree.User'
         '400':
           description: Invalid request
+        '403':
+          description: Access denied - invalid or missing setup token
         '409':
           description: Admin user already initialized
         '500':
@@ -15099,9 +15365,50 @@ paths:
       summary: Inspect environment authorizations for the current user
       tags:
       - users
+  /users/me/auth/{endpointID}/namespaces:
+    get:
+      description: 'Returns the per-namespace authorization map for the current user
+
+        on the given Kubernetes environment. Empty for admins, for
+
+        non-Kubernetes environments, and when the user has cluster-wide
+
+        namespace access.
+
+        **Access policy**: authenticated'
+      operationId: CurrentUserEndpointNamespaceAuthorizationsInspect
+      parameters:
+      - description: Environment identifier
+        in: path
+        name: endpointID
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/users.CurrentUserEndpointNamespaceAuthResponse'
+        '400':
+          description: Invalid request
+        '403':
+          description: Permission denied
+        '404':
+          description: Environment not found
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+      - jwt: []
+      summary: Inspect per-namespace Kubernetes authorizations for the current user
+      tags:
+      - users
   /webhooks:
     get:
       description: '**Access policy**: authenticated'
+      operationId: WebhookList
       parameters:
       - description: Filters (json-string)
         example: '{"EndpointID":1,"ResourceID":"abc12345-abcd-2345-ab12-58005b4a0260"}'
@@ -15130,6 +15437,7 @@ paths:
       - webhooks
     post:
       description: '**Access policy**: authenticated'
+      operationId: WebhookCreate
       requestBody:
         content:
           application/json:
@@ -15159,6 +15467,7 @@ paths:
   /webhooks/{id}:
     delete:
       description: '**Access policy**: authenticated'
+      operationId: WebhookDelete
       parameters:
       - description: Webhook id
         in: path
@@ -15183,6 +15492,7 @@ paths:
       description: 'Acts on a passed in token UUID to restart the docker service
 
         **Access policy**: public'
+      operationId: WebhookExecute
       parameters:
       - description: Webhook token
         in: path
@@ -15202,6 +15512,7 @@ paths:
       - webhooks
     put:
       description: '**Access policy**: authenticated'
+      operationId: WebhookUpdate
       parameters:
       - description: Webhook id
         in: path
@@ -15238,6 +15549,7 @@ paths:
   /webhooks/{id}/reassign:
     put:
       description: '**Access policy**: authenticated'
+      operationId: WebhookReassign
       parameters:
       - description: Webhook id
         in: path
@@ -15295,6 +15607,9 @@ tags:
 - description: Manage Edge related environment settings
   name: edge
   x-displayName: Edge settings
+- description: Manage an Edge Agent
+  name: edge_agent
+  x-displayName: Edge agent
 - description: Manage Edge Groups
   name: edge_groups
   x-displayName: Edge groups
@@ -15440,6 +15755,7 @@ x-tagGroups:
   - websocket
 - name: Edge Compute
   tags:
+  - edge_agent
   - edge_configs
   - edge_groups
   - edge_jobs
@@ -15534,6 +15850,15 @@ components:
       name: Authorization
       type: apiKey
   schemas:
+    allowlist.allowListUpdatePayload:
+      properties:
+        Entries:
+          items:
+            type: string
+          type: array
+        Mode:
+          $ref: '#/components/schemas/portainer.SSRFMode'
+      type: object
     auth.authenticatePayload:
       properties:
         apiKey:
@@ -15874,313 +16199,7 @@ components:
         gpus:
           type: string
       type: object
-    customtemplates.customTemplateFromFileContentPayload:
-      properties:
-        Description:
-          description: Description of the template
-          example: High performance web server
-          type: string
-        EdgeSettings:
-          $ref: '#/components/schemas/portaineree.CustomTemplateEdgeSettings'
-        EdgeTemplate:
-          description: EdgeTemplate indicates if this template purpose for Edge Stack
-          example: false
-          type: boolean
-        FileContent:
-          description: Content of stack file
-          type: string
-        Logo:
-          description: URL of the template's logo
-          example: https://portainer.io/img/logo.svg
-          type: string
-        Note:
-          description: A note that will be displayed in the UI. Supports HTML content
-          example: This is my <b>custom</b> template
-          type: string
-        Platform:
-          allOf:
-          - $ref: '#/components/schemas/portainer.CustomTemplatePlatform'
-          description: 'Platform associated to the template.
-
-            Valid values are: 1 - ''linux'', 2 - ''windows''
-
-            Required for Docker stacks'
-          enum:
-          - 1
-          - 2
-          example: 1
-        Title:
-          description: Title of the template
-          example: Nginx
-          type: string
-        Type:
-          allOf:
-          - $ref: '#/components/schemas/portainer.StackType'
-          description: 'Type of created stack:
-
-            * 1 - swarm
-
-            * 2 - compose
-
-            * 3 - kubernetes'
-          enum:
-          - 1
-          - 2
-          - 3
-          example: 1
-        Variables:
-          description: Definitions of variables in the stack file
-          items:
-            $ref: '#/components/schemas/portainer.CustomTemplateVariableDefinition'
-          type: array
-      required:
-      - Description
-      - FileContent
-      - Title
-      - Type
-      type: object
-    customtemplates.customTemplateFromGitRepositoryPayload:
-      properties:
-        ComposeFilePathInRepository:
-          default: docker-compose.yml
-          description: Path to the Stack file inside the Git repository
-          example: docker-compose.yml
-          type: string
-        Description:
-          description: Description of the template
-          example: High performance web server
-          type: string
-        EdgeSettings:
-          $ref: '#/components/schemas/portaineree.CustomTemplateEdgeSettings'
-        EdgeTemplate:
-          description: EdgeTemplate indicates if this template purpose for Edge Stack
-          example: false
-          type: boolean
-        IsComposeFormat:
-          description: IsComposeFormat indicates if the Kubernetes template is created
-            from a Docker Compose file
-          example: false
-          type: boolean
-        Logo:
-          description: URL of the template's logo
-          example: https://portainer.io/img/logo.svg
-          type: string
-        Note:
-          description: A note that will be displayed in the UI. Supports HTML content
-          example: This is my <b>custom</b> template
-          type: string
-        Platform:
-          allOf:
-          - $ref: '#/components/schemas/portainer.CustomTemplatePlatform'
-          description: 'Platform associated to the template.
-
-            Valid values are: 1 - ''linux'', 2 - ''windows''
-
-            Required for Docker stacks'
-          enum:
-          - 1
-          - 2
-          example: 1
-        RepositoryAuthentication:
-          description: Use basic authentication to clone the Git repository
-          example: true
-          type: boolean
-        RepositoryAuthorizationType:
-          allOf:
-          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
-          description: RepositoryAuthorizationType is the authorization type to use
-          example: 0
-        RepositoryGitCredentialID:
-          description: 'GitCredentialID used to identify the bound git credential.
-            Required when RepositoryAuthentication
-
-            is true and RepositoryUsername/RepositoryPassword are not provided'
-          example: 0
-          type: integer
-        RepositoryPassword:
-          description: 'Password used in basic authentication. Required when RepositoryAuthentication
-            is true
-
-            and RepositoryGitCredentialID is 0'
-          example: myGitPassword
-          type: string
-        RepositoryProvider:
-          allOf:
-          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
-          description: RepositoryProvider is the provider to use
-          example: 0
-        RepositoryReferenceName:
-          description: Reference name of a Git repository hosting the Stack file
-          example: refs/heads/master
-          type: string
-        RepositoryURL:
-          description: URL of a Git repository hosting the Stack file
-          example: https://github.com/openfaas/faas
-          type: string
-        RepositoryUsername:
-          description: 'Username used in basic authentication. Required when RepositoryAuthentication
-            is true
-
-            and RepositoryGitCredentialID is 0'
-          example: myGitUsername
-          type: string
-        TLSSkipVerify:
-          description: TLSSkipVerify skips SSL verification when cloning the Git repository
-          example: false
-          type: boolean
-        Title:
-          description: Title of the template
-          example: Nginx
-          type: string
-        Type:
-          allOf:
-          - $ref: '#/components/schemas/portainer.StackType'
-          description: 'Type of created stack:
-
-            * 1 - swarm
-
-            * 2 - compose
-
-            * 3 - kubernetes'
-          enum:
-          - 1
-          - 2
-          example: 1
-        Variables:
-          description: Definitions of variables in the stack file
-          items:
-            $ref: '#/components/schemas/portainer.CustomTemplateVariableDefinition'
-          type: array
-      required:
-      - Description
-      - RepositoryURL
-      - Title
-      - Type
-      type: object
-    customtemplates.customTemplateUpdatePayload:
-      properties:
-        ComposeFilePathInRepository:
-          default: docker-compose.yml
-          description: Path to the Stack file inside the Git repository
-          example: docker-compose.yml
-          type: string
-        Description:
-          description: Description of the template
-          example: High performance web server
-          type: string
-        EdgeSettings:
-          $ref: '#/components/schemas/portaineree.CustomTemplateEdgeSettings'
-        EdgeTemplate:
-          description: EdgeTemplate indicates if this template purpose for Edge Stack
-          example: false
-          type: boolean
-        FileContent:
-          description: Content of stack file
-          type: string
-        IsComposeFormat:
-          description: IsComposeFormat indicates if the Kubernetes template is created
-            from a Docker Compose file
-          example: false
-          type: boolean
-        Logo:
-          description: URL of the template's logo
-          example: https://portainer.io/img/logo.svg
-          type: string
-        Note:
-          description: A note that will be displayed in the UI. Supports HTML content
-          example: This is my <b>custom</b> template
-          type: string
-        Platform:
-          allOf:
-          - $ref: '#/components/schemas/portainer.CustomTemplatePlatform'
-          description: 'Platform associated to the template.
-
-            Valid values are: 1 - ''linux'', 2 - ''windows''
-
-            Required for Docker stacks'
-          enum:
-          - 1
-          - 2
-          example: 1
-        RepositoryAuthentication:
-          description: Use authentication to clone the Git repository
-          example: true
-          type: boolean
-        RepositoryAuthorizationType:
-          allOf:
-          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
-          description: RepositoryAuthorizationType is the authorization type to use
-          example: 0
-        RepositoryGitCredentialID:
-          description: 'GitCredentialID used to identify the bound git credential.
-            Required when RepositoryAuthentication
-
-            is true and RepositoryUsername/RepositoryPassword are not provided'
-          example: 0
-          type: integer
-        RepositoryPassword:
-          description: 'Password used in basic authentication or token used in token
-            authentication.
-
-            Required when RepositoryAuthentication is true and RepositoryGitCredentialID
-            is 0'
-          example: myGitPassword
-          type: string
-        RepositoryProvider:
-          allOf:
-          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
-          description: RepositoryProvider is the provider to use
-          example: 0
-        RepositoryReferenceName:
-          description: Reference name of a Git repository hosting the Stack file
-          example: refs/heads/master
-          type: string
-        RepositoryURL:
-          description: URL of a Git repository hosting the Stack file
-          example: https://github.com/openfaas/faas
-          type: string
-        RepositoryUsername:
-          description: 'Username used in basic authentication. Required when RepositoryAuthentication
-            is true
-
-            and RepositoryGitCredentialID is 0. Ignored if RepositoryAuthType is token'
-          example: myGitUsername
-          type: string
-        TLSSkipVerify:
-          description: TLSSkipVerify skips SSL verification when cloning the Git repository
-          example: false
-          type: boolean
-        Title:
-          description: Title of the template
-          example: Nginx
-          type: string
-        Type:
-          allOf:
-          - $ref: '#/components/schemas/portainer.StackType'
-          description: Type of created stack (1 - swarm, 2 - compose, 3 - kubernetes)
-          enum:
-          - 1
-          - 2
-          - 3
-          example: 1
-        Variables:
-          description: Definitions of variables in the stack file
-          items:
-            $ref: '#/components/schemas/portainer.CustomTemplateVariableDefinition'
-          type: array
-      required:
-      - Description
-      - FileContent
-      - RepositoryURL
-      - Title
-      - Type
-      type: object
-    customtemplates.fileResponse:
-      properties:
-        FileContent:
-          type: string
-      type: object
-    docker.dashboardResponse:
+    docker.dashboardData:
       properties:
         containers:
           $ref: '#/components/schemas/stats.ContainerStats'
@@ -16657,7 +16676,9 @@ components:
     edgestacks.stackGitUpdatePayload:
       properties:
         Authentication:
-          $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitAuthentication'
+          allOf:
+          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitAuthentication'
+          description: Deprecated. to update auth, update the related Source instead
         AutoUpdate:
           $ref: '#/components/schemas/portainer.AutoUpdateSettings'
         DeployerOptions:
@@ -17006,9 +17027,23 @@ components:
           description: Edge configurations associated to this environment(endpoint)
           type: object
         policy_chart_summaries:
-          description: Helm charts to be installed on the environment(endpoint)
+          description: "Helm charts in legacy per-chart format (older agents). Mutually\
+            \ exclusive\nwith PolicyStates \u2014 exactly one is populated per response\
+            \ based on agent version."
           items:
             $ref: '#/components/schemas/portainer.PolicyChartSummary'
+          type: array
+        policyStates:
+          description: 'Per-policy desired state (per-policy payload format). Omitted
+            for older agents.
+
+            Pointer: nil = field absent (old agent gets legacy path); non-nil empty
+            slice =
+
+            new agent, no active policies (agent must call Reconcile([]) to remove
+            handlers).'
+          items:
+            $ref: '#/components/schemas/portainer.PolicyDesiredState'
           type: array
         port:
           description: The tunnel port
@@ -17067,6 +17102,13 @@ components:
         edgeKey:
           type: string
       type: object
+    endpointedge.policyStatusesPayload:
+      properties:
+        statuses:
+          items:
+            $ref: '#/components/schemas/portainer.PolicyActualState'
+          type: array
+      type: object
     endpointedge.stackStatusResponse:
       properties:
         ForceRedeploy:
@@ -17096,95 +17138,24 @@ components:
           example: 3
           type: integer
       type: object
-    endpointgroups.decoratedEndpointGroup:
+    endpointgroups.EndpointGroupTypeInfo:
       properties:
-        AuthorizedTeams:
-          items:
-            type: integer
-          type: array
-        AuthorizedUsers:
-          description: Deprecated in DBVersion == 18
-          items:
-            type: integer
-          type: array
-        Description:
-          description: Description associated to the environment(endpoint) group
-          example: Environment(Endpoint) group description
-          type: string
-        Id:
-          description: Environment(Endpoint) group Identifier
-          example: 1
+        Docker:
           type: integer
-        Labels:
-          description: Deprecated fields
-          items:
-            $ref: '#/components/schemas/portainer.Pair'
-          type: array
-        Name:
-          description: Environment(Endpoint) group name
-          example: my-environment-group
-          type: string
-        Policies:
-          items:
-            $ref: '#/components/schemas/policies.GenericPolicy'
-          type: array
-        TagIds:
-          description: List of tags associated to this environment(endpoint) group
-          items:
-            type: integer
-          type: array
-        Tags:
-          description: Deprecated in DBVersion == 22
-          items:
-            type: string
-          type: array
-        TeamAccessPolicies:
-          $ref: '#/components/schemas/portainer.TeamAccessPolicies'
-        UserAccessPolicies:
-          $ref: '#/components/schemas/portainer.UserAccessPolicies'
-      type: object
-    endpointgroups.endpointGroupCreatePayload:
-      properties:
-        AssociatedEndpoints:
-          description: List of environment(endpoint) identifiers that will be part
-            of this group
-          example:
-          - 1
-          - 3
-          items:
-            type: integer
-          type: array
-        Description:
-          description: Environment(Endpoint) group description
-          example: description
-          type: string
-        Name:
-          description: Environment(Endpoint) group name
-          example: my-Environment-group
-          type: string
-        TagIDs:
-          description: List of tag identifiers to which this environment(endpoint)
-            group is associated
-          example:
-          - 1
-          - 2
-          items:
-            type: integer
-          type: array
+        Kubernetes:
+          type: integer
+        Mixed:
+          type: boolean
+        Podman:
+          type: integer
       required:
-      - Name
+      - Docker
+      - Kubernetes
+      - Mixed
+      - Podman
       type: object
     endpointgroups.endpointGroupResponse:
       properties:
-        AuthorizedTeams:
-          items:
-            type: integer
-          type: array
-        AuthorizedUsers:
-          description: Deprecated in DBVersion == 18
-          items:
-            type: integer
-          type: array
         Description:
           description: Description associated to the environment(endpoint) group
           example: Environment(Endpoint) group description
@@ -17193,11 +17164,6 @@ components:
           description: Environment(Endpoint) group Identifier
           example: 1
           type: integer
-        Labels:
-          description: Deprecated fields
-          items:
-            $ref: '#/components/schemas/portainer.Pair'
-          type: array
         Name:
           description: Environment(Endpoint) group name
           example: my-environment-group
@@ -17206,55 +17172,24 @@ components:
           items:
             $ref: '#/components/schemas/policies.GenericPolicy'
           type: array
-        Size:
-          type: integer
         TagIds:
           description: List of tags associated to this environment(endpoint) group
           items:
             type: integer
           type: array
-        Tags:
-          description: Deprecated in DBVersion == 22
-          items:
-            type: string
-          type: array
         TeamAccessPolicies:
           $ref: '#/components/schemas/portainer.TeamAccessPolicies'
+        Total:
+          type: integer
+        TypeInfo:
+          $ref: '#/components/schemas/endpointgroups.EndpointGroupTypeInfo'
         UserAccessPolicies:
           $ref: '#/components/schemas/portainer.UserAccessPolicies'
-      type: object
-    endpointgroups.endpointGroupUpdatePayload:
-      properties:
-        AssociatedEndpoints:
-          description: List of environment(endpoint) identifiers that will be part
-            of this group
-          example:
-          - 1
-          - 3
-          items:
-            type: integer
-          type: array
-        Description:
-          description: Environment(Endpoint) group description
-          example: description
-          type: string
-        Name:
-          description: Environment(Endpoint) group name
-          example: my-environment-group
-          type: string
-        TagIDs:
-          description: List of tag identifiers associated to the environment(endpoint)
-            group
-          example:
-          - 3
-          - 4
-          items:
-            type: integer
-          type: array
-        TeamAccessPolicies:
-          $ref: '#/components/schemas/portainer.TeamAccessPolicies'
-        UserAccessPolicies:
-          $ref: '#/components/schemas/portainer.UserAccessPolicies'
+      required:
+      - Description
+      - Id
+      - Name
+      - Policies
       type: object
     endpoints.EnvironmentSummaryCountsResponse:
       properties:
@@ -17276,6 +17211,17 @@ components:
           type: integer
         up:
           type: integer
+      type: object
+    endpoints.agentResponse:
+      properties:
+        IsOutdated:
+          type: boolean
+        PreviousVersion:
+          example: 1.0.0
+          type: string
+        Version:
+          example: 1.0.0
+          type: string
       type: object
     endpoints.dockerhubStatusResponse:
       properties:
@@ -17322,6 +17268,170 @@ components:
           allOf:
           - $ref: '#/components/schemas/ssl.Certificate'
           description: MTLSCertificate is the X.509 Certificate of the MTLS Certificate
+      type: object
+    endpoints.endpointResponse:
+      properties:
+        Agent:
+          $ref: '#/components/schemas/endpoints.agentResponse'
+        AzureCredentials:
+          $ref: '#/components/schemas/portainer.AzureCredentials'
+        ChangeWindow:
+          allOf:
+          - $ref: '#/components/schemas/portaineree.EndpointChangeWindow'
+          description: GitOps update change window restriction for stacks and apps
+        CloudProvider:
+          allOf:
+          - $ref: '#/components/schemas/portaineree.CloudProvider'
+          description: 'A Kubernetes as a service cloud provider. Only included if
+            this
+
+            endpoint was created using KaaS provisioning.'
+        ComposeSyntaxMaxVersion:
+          description: Maximum version of docker-compose
+          example: '3.8'
+          type: string
+        ContainerEngine:
+          description: ContainerEngine represents the container engine type. This
+            can be 'docker' or 'podman' when interacting directly with these environments,
+            otherwise '' for kubernetes environments.
+          example: docker
+          type: string
+        DeploymentOptions:
+          allOf:
+          - $ref: '#/components/schemas/portaineree.DeploymentOptions'
+          description: Hide manual deployment forms for an environment
+        Edge:
+          $ref: '#/components/schemas/portainer.EnvironmentEdgeSettings'
+        EdgeCheckinInterval:
+          description: The check in interval for edge agent (in seconds)
+          example: 5
+          type: integer
+        EdgeID:
+          description: The identifier of the edge agent associated with this environment(endpoint)
+          type: string
+        EdgeKey:
+          description: The key which is used to map the agent to Portainer
+          type: string
+        EnableGPUManagement:
+          type: boolean
+        EnableImageNotification:
+          type: boolean
+        Gpus:
+          items:
+            $ref: '#/components/schemas/portainer.Pair'
+          type: array
+        GroupId:
+          description: Environment(Endpoint) group identifier
+          example: 1
+          type: integer
+        Heartbeat:
+          description: Heartbeat indicates the heartbeat status of an edge environment
+          example: true
+          type: boolean
+        Id:
+          description: Environment(Endpoint) Identifier
+          example: 1
+          type: integer
+        Kubernetes:
+          allOf:
+          - $ref: '#/components/schemas/portaineree.KubernetesData'
+          description: Associated Kubernetes data
+        LastCheckInDate:
+          description: LastCheckInDate mark last check-in date on checkin
+          type: integer
+        LocalTimeZone:
+          description: LocalTimeZone is the local time zone of the endpoint
+          type: string
+        MTLSStatus:
+          $ref: '#/components/schemas/portaineree.MTLSStatus'
+        Name:
+          description: Environment(Endpoint) name
+          example: my-environment
+          type: string
+        Policies:
+          $ref: '#/components/schemas/portaineree.EndpointPolicies'
+        PublicURL:
+          description: URL or IP address where exposed containers will be reachable
+          example: docker.mydomain.tld:2375
+          type: string
+        SecuritySettings:
+          allOf:
+          - $ref: '#/components/schemas/portainer.EndpointSecuritySettings'
+          description: Environment(Endpoint) specific security settings
+        Snapshots:
+          description: List of snapshots
+          items:
+            $ref: '#/components/schemas/portainer.DockerSnapshot'
+          type: array
+        Status:
+          allOf:
+          - $ref: '#/components/schemas/portainer.EndpointStatus'
+          description: The status of the environment(endpoint) (1 - up, 2 - down,
+            3 - provisioning, 4 - error)
+          enum:
+          - 1
+          - 2
+          - 3
+          - 4
+          example: 1
+        StatusMessage:
+          allOf:
+          - $ref: '#/components/schemas/portaineree.EndpointStatusMessage'
+          description: 'A message that describes the status. Should be included for
+            Status 3
+
+            or 4.'
+        TLSConfig:
+          $ref: '#/components/schemas/portainer.TLSConfiguration'
+        TagIds:
+          description: List of tag identifiers to which this environment(endpoint)
+            is associated
+          items:
+            type: integer
+          type: array
+        TeamAccessPolicies:
+          allOf:
+          - $ref: '#/components/schemas/portainer.TeamAccessPolicies'
+          description: List of team identifiers authorized to connect to this environment(endpoint)
+        Type:
+          allOf:
+          - $ref: '#/components/schemas/portainer.EndpointType'
+          description: Environment(Endpoint) environment(endpoint) type. 1 for a Docker
+            environment(endpoint), 2 for an agent on Docker environment(endpoint)
+            or 3 for an Azure environment(endpoint).
+          example: 1
+        URL:
+          description: URL or IP address of the Docker host associated to this environment(endpoint)
+          example: docker.mydomain.tld:2375
+          type: string
+        UserAccessPolicies:
+          allOf:
+          - $ref: '#/components/schemas/portainer.UserAccessPolicies'
+          description: List of user identifiers authorized to connect to this environment(endpoint)
+        UserTrusted:
+          description: Whether the device has been trusted or not by the user
+          type: boolean
+      required:
+      - Agent
+      - ChangeWindow
+      - ComposeSyntaxMaxVersion
+      - ContainerEngine
+      - Edge
+      - EdgeCheckinInterval
+      - EdgeKey
+      - EnableImageNotification
+      - GroupId
+      - Id
+      - Kubernetes
+      - LastCheckInDate
+      - LocalTimeZone
+      - Name
+      - PublicURL
+      - SecuritySettings
+      - StatusMessage
+      - TLSConfig
+      - Type
+      - URL
       type: object
     endpoints.endpointSettingsUpdatePayload:
       properties:
@@ -17470,11 +17580,8 @@ components:
           type: integer
         StatusMessage:
           properties:
-            Detail:
+            detail:
               example: Error message
-              type: string
-            Summary:
-              example: Error
               type: string
             operation:
               description: '''scale'', ''upgrade'', ''addons'''
@@ -17485,6 +17592,9 @@ components:
               - $ref: '#/components/schemas/portaineree.EndpointOperationStatus'
               description: ''''', ''error'', ''processing'''
               example: error
+            summary:
+              example: Error
+              type: string
           type: object
         TLS:
           description: Require TLS to connect against this environment(endpoint)
@@ -17615,10 +17725,16 @@ components:
         Name:
           type: string
         Permissions:
-          $ref: '#/components/schemas/os.FileMode'
+          type: integer
       type: object
     github_com_portainer_portainer-ee_api_docker_images.Status:
       enum:
+      - processing
+      - outdated
+      - updated
+      - skipped
+      - preparing
+      - error
       - processing
       - outdated
       - updated
@@ -17636,15 +17752,6 @@ components:
     github_com_portainer_portainer-ee_api_git_types.GitAuthentication:
       properties:
         AuthorizationType:
-          type: integer
-        GitCredentialID:
-          description: 'Git credentials identifier when the value is not 0
-
-            When the value is 0, Username and Password are set without using saved
-            credential
-
-            This is introduced since 2.15.0'
-          example: 0
           type: integer
         Password:
           type: string
@@ -17707,6 +17814,311 @@ components:
         URL:
           description: The repo url
           example: https://github.com/portainer/portainer.git
+          type: string
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_customtemplates.customTemplateFromFileContentPayload:
+      properties:
+        Description:
+          description: Description of the template
+          example: High performance web server
+          type: string
+        EdgeSettings:
+          $ref: '#/components/schemas/portaineree.CustomTemplateEdgeSettings'
+        EdgeTemplate:
+          description: EdgeTemplate indicates if this template purpose for Edge Stack
+          example: false
+          type: boolean
+        FileContent:
+          description: Content of stack file
+          type: string
+        Logo:
+          description: URL of the template's logo
+          example: https://portainer.io/img/logo.svg
+          type: string
+        Note:
+          description: A note that will be displayed in the UI. Supports HTML content
+          example: This is my <b>custom</b> template
+          type: string
+        Platform:
+          allOf:
+          - $ref: '#/components/schemas/portainer.CustomTemplatePlatform'
+          description: 'Platform associated to the template.
+
+            Valid values are: 1 - ''linux'', 2 - ''windows''
+
+            Required for Docker stacks'
+          enum:
+          - 1
+          - 2
+          example: 1
+        Title:
+          description: Title of the template
+          example: Nginx
+          type: string
+        Type:
+          allOf:
+          - $ref: '#/components/schemas/portainer.StackType'
+          description: 'Type of created stack:
+
+            * 1 - swarm
+
+            * 2 - compose
+
+            * 3 - kubernetes'
+          enum:
+          - 1
+          - 2
+          - 3
+          example: 1
+        Variables:
+          description: Definitions of variables in the stack file
+          items:
+            $ref: '#/components/schemas/portainer.CustomTemplateVariableDefinition'
+          type: array
+      required:
+      - Description
+      - FileContent
+      - Title
+      - Type
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_customtemplates.customTemplateFromGitRepositoryPayload:
+      properties:
+        ComposeFilePathInRepository:
+          default: docker-compose.yml
+          description: Path to the Stack file inside the Git repository
+          example: docker-compose.yml
+          type: string
+        Description:
+          description: Description of the template
+          example: High performance web server
+          type: string
+        EdgeSettings:
+          $ref: '#/components/schemas/portaineree.CustomTemplateEdgeSettings'
+        EdgeTemplate:
+          description: EdgeTemplate indicates if this template purpose for Edge Stack
+          example: false
+          type: boolean
+        IsComposeFormat:
+          description: IsComposeFormat indicates if the Kubernetes template is created
+            from a Docker Compose file
+          example: false
+          type: boolean
+        Logo:
+          description: URL of the template's logo
+          example: https://portainer.io/img/logo.svg
+          type: string
+        Note:
+          description: A note that will be displayed in the UI. Supports HTML content
+          example: This is my <b>custom</b> template
+          type: string
+        Platform:
+          allOf:
+          - $ref: '#/components/schemas/portainer.CustomTemplatePlatform'
+          description: 'Platform associated to the template.
+
+            Valid values are: 1 - ''linux'', 2 - ''windows''
+
+            Required for Docker stacks'
+          enum:
+          - 1
+          - 2
+          example: 1
+        RepositoryAuthentication:
+          description: 'Deprecated: use SourceID instead. Use basic authentication
+            to clone the Git repository.'
+          example: true
+          type: boolean
+        RepositoryAuthorizationType:
+          allOf:
+          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
+          description: 'Deprecated: use SourceID instead. RepositoryAuthorizationType
+            is the authorization type to use'
+          example: 0
+        RepositoryPassword:
+          description: 'Deprecated: use SourceID instead. Password used in basic authentication.
+            Required when RepositoryAuthentication is true.'
+          example: myGitPassword
+          type: string
+        RepositoryProvider:
+          allOf:
+          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
+          description: 'Deprecated: use SourceID instead. RepositoryProvider is the
+            provider to use'
+          example: 0
+        RepositoryReferenceName:
+          description: Reference name of a Git repository hosting the Stack file
+          example: refs/heads/master
+          type: string
+        RepositoryURL:
+          description: 'Deprecated: use SourceID instead. URL of a Git repository
+            hosting the Stack file.'
+          example: https://github.com/openfaas/faas
+          type: string
+        RepositoryUsername:
+          description: 'Deprecated: use SourceID instead. Username used in basic authentication.
+            Required when RepositoryAuthentication is true.'
+          example: myGitUsername
+          type: string
+        SourceID:
+          description: 'SourceID references an existing Source for git credentials/URL.
+
+            When set, the inline URL and authentication fields are ignored.'
+          example: 1
+          type: integer
+        TLSSkipVerify:
+          description: 'Deprecated: use SourceID instead. TLSSkipVerify skips SSL
+            verification when cloning the Git repository.'
+          example: false
+          type: boolean
+        Title:
+          description: Title of the template
+          example: Nginx
+          type: string
+        Type:
+          allOf:
+          - $ref: '#/components/schemas/portainer.StackType'
+          description: 'Type of created stack:
+
+            * 1 - swarm
+
+            * 2 - compose
+
+            * 3 - kubernetes'
+          enum:
+          - 1
+          - 2
+          example: 1
+        Variables:
+          description: Definitions of variables in the stack file
+          items:
+            $ref: '#/components/schemas/portainer.CustomTemplateVariableDefinition'
+          type: array
+      required:
+      - Description
+      - SourceID
+      - Title
+      - Type
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_customtemplates.customTemplateUpdatePayload:
+      properties:
+        ComposeFilePathInRepository:
+          default: docker-compose.yml
+          description: Path to the Stack file inside the Git repository
+          example: docker-compose.yml
+          type: string
+        Description:
+          description: Description of the template
+          example: High performance web server
+          type: string
+        EdgeSettings:
+          $ref: '#/components/schemas/portaineree.CustomTemplateEdgeSettings'
+        EdgeTemplate:
+          description: EdgeTemplate indicates if this template purpose for Edge Stack
+          example: false
+          type: boolean
+        FileContent:
+          description: Content of stack file
+          type: string
+        IsComposeFormat:
+          description: IsComposeFormat indicates if the Kubernetes template is created
+            from a Docker Compose file
+          example: false
+          type: boolean
+        Logo:
+          description: URL of the template's logo
+          example: https://portainer.io/img/logo.svg
+          type: string
+        Note:
+          description: A note that will be displayed in the UI. Supports HTML content
+          example: This is my <b>custom</b> template
+          type: string
+        Platform:
+          allOf:
+          - $ref: '#/components/schemas/portainer.CustomTemplatePlatform'
+          description: 'Platform associated to the template.
+
+            Valid values are: 1 - ''linux'', 2 - ''windows''
+
+            Required for Docker stacks'
+          enum:
+          - 1
+          - 2
+          example: 1
+        RepositoryAuthentication:
+          description: 'Deprecated: use SourceID instead. Use authentication to clone
+            the Git repository.'
+          example: true
+          type: boolean
+        RepositoryAuthorizationType:
+          allOf:
+          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
+          description: 'Deprecated: use SourceID instead. RepositoryAuthorizationType
+            is the authorization type to use'
+          example: 0
+        RepositoryPassword:
+          description: 'Deprecated: use SourceID instead. Password used in basic authentication
+            or token used in token authentication. Required when RepositoryAuthentication
+            is true.'
+          example: myGitPassword
+          type: string
+        RepositoryProvider:
+          allOf:
+          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
+          description: 'Deprecated: use SourceID instead. RepositoryProvider is the
+            provider to use'
+          example: 0
+        RepositoryReferenceName:
+          description: Reference name of a Git repository hosting the Stack file
+          example: refs/heads/master
+          type: string
+        RepositoryURL:
+          description: 'Deprecated: use SourceID instead. URL of a Git repository
+            hosting the Stack file.'
+          example: https://github.com/openfaas/faas
+          type: string
+        RepositoryUsername:
+          description: 'Deprecated: use SourceID instead. Username used in basic authentication.
+            Required when RepositoryAuthentication is true.'
+          example: myGitUsername
+          type: string
+        SourceID:
+          description: 'SourceID references an existing Source for git credentials/URL.
+
+            When set, the inline URL and authentication fields are ignored.'
+          example: 1
+          type: integer
+        TLSSkipVerify:
+          description: 'Deprecated: use SourceID instead. TLSSkipVerify skips SSL
+            verification when cloning the Git repository.'
+          example: false
+          type: boolean
+        Title:
+          description: Title of the template
+          example: Nginx
+          type: string
+        Type:
+          allOf:
+          - $ref: '#/components/schemas/portainer.StackType'
+          description: Type of created stack (1 - swarm, 2 - compose, 3 - kubernetes)
+          enum:
+          - 1
+          - 2
+          - 3
+          example: 1
+        Variables:
+          description: Definitions of variables in the stack file
+          items:
+            $ref: '#/components/schemas/portainer.CustomTemplateVariableDefinition'
+          type: array
+      required:
+      - Description
+      - FileContent
+      - Title
+      - Type
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_customtemplates.fileResponse:
+      properties:
+        FileContent:
           type: string
       type: object
     github_com_portainer_portainer-ee_api_http_handler_edgestacks.aggregatedStatusesMap:
@@ -17812,39 +18224,39 @@ components:
             type: integer
           type: array
         RepositoryAuthentication:
-          description: Use basic authentication to clone the Git repository
+          description: 'Deprecated: Use SourceID instead. Use basic authentication
+            to clone the Git repository.'
           example: true
           type: boolean
         RepositoryAuthorizationType:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
-          description: RepositoryAuthorizationType is the authorization type to use
+          description: 'Deprecated: Use SourceID instead. RepositoryAuthorizationType
+            is the authorization type to use'
           example: 0
-        RepositoryGitCredentialID:
-          description: GitCredentialID used to identify the binded git credential
-          example: 0
-          type: integer
         RepositoryPassword:
-          description: Password used in basic authentication. Required when RepositoryAuthentication
-            is true.
+          description: 'Deprecated: Use SourceID instead. Password used in basic authentication.
+            Required when RepositoryAuthentication is true.'
           example: myGitPassword
           type: string
         RepositoryProvider:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
-          description: RepositoryProvider is the provider to use
+          description: 'Deprecated: Use SourceID instead. RepositoryProvider is the
+            provider to use'
           example: 0
         RepositoryReferenceName:
           description: Reference name of a Git repository hosting the Stack file
           example: refs/heads/master
           type: string
         RepositoryURL:
-          description: URL of a Git repository hosting the Stack file
+          description: 'Deprecated: Use SourceID instead. URL of a Git repository
+            hosting the Stack file.'
           example: https://github.com/openfaas/faas
           type: string
         RepositoryUsername:
-          description: Username used in basic authentication. Required when RepositoryAuthentication
-            is true.
+          description: 'Deprecated: Use SourceID instead. Username used in basic authentication.
+            Required when RepositoryAuthentication is true.'
           example: myGitUsername
           type: string
         RetryDeploy:
@@ -17854,6 +18266,13 @@ components:
         RetryPeriod:
           description: Retry period specifies the duration, in seconds, for which
             the agent should continue attempting to deploy the stack after a failure
+          type: integer
+        SourceID:
+          description: 'SourceID references an existing Source that provides the git
+            repository URL and credentials.
+
+            When set, the inline URL and authentication fields below are ignored.'
+          example: 1
           type: integer
         StaggerConfig:
           allOf:
@@ -17868,7 +18287,8 @@ components:
           example: false
           type: boolean
         TLSSkipVerify:
-          description: TLSSkipVerify skips SSL verification when cloning the Git repository
+          description: 'Deprecated: Use SourceID instead. TLSSkipVerify skips SSL
+            verification when cloning the Git repository'
           example: false
           type: boolean
         UseManifestNamespaces:
@@ -17877,7 +18297,6 @@ components:
       required:
       - EdgeGroups
       - Name
-      - RepositoryURL
       type: object
     github_com_portainer_portainer-ee_api_http_handler_edgestacks.edgeStackFromStringPayload:
       properties:
@@ -18006,7 +18425,16 @@ components:
         GitConfig:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.RepoConfig'
-          description: The git configuration of a git stack
+          description: 'GitConfig is the git repository configuration for git-backed
+            edge stacks.
+
+            Deprecated: loaded from Source via WorkflowID; kept for DB backwards-compatibility
+            only.
+
+            Non-migration code must not read or write this field; use Source records
+            instead.'
+        GitSourceId:
+          type: integer
         HelmConfig:
           allOf:
           - $ref: '#/components/schemas/portainer.HelmConfig'
@@ -18108,6 +18536,10 @@ components:
             and pull the latest image when the webhook was invoked.
           example: c11fdf23-183e-428a-9bb6-16db01032174
           type: string
+        WorkflowID:
+          description: WorkflowID is the ID of the Workflow that owns the Source for
+            this edge stack.
+          type: integer
       type: object
     github_com_portainer_portainer-ee_api_http_handler_edgestacks.edgeStackStatusSummary:
       properties:
@@ -18196,6 +18628,128 @@ components:
           type: integer
         Version:
           type: integer
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_endpointgroups.endpointGroupCreatePayload:
+      properties:
+        AssociatedEndpoints:
+          description: List of environment(endpoint) identifiers that will be part
+            of this group
+          example:
+          - 1
+          - 3
+          items:
+            type: integer
+          type: array
+        Description:
+          description: Environment(Endpoint) group description
+          example: description
+          type: string
+        Name:
+          description: Environment(Endpoint) group name
+          example: my-Environment-group
+          type: string
+        TagIDs:
+          description: List of tag identifiers to which this environment(endpoint)
+            group is associated
+          example:
+          - 1
+          - 2
+          items:
+            type: integer
+          type: array
+      required:
+      - Name
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_endpointgroups.endpointGroupUpdatePayload:
+      properties:
+        AssociatedEndpoints:
+          description: List of environment(endpoint) identifiers that will be part
+            of this group
+          example:
+          - 1
+          - 3
+          items:
+            type: integer
+          type: array
+        Description:
+          description: Environment(Endpoint) group description
+          example: description
+          type: string
+        Name:
+          description: Environment(Endpoint) group name
+          example: my-environment-group
+          type: string
+        TagIDs:
+          description: List of tag identifiers associated to the environment(endpoint)
+            group
+          example:
+          - 3
+          - 4
+          items:
+            type: integer
+          type: array
+        TeamAccessPolicies:
+          $ref: '#/components/schemas/portainer.TeamAccessPolicies'
+        UserAccessPolicies:
+          $ref: '#/components/schemas/portainer.UserAccessPolicies'
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesNodeResponse:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object.
+
+            Servers should convert recognized schemas to the latest internal value,
+            and
+
+            may reject unrecognized values.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+            +optional'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents.
+
+            Servers may infer this from the endpoint the client submits requests to.
+
+            Cannot be updated.
+
+            In CamelCase.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+            +optional'
+          type: string
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/v1.ObjectMeta'
+          description: 'Standard object''s metadata.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+            +optional'
+        spec:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeSpec'
+          description: 'Spec defines the behavior of a node.
+
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+            +optional'
+        status:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeStatus'
+          description: 'Most recently observed status of the node.
+
+            Populated by the system.
+
+            Read-only.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+            +optional'
       type: object
     github_com_portainer_portainer-ee_api_http_handler_kubernetes.describeResourceResponse:
       properties:
@@ -18311,15 +18865,6 @@ components:
       properties:
         AuthorizationType:
           type: integer
-        GitCredentialID:
-          description: 'Git credentials identifier when the value is not 0
-
-            When the value is 0, Username and Password are set without using saved
-            credential
-
-            This is introduced since 2.15.0'
-          example: 0
-          type: integer
         Password:
           type: string
         Provider:
@@ -18355,6 +18900,34 @@ components:
         URL:
           description: The repo url
           example: https://github.com/portainer/portainer.git
+          type: string
+      type: object
+    github_com_portainer_portainer_api_gitops_workflows.Status:
+      enum:
+      - healthy
+      - syncing
+      - error
+      - paused
+      - unknown
+      type: string
+      x-enum-varnames:
+      - StatusHealthy
+      - StatusSyncing
+      - StatusError
+      - StatusPaused
+      - StatusUnknown
+    github_com_portainer_portainer_api_http_handler_gitops_sources.GitAuthenticationPayload:
+      properties:
+        password:
+          type: string
+        username:
+          type: string
+      type: object
+    github_com_portainer_portainer_api_http_handler_gitops_sources.GitAuthenticationUpdatePayload:
+      properties:
+        password:
+          type: string
+        username:
           type: string
       type: object
     github_com_portainer_portainer_pkg_libhelm_release.Hook:
@@ -18397,31 +18970,47 @@ components:
       type: object
     gitops.helmValuesPreviewPayload:
       properties:
+        TLSSkipVerify:
+          description: 'TLSSkipVerify skips SSL verification when cloning the Git
+            repository
+
+            Deprecated: use SourceID instead'
+          example: false
+          type: boolean
         authorizationType:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
+          description: 'Deprecated: use SourceID instead'
           example: 0
-        gitCredentialID:
-          example: 0
+        createdFromCustomTemplateID:
+          description: CreatedFromCustomTemplateID will fetch auth from this custom
+            template's git settings
           type: integer
+        fromEdgeStack:
+          type: boolean
         password:
-          example: myGitPassword
+          description: 'Deprecated: use SourceID instead'
           type: string
         provider:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
+          description: 'Deprecated: use SourceID instead'
           example: 0
         reference:
           example: refs/heads/main
           type: string
         repository:
-          example: https://github.com/example/charts
+          description: 'Deprecated: use SourceID instead'
           type: string
-        tlsSkipVerify:
-          example: false
-          type: boolean
+        sourceId:
+          description: SourceID resolves URL and auth from the stored source record
+          type: integer
+        stackId:
+          description: StackID will fetch auth from this stack's git settings (edge
+            stack if FromEdgeStack is true)
+          type: integer
         username:
-          example: myGitUsername
+          description: 'Deprecated: use SourceID instead'
           type: string
         valuesFiles:
           description: ValuesFiles is an array of paths to Helm values files (matches
@@ -18433,7 +19022,6 @@ components:
             type: string
           type: array
       required:
-      - repository
       - valuesFiles
       type: object
     gitops.helmValuesPreviewResponse:
@@ -18450,50 +19038,69 @@ components:
     gitops.repositoryFilePreviewPayload:
       properties:
         TLSSkipVerify:
-          description: TLSSkipVerify skips SSL verification when cloning the Git repository
+          description: 'TLSSkipVerify skips SSL verification when cloning the Git
+            repository
+
+            Deprecated: use SourceID instead'
           example: false
           type: boolean
         authorizationType:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
+          description: 'Deprecated: use SourceID instead'
           example: 0
-        gitCredentialID:
-          example: 0
+        createdFromCustomTemplateID:
+          description: CreatedFromCustomTemplateID will fetch auth from this custom
+            template's git settings
           type: integer
+        fromEdgeStack:
+          type: boolean
         password:
-          example: myGitPassword
+          description: 'Deprecated: use SourceID instead'
           type: string
         provider:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
+          description: 'Deprecated: use SourceID instead'
           example: 0
         reference:
           example: refs/heads/master
           type: string
         repository:
-          example: https://github.com/openfaas/faas
+          description: 'Deprecated: use SourceID instead'
           type: string
+        sourceId:
+          description: SourceID resolves URL and auth from the stored source record
+          type: integer
+        stackId:
+          description: StackID will fetch auth from this stack's git settings (edge
+            stack if FromEdgeStack is true)
+          type: integer
         targetFile:
           description: Path to file whose content will be read
           example: docker-compose.yml
           type: string
         username:
-          example: myGitUsername
+          description: 'Deprecated: use SourceID instead'
           type: string
-      required:
-      - repository
       type: object
     gitops.repositoryFileSearchPayload:
       properties:
         TLSSkipVerify:
-          description: TLSSkipVerify skips SSL verification when cloning the Git repository
+          description: 'TLSSkipVerify skips SSL verification when cloning the Git
+            repository
+
+            Deprecated: use SourceID instead'
           example: false
           type: boolean
         authorizationType:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
+          description: 'Deprecated: use SourceID instead'
           example: 0
         createdFromCustomTemplateID:
+          description: CreatedFromCustomTemplateID will fetch auth from this custom
+            template's git settings
           type: integer
         dirOnly:
           description: DirOnly List directories only
@@ -18501,8 +19108,6 @@ components:
           type: boolean
         fromEdgeStack:
           type: boolean
-        gitCredentialID:
-          type: integer
         include:
           description: Allow to provide specific file extension as the search result.
             If empty, the file extensions yml,yaml,hcl,json will be set by default
@@ -18514,10 +19119,12 @@ components:
           example: docker-compose
           type: string
         password:
+          description: 'Deprecated: use SourceID instead'
           type: string
         provider:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
+          description: 'Deprecated: use SourceID instead'
           example: 0
         reference:
           description: Specific Git repository reference. If empty, the reference
@@ -18525,48 +19132,60 @@ components:
           example: refs/heads/develop
           type: string
         repository:
+          description: 'Deprecated: use SourceID instead'
           type: string
-        stackID:
+        sourceId:
+          description: SourceID resolves URL and auth from the stored source record
+          type: integer
+        stackId:
+          description: StackID will fetch auth from this stack's git settings (edge
+            stack if FromEdgeStack is true)
           type: integer
         username:
+          description: 'Deprecated: use SourceID instead'
           type: string
-      required:
-      - repository
       type: object
     gitops.repositoryReferenceListPayload:
       properties:
         TLSSkipVerify:
-          description: TLSSkipVerify skips SSL verification when cloning the Git repository
+          description: 'TLSSkipVerify skips SSL verification when cloning the Git
+            repository
+
+            Deprecated: use SourceID instead'
           example: false
           type: boolean
         authorizationType:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
+          description: 'Deprecated: use SourceID instead'
           example: 0
         createdFromCustomTemplateID:
-          description: CreatedFromCustomTemplateID will fetch refs based on this custom
-            template settings
+          description: CreatedFromCustomTemplateID will fetch auth from this custom
+            template's git settings
           type: integer
         fromEdgeStack:
           type: boolean
-        gitCredentialID:
-          type: integer
         password:
+          description: 'Deprecated: use SourceID instead'
           type: string
         provider:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
+          description: 'Deprecated: use SourceID instead'
           example: 0
         repository:
+          description: 'Deprecated: use SourceID instead'
           type: string
-        stackID:
-          description: StackID will fetch refs based on this stack settings (edge
+        sourceId:
+          description: SourceID resolves URL and auth from the stored source record
+          type: integer
+        stackId:
+          description: StackID will fetch auth from this stack's git settings (edge
             stack if FromEdgeStack is true)
           type: integer
         username:
+          description: 'Deprecated: use SourceID instead'
           type: string
-      required:
-      - repository
       type: object
     helm.gitHelmDryRunPayload:
       properties:
@@ -18584,8 +19203,6 @@ components:
           type: boolean
         repositoryAuthorizationType:
           $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
-        repositoryGitCredentialID:
-          type: integer
         repositoryPassword:
           type: string
         repositoryProvider:
@@ -18598,6 +19215,11 @@ components:
           type: string
         repositoryUsername:
           type: string
+        sourceId:
+          description: 'SourceID resolves URL and auth from the stored Source record.
+
+            When set, the inline Repository/auth/tls fields are ignored.'
+          type: integer
         tlsSkipVerify:
           type: boolean
       type: object
@@ -19356,17 +19978,17 @@ components:
         valid:
           type: boolean
       type: object
-    licenses.attachPayload:
-      properties:
-        key:
-          type: string
-      type: object
-    licenses.attachResponse:
+    licenses.attachData:
       properties:
         conflictingKeys:
           items:
             type: string
           type: array
+      type: object
+    licenses.attachPayload:
+      properties:
+        key:
+          type: string
       type: object
     licenses.deletePayload:
       properties:
@@ -20462,6 +21084,13 @@ components:
       - alertManagerURL
       - silence
       type: object
+    omni.clusterData:
+      properties:
+        metadata:
+          $ref: '#/components/schemas/omni.clusterSpec'
+        status:
+          $ref: '#/components/schemas/omni.clusterStatusSpec'
+      type: object
     omni.clusterSpec:
       properties:
         backup_configuration:
@@ -20534,14 +21163,7 @@ components:
         worker:
           $ref: '#/components/schemas/portaineree.OmniWorker'
       type: object
-    omni.getClusterResponse:
-      properties:
-        metadata:
-          $ref: '#/components/schemas/omni.clusterSpec'
-        status:
-          $ref: '#/components/schemas/omni.clusterStatusSpec'
-      type: object
-    omni.getMachineResponse:
+    omni.machineData:
       properties:
         labels:
           additionalProperties:
@@ -20708,56 +21330,17 @@ components:
             type: string
           type: array
       type: object
-    os.FileMode:
-      format: int32
-      type: integer
-      x-enum-comments:
-        ModeAppend: 'a: append-only'
-        ModeCharDevice: 'c: Unix character device, when ModeDevice is set'
-        ModeDevice: 'D: device file'
-        ModeDir: 'd: is a directory'
-        ModeExclusive: 'l: exclusive use'
-        ModeIrregular: '?: non-regular file; nothing else is known about this file'
-        ModeNamedPipe: 'p: named pipe (FIFO)'
-        ModePerm: Unix permission bits, 0o777
-        ModeSetgid: 'g: setgid'
-        ModeSetuid: 'u: setuid'
-        ModeSocket: 'S: Unix domain socket'
-        ModeSticky: 't: sticky'
-        ModeSymlink: 'L: symbolic link'
-        ModeTemporary: 'T: temporary file; Plan 9 only'
-      x-enum-descriptions:
-      - 'd: is a directory'
-      - 'a: append-only'
-      - 'l: exclusive use'
-      - 'T: temporary file; Plan 9 only'
-      - 'L: symbolic link'
-      - 'D: device file'
-      - 'p: named pipe (FIFO)'
-      - 'S: Unix domain socket'
-      - 'u: setuid'
-      - 'g: setgid'
-      - 'c: Unix character device, when ModeDevice is set'
-      - 't: sticky'
-      - '?: non-regular file; nothing else is known about this file'
-      - ''
-      - Unix permission bits, 0o777
-      x-enum-varnames:
-      - ModeDir
-      - ModeAppend
-      - ModeExclusive
-      - ModeTemporary
-      - ModeSymlink
-      - ModeDevice
-      - ModeNamedPipe
-      - ModeSocket
-      - ModeSetuid
-      - ModeSetgid
-      - ModeCharDevice
-      - ModeSticky
-      - ModeIrregular
-      - ModeType
-      - ModePerm
+    omni.validateClusterPayload:
+      properties:
+        cluster:
+          $ref: '#/components/schemas/portaineree.OmniCluster'
+        clusterConfig:
+          type: string
+        controlPlane:
+          $ref: '#/components/schemas/portaineree.OmniControlPlane'
+        worker:
+          $ref: '#/components/schemas/portaineree.OmniWorker'
+      type: object
     platform.ContainerPlatform:
       enum:
       - Docker
@@ -21151,8 +21734,16 @@ components:
           - registry-k8s
           - registry-docker
           - change-confirmation
+          - cleanup-docker
+          - observability-k8s
         UpdatedAt:
           type: string
+      required:
+      - CreatedAt
+      - Id
+      - Name
+      - Type
+      - UpdatedAt
       type: object
     policies.Policy:
       properties:
@@ -21195,8 +21786,16 @@ components:
           - registry-k8s
           - registry-docker
           - change-confirmation
+          - cleanup-docker
+          - observability-k8s
         UpdatedAt:
           type: string
+      required:
+      - CreatedAt
+      - Id
+      - Name
+      - Type
+      - UpdatedAt
       type: object
     policies.PolicyCategory:
       enum:
@@ -21204,12 +21803,16 @@ components:
       - security
       - setup
       - registry
+      - cleanup
+      - observability
       type: string
       x-enum-varnames:
       - CategoryRBAC
       - CategorySecurity
       - CategorySetup
       - CategoryRegistry
+      - CategoryCleanup
+      - CategoryObservability
     policies.PolicyStatusBreakdown:
       properties:
         Applied:
@@ -21250,6 +21853,7 @@ components:
       - SecurityDocker
       - SetupDocker
       - RegistryDocker
+      - ObservabilityK8s
     policies.conflictInfo:
       properties:
         environmentCount:
@@ -21331,7 +21935,19 @@ components:
           example: Updated Development Policy
           type: string
         Type:
-          $ref: '#/components/schemas/policies.PolicyType'
+          allOf:
+          - $ref: '#/components/schemas/policies.PolicyType'
+          enum:
+          - rbac-k8s
+          - rbac-docker
+          - security-k8s
+          - security-docker
+          - setup-k8s
+          - setup-docker
+          - registry-k8s
+          - registry-docker
+          - change-confirmation
+          - observability-k8s
       type: object
     policies.templateListResponse:
       properties:
@@ -21339,6 +21955,32 @@ components:
           items:
             $ref: '#/components/schemas/policies.PolicyTemplate'
           type: array
+      type: object
+    policies.testObservabilityConnectionPayload:
+      properties:
+        apiKey:
+          type: string
+        autoRotateKey:
+          description: AutoRotateKey when true additionally checks that the key has
+            CreateProjectApiKey permission.
+          type: boolean
+        oneUptimeURL:
+          type: string
+        policyId:
+          description: PolicyID is optional; when set and APIKey is empty, the stored
+            API key is used.
+          type: integer
+        projectID:
+          type: string
+        tlsSkipVerify:
+          type: boolean
+      type: object
+    policies.testObservabilityConnectionResponse:
+      properties:
+        message:
+          type: string
+        success:
+          type: boolean
       type: object
     portainer.APIKey:
       properties:
@@ -21376,6 +22018,62 @@ components:
           description: Role identifier. Reference the role that will be associated
             to this access policy
           example: 1
+          type: integer
+      required:
+      - RoleId
+      type: object
+    portainer.AllowList:
+      properties:
+        Entries:
+          items:
+            type: string
+          type: array
+        Id:
+          $ref: '#/components/schemas/portainer.AllowListKey'
+        Mode:
+          $ref: '#/components/schemas/portainer.SSRFMode'
+      type: object
+    portainer.AllowListKey:
+      enum:
+      - 0
+      type: integer
+      x-enum-varnames:
+      - AllowListSSRF
+    portainer.Artifact:
+      properties:
+        edgeGroups:
+          items:
+            type: integer
+          type: array
+        edgeStackId:
+          type: integer
+        envGroups:
+          items:
+            type: integer
+          type: array
+        envIds:
+          items:
+            type: integer
+          type: array
+        files:
+          items:
+            $ref: '#/components/schemas/portainer.ArtifactFile'
+          type: array
+        stackId:
+          type: integer
+      type: object
+    portainer.ArtifactFile:
+      properties:
+        hash:
+          example: abc123
+          type: string
+        path:
+          example: portainer.yaml
+          type: string
+        ref:
+          example: refs/heads/main
+          type: string
+        sourceId:
           type: integer
       type: object
     portainer.AuthenticationMethod:
@@ -21431,6 +22129,10 @@ components:
           description: Azure tenant ID
           example: 34ddc78d-4fel-2358-8cc1-df84c8o839f5
           type: string
+      required:
+      - ApplicationID
+      - AuthenticationKey
+      - TenantID
       type: object
     portainer.CustomTemplatePlatform:
       enum:
@@ -21576,6 +22278,24 @@ components:
           type: integer
         VolumeCount:
           type: integer
+      required:
+      - ContainerCount
+      - DockerVersion
+      - GpuUseAll
+      - HealthyContainerCount
+      - ImageCount
+      - IsPodman
+      - NodeCount
+      - RunningContainerCount
+      - ServiceCount
+      - StackCount
+      - StoppedContainerCount
+      - Swarm
+      - Time
+      - TotalCPU
+      - TotalMemory
+      - UnhealthyContainerCount
+      - VolumeCount
       type: object
     portainer.DockerSnapshotRaw:
       type: object
@@ -21758,21 +22478,8 @@ components:
       - EdgeStackStatusRollingBack
       - EdgeStackStatusRolledBack
       - EdgeStackStatusCompleted
-    portainer.EndpointAuthorizations:
-      additionalProperties:
-        $ref: '#/components/schemas/portainer.Authorizations'
-      type: object
     portainer.EndpointGroup:
       properties:
-        AuthorizedTeams:
-          items:
-            type: integer
-          type: array
-        AuthorizedUsers:
-          description: Deprecated in DBVersion == 18
-          items:
-            type: integer
-          type: array
         Description:
           description: Description associated to the environment(endpoint) group
           example: Environment(Endpoint) group description
@@ -21781,11 +22488,6 @@ components:
           description: Environment(Endpoint) group Identifier
           example: 1
           type: integer
-        Labels:
-          description: Deprecated fields
-          items:
-            $ref: '#/components/schemas/portainer.Pair'
-          type: array
         Name:
           description: Environment(Endpoint) group name
           example: my-environment-group
@@ -21795,24 +22497,14 @@ components:
           items:
             type: integer
           type: array
-        Tags:
-          description: Deprecated in DBVersion == 22
-          items:
-            type: string
-          type: array
         TeamAccessPolicies:
           $ref: '#/components/schemas/portainer.TeamAccessPolicies'
         UserAccessPolicies:
           $ref: '#/components/schemas/portainer.UserAccessPolicies'
-      type: object
-    portainer.EndpointPostInitMigrations:
-      properties:
-        MigrateGPUs:
-          type: boolean
-        MigrateIngresses:
-          type: boolean
-        MigrateRegistrySASecrets:
-          type: boolean
+      required:
+      - Description
+      - Id
+      - Name
       type: object
     portainer.EndpointSecuritySettings:
       properties:
@@ -21859,6 +22551,17 @@ components:
           description: Whether host management features are enabled
           example: true
           type: boolean
+      required:
+      - allowBindMountsForRegularUsers
+      - allowContainerCapabilitiesForRegularUsers
+      - allowDeviceMappingForRegularUsers
+      - allowHostNamespaceForRegularUsers
+      - allowPrivilegedModeForRegularUsers
+      - allowSecurityOptForRegularUsers
+      - allowStackManagementForRegularUsers
+      - allowSysctlSettingForRegularUsers
+      - allowVolumeBrowserForRegularUsers
+      - enableHostManagementFeatures
       type: object
     portainer.EndpointStatus:
       enum:
@@ -21890,6 +22593,12 @@ components:
       - KubernetesLocalEnvironment
       - AgentOnKubernetesEnvironment
       - EdgeAgentOnKubernetesEnvironment
+    portainer.EnvironmentAgentData:
+      properties:
+        Version:
+          example: 1.0.0
+          type: string
+      type: object
     portainer.EnvironmentEdgeSettings:
       properties:
         AsyncMode:
@@ -21910,6 +22619,11 @@ components:
             [seconds]
           example: 60
           type: integer
+      required:
+      - AsyncMode
+      - CommandInterval
+      - PingInterval
+      - SnapshotInterval
       type: object
     portainer.GithubRegistryData:
       properties:
@@ -22082,6 +22796,9 @@ components:
           type: boolean
         UseServerMetrics:
           type: boolean
+      required:
+      - AllowNoneIngressClass
+      - IngressAvailabilityPerNamespace
       type: object
     portainer.KubernetesData:
       properties:
@@ -22093,6 +22810,9 @@ components:
           items:
             $ref: '#/components/schemas/portainer.KubernetesSnapshot'
           type: array
+      required:
+      - Configuration
+      - Flags
       type: object
     portainer.KubernetesFlags:
       properties:
@@ -22102,6 +22822,10 @@ components:
           type: boolean
         IsServerStorageDetected:
           type: boolean
+      required:
+      - IsServerIngressClassDetected
+      - IsServerMetricsDetected
+      - IsServerStorageDetected
       type: object
     portainer.KubernetesIngressClassConfig:
       properties:
@@ -22115,9 +22839,14 @@ components:
           type: string
         Type:
           type: string
+      required:
+      - Name
+      - Type
       type: object
     portainer.KubernetesSnapshot:
       properties:
+        ClusterType:
+          type: string
         DiagnosticsData:
           $ref: '#/components/schemas/portainer.DiagnosticsData'
         KubernetesVersion:
@@ -22132,6 +22861,12 @@ components:
           type: integer
         TotalMemory:
           type: integer
+      required:
+      - KubernetesVersion
+      - NodeCount
+      - Time
+      - TotalCPU
+      - TotalMemory
       type: object
     portainer.KubernetesStorageClassConfig:
       properties:
@@ -22145,6 +22880,10 @@ components:
           type: string
         Provisioner:
           type: string
+      required:
+      - AllowVolumeExpansion
+      - Name
+      - Provisioner
       type: object
     portainer.LDAPGroupSearchSettings:
       properties:
@@ -22277,6 +23016,9 @@ components:
         value:
           example: value
           type: string
+      required:
+      - name
+      - value
       type: object
     portainer.PerDevConfigsFilterType:
       enum:
@@ -22297,6 +23039,20 @@ components:
         NetworkUsage:
           type: number
       type: object
+    portainer.PolicyActualState:
+      properties:
+        fingerprint:
+          type: string
+        message:
+          type: string
+        policyID:
+          type: integer
+        status:
+          description: applying|applied|failed|removing
+          type: string
+        type:
+          type: string
+      type: object
     portainer.PolicyChartBundle:
       properties:
         ChartName:
@@ -22309,6 +23065,12 @@ components:
           type: string
         Namespace:
           type: string
+        NoWait:
+          description: NoWait disables waiting for pods to be ready after install.
+          type: boolean
+        PolicyID:
+          description: 0 when server hasn't populated the field
+          type: integer
         PreInstallAdoptions:
           items:
             $ref: '#/components/schemas/portainer.ResourceAdoption'
@@ -22318,13 +23080,44 @@ components:
             $ref: '#/components/schemas/portainer.ResourceDeletion'
           type: array
         PreReleaseManifest:
+          description: Base64 YAML kubectl-applied by the agent before Helm install
+            when set (e.g. Gatekeeper gatekeeper-system namespace + PSA labels).
           type: string
+        ReleaseName:
+          type: string
+        WaitForCRDs:
+          description: 'WaitForCRDs lists CRD names that must be registered in API
+            discovery after
+
+            this chart installs before the agent proceeds to the next chart.'
+          items:
+            type: string
+          type: array
       type: object
     portainer.PolicyChartSummary:
       properties:
         ChartName:
           type: string
         Fingerprint:
+          type: string
+        PolicyID:
+          description: 0 when server hasn't populated the field
+          type: integer
+      type: object
+    portainer.PolicyDesiredState:
+      properties:
+        config:
+          description: handler-specific config blob (e.g. HelmPolicyConfig JSON)
+          items:
+            type: integer
+          type: array
+        fingerprint:
+          description: install-affecting only; restore manifest excluded
+          type: string
+        policyID:
+          type: integer
+        type:
+          description: e.g. "helm-k8s"
           type: string
       type: object
     portainer.QuayRegistryData:
@@ -22333,6 +23126,88 @@ components:
           type: string
         UseOrganisation:
           type: boolean
+      type: object
+    portainer.Registry:
+      properties:
+        AccessToken:
+          description: Stores temporary access token
+          type: string
+        AccessTokenExpiry:
+          type: integer
+        Authentication:
+          description: Is authentication against this registry enabled
+          example: true
+          type: boolean
+        AuthorizedTeams:
+          description: Deprecated in DBVersion == 18
+          items:
+            type: integer
+          type: array
+        AuthorizedUsers:
+          description: Deprecated in DBVersion == 18
+          items:
+            type: integer
+          type: array
+        BaseURL:
+          description: Base URL, introduced for ProGet registry
+          example: registry.mydomain.tld:2375
+          type: string
+        Ecr:
+          $ref: '#/components/schemas/portainer.EcrData'
+        Github:
+          $ref: '#/components/schemas/portainer.GithubRegistryData'
+        Gitlab:
+          $ref: '#/components/schemas/portainer.GitlabRegistryData'
+        Id:
+          description: Registry Identifier
+          example: 1
+          type: integer
+        ManagementConfiguration:
+          $ref: '#/components/schemas/portainer.RegistryManagementConfiguration'
+        Name:
+          description: Registry Name
+          example: my-registry
+          type: string
+        Password:
+          description: Password or SecretAccessKey used to authenticate against this
+            registry
+          example: registry_password
+          type: string
+        Quay:
+          $ref: '#/components/schemas/portainer.QuayRegistryData'
+        RegistryAccesses:
+          $ref: '#/components/schemas/portainer.RegistryAccesses'
+        TeamAccessPolicies:
+          allOf:
+          - $ref: '#/components/schemas/portainer.TeamAccessPolicies'
+          description: Deprecated in DBVersion == 31
+        Type:
+          allOf:
+          - $ref: '#/components/schemas/portainer.RegistryType'
+          description: Registry Type (1 - Quay, 2 - Azure, 3 - Custom, 4 - Gitlab,
+            5 - ProGet, 6 - DockerHub, 7 - ECR)
+          enum:
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+        URL:
+          description: URL or IP address of the Docker registry
+          example: registry.mydomain.tld:2375
+          type: string
+        UserAccessPolicies:
+          allOf:
+          - $ref: '#/components/schemas/portainer.UserAccessPolicies'
+          description: 'Deprecated fields
+
+            Deprecated in DBVersion == 31'
+        Username:
+          description: Username or AccessKeyID used to authenticate against this registry
+          example: registry user
+          type: string
       type: object
     portainer.RegistryAccessPolicies:
       properties:
@@ -22523,6 +23398,64 @@ components:
       additionalProperties:
         $ref: '#/components/schemas/portainer.RestoreSettings'
       type: object
+    portainer.SSRFMode:
+      enum:
+      - 0
+      - 1
+      - 2
+      type: integer
+      x-enum-varnames:
+      - SSRFModeOff
+      - SSRFModeAudit
+      - SSRFModeEnforce
+    portainer.Source:
+      properties:
+        administratorsOnly:
+          type: boolean
+        git:
+          $ref: '#/components/schemas/github_com_portainer_portainer_api_git_types.RepoConfig'
+        helm:
+          $ref: '#/components/schemas/portainer.HelmConfig'
+        id:
+          example: 1
+          type: integer
+        lastSync:
+          example: 1587399600
+          type: integer
+        name:
+          example: my-source
+          type: string
+        ownerID:
+          type: integer
+        public:
+          type: boolean
+        registry:
+          $ref: '#/components/schemas/portainer.Registry'
+        teamAccesses:
+          items:
+            type: integer
+          type: array
+        type:
+          allOf:
+          - $ref: '#/components/schemas/portainer.SourceType'
+          example: 1
+        userAccesses:
+          items:
+            type: integer
+          type: array
+      type: object
+    portainer.SourceType:
+      enum:
+      - 0
+      - 1
+      - 2
+      - 3
+      type: integer
+      x-enum-varnames:
+      - _
+      - SourceTypeGit
+      - SourceTypeRegistry
+      - SourceTypeHelm
     portainer.StackDeploymentInfo:
       properties:
         AdditionalFiles:
@@ -22551,6 +23484,9 @@ components:
           description: RepositoryURL is the git repository URL used for deploying
             the stack
           type: string
+        SourceID:
+          description: SourceID is the Source used for deploying the stack
+          type: integer
         Version:
           description: Version is the version of the stack and also is the deployed
             version in edge agent
@@ -22637,6 +23573,9 @@ components:
           description: Skip the verification of the server TLS certificate
           example: false
           type: boolean
+      required:
+      - TLS
+      - TLSSkipVerify
       type: object
     portainer.Tag:
       properties:
@@ -23046,14 +23985,8 @@ components:
           - security
           - environment
         conditionOperator:
-          allOf:
-          - $ref: '#/components/schemas/portaineree.ConditionOperator'
-          enum:
-          - '>'
-          - <
-          - '='
-          - '>='
-          - <=
+          example: '>'
+          type: string
         createdAt:
           type: string
         createdBy:
@@ -23447,6 +24380,8 @@ components:
           items:
             $ref: '#/components/schemas/portainer.CustomTemplateVariableDefinition'
           type: array
+        artifact:
+          $ref: '#/components/schemas/portainer.Artifact'
       type: object
     portaineree.CustomTemplateEdgeSettings:
       properties:
@@ -23519,6 +24454,11 @@ components:
           type: boolean
         overrideGlobalOptions:
           type: boolean
+      required:
+      - hideAddWithForm
+      - hideFileUpload
+      - hideWebEditor
+      - overrideGlobalOptions
       type: object
     portaineree.Edge:
       properties:
@@ -23736,7 +24676,14 @@ components:
         GitConfig:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.RepoConfig'
-          description: The git configuration of a git stack
+          description: 'GitConfig is the git repository configuration for git-backed
+            edge stacks.
+
+            Deprecated: loaded from Source via WorkflowID; kept for DB backwards-compatibility
+            only.
+
+            Non-migration code must not read or write this field; use Source records
+            instead.'
         HelmConfig:
           allOf:
           - $ref: '#/components/schemas/portainer.HelmConfig'
@@ -23836,6 +24783,10 @@ components:
             and pull the latest image when the webhook was invoked.
           example: c11fdf23-183e-428a-9bb6-16db01032174
           type: string
+        WorkflowID:
+          description: WorkflowID is the ID of the Workflow that owns the Source for
+            this edge stack.
+          type: integer
       type: object
     portaineree.EdgeStackDeployerOptions:
       properties:
@@ -23906,15 +24857,6 @@ components:
       properties:
         Agent:
           $ref: '#/components/schemas/portaineree.EnvironmentAgentData'
-        AuthorizedTeams:
-          items:
-            type: integer
-          type: array
-        AuthorizedUsers:
-          description: Deprecated in DBVersion == 18
-          items:
-            type: integer
-          type: array
         AzureCredentials:
           $ref: '#/components/schemas/portainer.AzureCredentials'
         ChangeWindow:
@@ -23934,7 +24876,7 @@ components:
           type: string
         ContainerEngine:
           description: ContainerEngine represents the container engine type. This
-            can be 'docker' or 'podman' when interacting directly with these environmentes,
+            can be 'docker' or 'podman' when interacting directly with these environments,
             otherwise '' for kubernetes environments.
           example: docker
           type: string
@@ -23974,16 +24916,12 @@ components:
           description: Environment(Endpoint) Identifier
           example: 1
           type: integer
-        IsEdgeDevice:
-          description: Deprecated v2.18
-          type: boolean
         Kubernetes:
           allOf:
           - $ref: '#/components/schemas/portaineree.KubernetesData'
           description: Associated Kubernetes data
         LastCheckInDate:
           description: LastCheckInDate mark last check-in date on checkin
-          format: int64
           type: integer
         LocalTimeZone:
           description: LocalTimeZone is the local time zone of the endpoint
@@ -23996,10 +24934,6 @@ components:
           type: string
         Policies:
           $ref: '#/components/schemas/portaineree.EndpointPolicies'
-        PostInitMigrations:
-          allOf:
-          - $ref: '#/components/schemas/portaineree.EndpointPostInitMigrations'
-          description: Whether we need to run any "post init migrations".
         PublicURL:
           description: URL or IP address where exposed containers will be reachable
           example: docker.mydomain.tld:2375
@@ -24016,7 +24950,13 @@ components:
         Status:
           allOf:
           - $ref: '#/components/schemas/portainer.EndpointStatus'
-          description: The status of the environment(endpoint) (1 - up, 2 - down)
+          description: The status of the environment(endpoint) (1 - up, 2 - down,
+            3 - provisioning, 4 - error)
+          enum:
+          - 1
+          - 2
+          - 3
+          - 4
           example: 1
         StatusMessage:
           allOf:
@@ -24025,29 +24965,13 @@ components:
             Status 3
 
             or 4.'
-        TLS:
-          description: 'Deprecated fields
-
-            Deprecated in DBVersion == 4'
-          type: boolean
-        TLSCACert:
-          type: string
-        TLSCert:
-          type: string
         TLSConfig:
           $ref: '#/components/schemas/portainer.TLSConfiguration'
-        TLSKey:
-          type: string
         TagIds:
           description: List of tag identifiers to which this environment(endpoint)
             is associated
           items:
             type: integer
-          type: array
-        Tags:
-          description: Deprecated in DBVersion == 22
-          items:
-            type: string
           type: array
         TeamAccessPolicies:
           allOf:
@@ -24071,6 +24995,27 @@ components:
         UserTrusted:
           description: Whether the device has been trusted or not by the user
           type: boolean
+      required:
+      - Agent
+      - ChangeWindow
+      - ComposeSyntaxMaxVersion
+      - ContainerEngine
+      - Edge
+      - EdgeCheckinInterval
+      - EdgeKey
+      - EnableImageNotification
+      - GroupId
+      - Id
+      - Kubernetes
+      - LastCheckInDate
+      - LocalTimeZone
+      - Name
+      - PublicURL
+      - SecuritySettings
+      - StatusMessage
+      - TLSConfig
+      - Type
+      - URL
       type: object
     portaineree.EndpointChangeWindow:
       properties:
@@ -24083,6 +25028,10 @@ components:
         StartTime:
           example: 1320
           type: string
+      required:
+      - Enabled
+      - EndTime
+      - StartTime
       type: object
     portaineree.EndpointOperationStatus:
       enum:
@@ -24100,6 +25049,8 @@ components:
       properties:
         changeConfirmationPolicy:
           $ref: '#/components/schemas/portaineree.AppliedPolicy'
+        dockerCleanupPolicy:
+          $ref: '#/components/schemas/portaineree.AppliedPolicy'
         dockerRBACPolicy:
           $ref: '#/components/schemas/portaineree.AppliedPolicy'
         dockerRegistryPolicy:
@@ -24107,6 +25058,8 @@ components:
         dockerSecurityPolicy:
           $ref: '#/components/schemas/portaineree.AppliedPolicy'
         dockerSetupPolicy:
+          $ref: '#/components/schemas/portaineree.AppliedPolicy'
+        k8sObservabilityPolicy:
           $ref: '#/components/schemas/portaineree.AppliedPolicy'
         k8sRBACPolicy:
           $ref: '#/components/schemas/portaineree.AppliedPolicy'
@@ -24116,19 +25069,6 @@ components:
           $ref: '#/components/schemas/portaineree.AppliedPolicy'
         k8sSetupPolicy:
           $ref: '#/components/schemas/portaineree.AppliedPolicy'
-      type: object
-    portaineree.EndpointPostInitMigrations:
-      properties:
-        MigrateGPUs:
-          type: boolean
-        MigrateGateKeeper:
-          type: boolean
-        MigrateIngresses:
-          type: boolean
-        MigrateRegistrySASecrets:
-          type: boolean
-        MigrateSecretOwners:
-          type: boolean
       type: object
     portaineree.EndpointStatusMessage:
       properties:
@@ -24164,32 +25104,6 @@ components:
           type: string
       type: object
     portaineree.ExperimentalFeatures:
-      type: object
-    portaineree.GitCredential:
-      properties:
-        authorizationType:
-          allOf:
-          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
-          example: 0
-        creationDate:
-          example: 1587399600
-          type: integer
-        id:
-          example: 1
-          type: integer
-        name:
-          type: string
-        password:
-          type: string
-        provider:
-          allOf:
-          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
-          example: 0
-        userId:
-          example: 1
-          type: integer
-        username:
-          type: string
       type: object
     portaineree.GithubRegistryData:
       properties:
@@ -24255,6 +25169,9 @@ components:
           type: boolean
         UseServerMetrics:
           type: boolean
+      required:
+      - AllowNoneIngressClass
+      - IngressAvailabilityPerNamespace
       type: object
     portaineree.KubernetesData:
       properties:
@@ -24266,6 +25183,9 @@ components:
           items:
             $ref: '#/components/schemas/portainer.KubernetesSnapshot'
           type: array
+      required:
+      - Configuration
+      - Flags
       type: object
     portaineree.LDAPKerberosSettings:
       properties:
@@ -24387,6 +25307,9 @@ components:
           type: boolean
         ok:
           type: boolean
+      required:
+      - enabled
+      - ok
       type: object
     portaineree.OAuthClaimMappings:
       properties:
@@ -24438,102 +25361,102 @@ components:
       type: object
     portaineree.OmniCluster:
       properties:
-        Kind:
+        kind:
           type: string
-        Kubernetes:
+        kubernetes:
           properties:
-            Version:
+            version:
               type: string
           type: object
-        Labels:
+        labels:
           additionalProperties:
             type: string
           type: object
-        Name:
+        name:
           type: string
-        Patches:
+        patches:
           items:
             $ref: '#/components/schemas/portaineree.OmniClusterPatch'
           type: array
-        Talos:
+        talos:
           properties:
-            Version:
+            version:
               type: string
           type: object
       type: object
     portaineree.OmniClusterPatch:
       properties:
-        Annotations:
+        annotations:
           $ref: '#/components/schemas/portaineree.OmniClusterPatchAnnotations'
-        IDOverride:
+        idOverride:
           type: string
-        Inline:
+        inline:
           additionalProperties: {}
           type: object
       type: object
     portaineree.OmniClusterPatchAnnotations:
       properties:
-        Name:
+        name:
           type: string
       type: object
     portaineree.OmniControlPlane:
       properties:
-        Kind:
+        kind:
           type: string
-        Machines:
+        machines:
           items:
             $ref: '#/components/schemas/portaineree.OmniMachine'
           type: array
       type: object
     portaineree.OmniInterface:
       properties:
-        Addresses:
+        addresses:
           items:
             type: string
           type: array
-        DHCP:
+        dhcp:
           type: boolean
-        Interface:
+        interface:
           type: string
-        Routes:
+        routes:
           items:
             $ref: '#/components/schemas/portaineree.OmniInterfaceRoute'
           type: array
       type: object
     portaineree.OmniInterfaceRoute:
       properties:
-        Gateway:
+        gateway:
           type: string
-        Network:
+        network:
           type: string
       type: object
     portaineree.OmniMachine:
       properties:
-        Hostname:
+        hostname:
           type: string
-        Install:
+        install:
           $ref: '#/components/schemas/portaineree.OmniMachineInstall'
-        Interfaces:
+        interfaces:
           items:
             $ref: '#/components/schemas/portaineree.OmniInterface'
           type: array
-        Kind:
+        kind:
           type: string
-        Name:
+        name:
           type: string
-        Nameservers:
+        nameservers:
           items:
             type: string
           type: array
-        Patches:
+        patches:
           items:
             $ref: '#/components/schemas/portaineree.OmniMachinePatch'
           type: array
-        SystemDiskSize:
+        systemDiskSize:
           description: in GiB; drives VolumeConfig EPHEMERAL patch generation, not
             serialized to YAML directly
           type: integer
-        UserDisk:
+        userDisk:
           allOf:
           - $ref: '#/components/schemas/portaineree.OmniUserDisk'
           description: drives user VolumeConfig patch generation, not serialized to
@@ -24541,59 +25464,59 @@ components:
       type: object
     portaineree.OmniMachineInstall:
       properties:
-        Disk:
+        disk:
           type: string
       type: object
     portaineree.OmniMachinePatch:
       properties:
-        IDOverride:
+        idOverride:
           type: string
-        Inline:
+        inline:
           $ref: '#/components/schemas/portaineree.OmniMachinePatchInline'
       type: object
     portaineree.OmniMachinePatchInline:
       properties:
-        Machine:
+        machine:
           $ref: '#/components/schemas/portaineree.OmniMachinePatchMachine'
       type: object
     portaineree.OmniMachinePatchInterface:
       properties:
-        Addresses:
+        addresses:
           items:
             type: string
           type: array
-        DHCP:
+        dhcp:
           type: boolean
-        Interface:
+        interface:
           type: string
-        Routes:
+        routes:
           items:
             $ref: '#/components/schemas/portaineree.OmniMachinePatchRoute'
           type: array
       type: object
     portaineree.OmniMachinePatchMachine:
       properties:
-        Network:
+        network:
           $ref: '#/components/schemas/portaineree.OmniMachinePatchNetwork'
       type: object
     portaineree.OmniMachinePatchNetwork:
       properties:
-        Hostname:
+        hostname:
           type: string
-        Interfaces:
+        interfaces:
           items:
             $ref: '#/components/schemas/portaineree.OmniMachinePatchInterface'
           type: array
-        Nameservers:
+        nameservers:
           items:
             type: string
           type: array
       type: object
     portaineree.OmniMachinePatchRoute:
       properties:
-        Gateway:
+        gateway:
           type: string
-        Network:
+        network:
           type: string
       type: object
     portaineree.OmniUserDisk:
@@ -24606,13 +25529,13 @@ components:
       type: object
     portaineree.OmniWorker:
       properties:
-        Kind:
+        kind:
           type: string
-        Machines:
+        machines:
           items:
             $ref: '#/components/schemas/portaineree.OmniMachine'
           type: array
-        Name:
+        name:
           type: string
       type: object
     portaineree.PolicyStatus:
@@ -25054,7 +25977,14 @@ components:
         GitConfig:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.RepoConfig'
-          description: The git config of this stack
+          description: 'GitConfig is the git repository configuration for git-backed
+            stacks.
+
+            Deprecated: loaded from Source via WorkflowID; kept for DB backwards-compatibility
+            only.
+
+            Non-migration code must not read or write this field; use Source records
+            instead.'
         HelmChartPath:
           description: Path to a Helm chart folder for Helm git deployments
           example: charts/my-app
@@ -25140,6 +26070,10 @@ components:
             and pull the latest image when the webhook was invoked.
           example: c11fdf23-183e-428a-9bb6-16db01032174
           type: string
+        WorkflowID:
+          description: WorkflowID is the ID of the Workflow that owns the Source for
+            this stack.
+          type: integer
       type: object
     portaineree.TalosVersions:
       additionalProperties:
@@ -25164,11 +26098,6 @@ components:
       type: object
     portaineree.User:
       properties:
-        EndpointAuthorizations:
-          allOf:
-          - $ref: '#/components/schemas/portainer.EndpointAuthorizations'
-          description: 'Deprecated: in 2.32, no longer populated - see separate dataservice
-            for UserEndpointAuthorizations'
         Id:
           description: User Identifier
           example: 1
@@ -25188,13 +26117,13 @@ components:
         UseCache:
           example: true
           type: boolean
-        UserTheme:
-          description: 'Deprecated: xxxx'
-          example: dark
-          type: string
         Username:
           example: bob
           type: string
+      required:
+      - Id
+      - Role
+      - Username
       type: object
     portaineree.UserActivityLog:
       properties:
@@ -25222,6 +26151,7 @@ components:
           - light
           - highcontrast
           - auto
+          - ''
           example: dark
           type: string
         subtleUpgradeButton:
@@ -26201,6 +27131,11 @@ components:
             using internal auth mode
           example: 1
           type: integer
+        RequiresSetupToken:
+          description: Whether the setup wizard must send the X-Setup-Token header
+            for admin init / restore
+          example: false
+          type: boolean
         TeamSync:
           description: Whether team sync is enabled
           example: true
@@ -26350,7 +27285,7 @@ components:
           example: 24h
           type: string
         KubectlShellImage:
-          description: Kubec tl Shell Image Name/Tag
+          description: Kubectl Shell Image Name/Tag
           example: portainer/kubectl-shell:latest
           type: string
         LDAPSettings:
@@ -26382,6 +27317,108 @@ components:
           example: 5m
           type: string
       type: object
+    sources.AuthType:
+      enum:
+      - basic
+      - token
+      type: string
+      x-enum-varnames:
+      - AuthTypeBasic
+      - AuthTypeToken
+    sources.AutoUpdateInfo:
+      properties:
+        fetchInterval:
+          type: string
+        mechanism:
+          type: string
+      type: object
+    sources.ConnectionTestResult:
+      properties:
+        error:
+          type: string
+        success:
+          type: boolean
+      type: object
+    sources.GitAuthenticationPayload:
+      properties:
+        password:
+          type: string
+        provider:
+          $ref: '#/components/schemas/sources.Provider'
+        type:
+          $ref: '#/components/schemas/sources.AuthType'
+        username:
+          type: string
+      type: object
+    sources.GitAuthenticationUpdatePayload:
+      properties:
+        password:
+          type: string
+        provider:
+          $ref: '#/components/schemas/sources.Provider'
+        type:
+          $ref: '#/components/schemas/sources.AuthType'
+        username:
+          type: string
+      type: object
+    sources.GitSourceCreatePayload:
+      properties:
+        administratorsOnly:
+          example: true
+          type: boolean
+        authentication:
+          $ref: '#/components/schemas/sources.GitAuthenticationPayload'
+        name:
+          type: string
+        public:
+          example: true
+          type: boolean
+        teamAccesses:
+          items:
+            type: integer
+          type: array
+        tlsSkipVerify:
+          type: boolean
+        url:
+          type: string
+        userAccesses:
+          items:
+            type: integer
+          type: array
+      required:
+      - url
+      type: object
+    sources.GitSourceUpdatePayload:
+      properties:
+        authentication:
+          $ref: '#/components/schemas/sources.GitAuthenticationUpdatePayload'
+        name:
+          type: string
+        referenceName:
+          type: string
+        tlsSkipVerify:
+          type: boolean
+        url:
+          type: string
+      type: object
+    sources.Provider:
+      enum:
+      - custom
+      - github
+      - gitlab
+      - bitbucket-cloud
+      - bitbucket-datacenter
+      - azure-devops
+      - gitea-forgejo
+      type: string
+      x-enum-varnames:
+      - ProviderCustom
+      - ProviderGitHub
+      - ProviderGitLab
+      - ProviderBitbucketCloud
+      - ProviderBitbucketDataCenter
+      - ProviderAzureDevOps
+      - ProviderGiteaForgejo
     sources.Source:
       properties:
         environments:
@@ -26389,28 +27426,60 @@ components:
         error:
           type: string
         id:
-          type: string
+          type: integer
         lastSync:
           type: integer
         name:
           type: string
         provider:
-          $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
+          $ref: '#/components/schemas/sources.Provider'
         status:
-          $ref: '#/components/schemas/workflows.Status'
+          $ref: '#/components/schemas/github_com_portainer_portainer_api_gitops_workflows.Status'
         type:
-          type: string
+          $ref: '#/components/schemas/sources.SourceType'
         url:
           type: string
         usedBy:
           type: integer
+      required:
+      - id
+      - name
+      - status
+      - type
+      - url
+      type: object
+    sources.SourceAccess:
+      properties:
+        public:
+          type: boolean
+        teams:
+          items:
+            type: integer
+          type: array
+        users:
+          items:
+            type: integer
+          type: array
+      type: object
+    sources.SourceAccessUpdatePayload:
+      properties:
+        public:
+          type: boolean
+        teams:
+          items:
+            type: integer
+          type: array
+        users:
+          items:
+            type: integer
+          type: array
       type: object
     sources.SourceDetail:
       properties:
-        authentication:
-          $ref: '#/components/schemas/sources.gitAuthInfo'
+        access:
+          $ref: '#/components/schemas/sources.SourceAccess'
         autoUpdate:
-          $ref: '#/components/schemas/sources.autoUpdateInfo'
+          $ref: '#/components/schemas/sources.AutoUpdateInfo'
         connection:
           $ref: '#/components/schemas/sources.connectionInfo'
         environments:
@@ -26418,17 +27487,17 @@ components:
         error:
           type: string
         id:
-          type: string
+          type: integer
         lastSync:
           type: integer
         name:
           type: string
         provider:
-          $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
+          $ref: '#/components/schemas/sources.Provider'
         status:
-          $ref: '#/components/schemas/workflows.Status'
+          $ref: '#/components/schemas/github_com_portainer_portainer_api_gitops_workflows.Status'
         type:
-          type: string
+          $ref: '#/components/schemas/sources.SourceType'
         url:
           type: string
         usedBy:
@@ -26437,29 +27506,37 @@ components:
           items:
             $ref: '#/components/schemas/workflows.Workflow'
           type: array
+      required:
+      - connection
+      - id
+      - name
+      - status
+      - type
+      - url
       type: object
-    sources.autoUpdateInfo:
-      properties:
-        fetchInterval:
-          type: string
-        mechanism:
-          type: string
-      type: object
+    sources.SourceType:
+      enum:
+      - git
+      - helm
+      - oci
+      type: string
+      x-enum-varnames:
+      - SourceTypeGit
+      - SourceTypeHelm
+      - SourceTypeOCI
     sources.connectionInfo:
       properties:
-        configFilePath:
-          type: string
-        referenceName:
-          type: string
+        authentication:
+          $ref: '#/components/schemas/sources.gitAuthInfo'
         tlsSkipVerify:
           type: boolean
       type: object
     sources.gitAuthInfo:
       properties:
-        provider:
-          $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
         type:
-          $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
+          $ref: '#/components/schemas/sources.AuthType'
+        username:
+          type: string
       type: object
     ssl.Certificate:
       properties:
@@ -26664,59 +27741,62 @@ components:
             type: integer
           type: array
         RepositoryAuthentication:
-          description: Use basic authentication to clone the Git repository
+          description: 'Deprecated: use SourceID instead. Use basic authentication
+            to clone the Git repository.'
           example: true
           type: boolean
         RepositoryAuthorizationType:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
-          description: RepositoryAuthorizationType is the authorization type to use
+          description: 'Deprecated: use SourceID instead. RepositoryAuthorizationType
+            is the authorization type to use.'
           example: 0
-        RepositoryGitCredentialID:
-          description: 'GitCredentialID used to identify the bound git credential.
-            Required when RepositoryAuthentication
-
-            is true and RepositoryUsername/RepositoryPassword are not provided'
-          example: 0
-          type: integer
         RepositoryPassword:
-          description: 'Password used in basic authentication. Required when RepositoryAuthentication
-            is true
+          description: 'Deprecated: use SourceID instead.
 
-            and RepositoryGitCredentialID is 0'
+            Password used in basic authentication. Required when RepositoryAuthentication
+            is true'
           example: myGitPassword
           type: string
         RepositoryProvider:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
-          description: RepositoryProvider is the provider to use
+          description: 'Deprecated: use SourceID instead. RepositoryProvider is the
+            provider to use.'
           example: 0
         RepositoryReferenceName:
           description: Reference name of a Git repository hosting the Stack file
           example: refs/heads/master
           type: string
         RepositoryURL:
-          description: URL of a Git repository hosting the Stack file
+          description: 'Deprecated: use SourceID instead. URL of a Git repository
+            hosting the Stack file.'
           example: https://github.com/openfaas/faas
           type: string
         RepositoryUsername:
-          description: 'Username used in basic authentication. Required when RepositoryAuthentication
-            is true
+          description: 'Deprecated: use SourceID instead.
 
-            and RepositoryGitCredentialID is 0'
+            Username used in basic authentication. Required when RepositoryAuthentication
+            is true'
           example: myGitUsername
           type: string
+        SourceID:
+          description: 'SourceID references an existing Source for git credentials/URL.
+
+            When set, the inline URL and authentication fields are ignored.'
+          example: 1
+          type: integer
         SupportRelativePath:
           description: Whether the stack supports relative path volume
           example: false
           type: boolean
         TLSSkipVerify:
-          description: TLSSkipVerify skips SSL verification when cloning the Git repository
+          description: 'Deprecated: use SourceID instead. TLSSkipVerify skips SSL
+            verification when cloning the Git repository.'
           example: false
           type: boolean
       required:
       - Name
-      - RepositoryURL
       type: object
     stacks.kubernetesGitDeploymentPayload:
       properties:
@@ -26741,25 +27821,44 @@ components:
         Namespace:
           type: string
         RepositoryAuthentication:
+          description: 'Deprecated: use SourceID instead. Use authentication to clone
+            the Git repository.'
           type: boolean
         RepositoryAuthorizationType:
-          $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
-        RepositoryGitCredentialID:
-          type: integer
+          allOf:
+          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
+          description: 'Deprecated: use SourceID instead. Authorization type used
+            to clone the Git repository.'
         RepositoryPassword:
+          description: 'Deprecated: use SourceID instead. Password used in authentication.'
           type: string
         RepositoryProvider:
-          $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
+          allOf:
+          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
+          description: 'Deprecated: use SourceID instead. Provider used to clone the
+            Git repository.'
         RepositoryReferenceName:
+          description: 'Deprecated: use SourceID instead. Reference name of a Git
+            repository hosting the Stack file.'
           type: string
         RepositoryURL:
+          description: 'Deprecated: use SourceID instead. URL of a Git repository
+            hosting the Stack file.'
           type: string
         RepositoryUsername:
+          description: 'Deprecated: use SourceID instead. Username used in authentication.'
           type: string
+        SourceID:
+          description: 'SourceID references an existing Source for git credentials/URL.
+
+            When set, the inline URL and authentication fields are ignored.'
+          example: 1
+          type: integer
         StackName:
           type: string
         TLSSkipVerify:
-          description: TLSSkipVerify skips SSL verification when cloning the Git repository
+          description: 'Deprecated: use SourceID instead. TLSSkipVerify skips SSL
+            verification when cloning the Git repository.'
           example: false
           type: boolean
       type: object
@@ -26839,8 +27938,6 @@ components:
           type: boolean
         RepositoryAuthorizationType:
           $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
-        RepositoryGitCredentialID:
-          type: integer
         RepositoryPassword:
           type: string
         RepositoryProvider:
@@ -26888,21 +27985,36 @@ components:
             type: integer
           type: array
         RepositoryAuthentication:
+          description: 'Deprecated: use SourceID instead. Use basic authentication
+            to clone the Git repository.'
           type: boolean
         RepositoryAuthorizationType:
-          $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
-        RepositoryGitCredentialID:
-          type: integer
+          allOf:
+          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
+          description: 'Deprecated: use SourceID instead. Authorization type for git
+            authentication.'
         RepositoryPassword:
+          description: 'Deprecated: use SourceID instead. Password used in basic authentication.'
           type: string
         RepositoryProvider:
-          $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
+          allOf:
+          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
+          description: 'Deprecated: use SourceID instead. Git provider for OAuth-based
+            authentication.'
         RepositoryReferenceName:
           type: string
         RepositoryURL:
+          description: 'Deprecated: use SourceID instead. URL of a Git repository
+            hosting the Stack file.'
           type: string
         RepositoryUsername:
+          description: 'Deprecated: use SourceID instead. Username used in basic authentication.'
           type: string
+        SourceID:
+          description: 'SourceID references an existing Source for git credentials/URL.
+
+            When set, the inline URL and authentication fields are ignored.'
+          type: integer
         TLSSkipVerify:
           type: boolean
       type: object
@@ -26925,6 +28037,187 @@ components:
           type: string
       required:
       - EndpointID
+      type: object
+    stacks.stackResponse:
+      properties:
+        AdditionalFiles:
+          description: Only applies when deploying stack with multiple files
+          items:
+            type: string
+          type: array
+        AutoUpdate:
+          allOf:
+          - $ref: '#/components/schemas/portainer.AutoUpdateSettings'
+          description: The GitOps update settings of a git stack
+        CreatedBy:
+          description: The username which created this stack
+          example: admin
+          type: string
+        CreatedByUserId:
+          description: The username id which created this stack
+          example: '1'
+          type: string
+        CreationDate:
+          description: The date in unix time when stack was created
+          example: 1587399600
+          type: integer
+        CurrentDeploymentInfo:
+          allOf:
+          - $ref: '#/components/schemas/portainer.StackDeploymentInfo'
+          description: CurrentDeploymentInfo records the git repository state at the
+            time of the last actual deployment.
+        DeploymentStartStatus:
+          allOf:
+          - $ref: '#/components/schemas/portainer.StackStatus'
+          description: 'DeploymentStartStatus is the stack status captured when the
+            current
+
+            deployment starts. It is used by deployment logic during the current
+
+            deployment attempt and is cleared/replaced when a new deployment begins.'
+          example: 1
+        DeploymentStatus:
+          description: 'DeploymentStatus records the status progression of the current
+            deployment.
+
+            Cleared when a new deployment starts.'
+          items:
+            $ref: '#/components/schemas/portainer.StackDeploymentStatus'
+          type: array
+        EndpointId:
+          description: Environment(Endpoint) identifier. Reference the environment(endpoint)
+            that will be used for deployment
+          example: 1
+          type: integer
+        EntryPoint:
+          description: 'EntryPoint is the path to the config file relative to the
+            project root.
+
+            NOTE: For git stacks this mirrors GitConfig.ConfigFilePath and the two
+            are kept in sync
+
+            by stackUpdateGit. The deploy command builder (compose_unpacker_cmd_builder)
+            uses this
+
+            field directly; Kubernetes deploy and git clone operations use GitConfig.ConfigFilePath.'
+          example: docker-compose.yml
+          type: string
+        Env:
+          description: A list of environment(endpoint) variables used during stack
+            deployment
+          items:
+            $ref: '#/components/schemas/portainer.Pair'
+          type: array
+        FilesystemPath:
+          description: Network(Swarm) or local(Standalone) filesystem path
+          example: /tmp
+          type: string
+        FromAppTemplate:
+          description: Whether the stack is from a app template
+          example: false
+          type: boolean
+        GitConfig:
+          allOf:
+          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.RepoConfig'
+          description: 'GitConfig is the git repository configuration for git-backed
+            stacks.
+
+            Deprecated: loaded from Source via WorkflowID; kept for DB backwards-compatibility
+            only.
+
+            Non-migration code must not read or write this field; use Source records
+            instead.'
+        GitSourceId:
+          type: integer
+        HelmChartPath:
+          description: Path to a Helm chart folder for Helm git deployments
+          example: charts/my-app
+          type: string
+        HelmValuesFiles:
+          description: Array of paths to Helm values YAML files for Helm git deployments
+          example:
+          - '[''values/prod.yaml'''
+          - ' ''values/secrets.yaml'']'
+          items:
+            type: string
+          type: array
+        Id:
+          description: Stack Identifier
+          example: 1
+          type: integer
+        IsDetachedFromGit:
+          description: Whether the stack is detached from git
+          example: false
+          type: boolean
+        Name:
+          description: Stack name
+          example: myStack
+          type: string
+        Namespace:
+          description: Kubernetes namespace if stack is a kube application
+          example: default
+          type: string
+        Option:
+          allOf:
+          - $ref: '#/components/schemas/portainer.StackOption'
+          description: The stack deployment option
+        PreviousDeploymentInfo:
+          allOf:
+          - $ref: '#/components/schemas/portainer.StackDeploymentInfo'
+          description: The previous deployment info of the stack
+        ProjectPath:
+          description: Path on disk to the repository hosting the Stack file
+          example: /data/compose/myStack_jpofkc0i9uo9wtx1zesuk649w
+          type: string
+        Registries:
+          description: List of Registries to use for this stack
+          items:
+            type: integer
+          type: array
+        ResourceControl:
+          $ref: '#/components/schemas/portainer.ResourceControl'
+        StackFileVersion:
+          description: StackFileVersion indicates the stack file version, such as
+            yaml, hcl, and manifest
+          example: 1
+          type: integer
+        Status:
+          allOf:
+          - $ref: '#/components/schemas/portainer.StackStatus'
+          description: Stack status (1 - active, 2 - inactive, 3 - deploying, 4 -
+            error)
+          example: 1
+        SupportRelativePath:
+          description: If stack support relative path volume
+          example: false
+          type: boolean
+        SwarmId:
+          description: Cluster identifier of the Swarm cluster where the stack is
+            deployed
+          example: jpofkc0i9uo9wtx1zesuk649w
+          type: string
+        Type:
+          allOf:
+          - $ref: '#/components/schemas/portainer.StackType'
+          description: Stack type. 1 for a Swarm stack, 2 for a Compose stack
+          example: 2
+        UpdateDate:
+          description: The date in unix time when stack was last updated
+          example: 1587399600
+          type: integer
+        UpdatedBy:
+          description: The username which last updated this stack
+          example: bob
+          type: string
+        Webhook:
+          description: A UUID to identify a webhook. The stack will be force updated
+            and pull the latest image when the webhook was invoked.
+          example: c11fdf23-183e-428a-9bb6-16db01032174
+          type: string
+        WorkflowID:
+          description: WorkflowID is the ID of the Workflow that owns the Source for
+            this stack.
+          type: integer
       type: object
     stacks.swarmStackFromFileContentPayload:
       properties:
@@ -27006,48 +28299,51 @@ components:
             type: integer
           type: array
         RepositoryAuthentication:
-          description: Use basic authentication to clone the Git repository
+          description: 'Deprecated: use SourceID instead. Use basic authentication
+            to clone the Git repository.'
           example: true
           type: boolean
         RepositoryAuthorizationType:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
-          description: RepositoryAuthorizationType is the authorization type to use
+          description: 'Deprecated: use SourceID instead. RepositoryAuthorizationType
+            is the authorization type to use.'
           example: 0
-        RepositoryGitCredentialID:
-          description: 'GitCredentialID used to identify the bound git credential.
-            Required when RepositoryAuthentication
-
-            is true and RepositoryUsername/RepositoryPassword are not provided'
-          example: 0
-          type: integer
         RepositoryPassword:
-          description: 'Password used in basic authentication. Required when RepositoryAuthentication
-            is true
+          description: 'Deprecated: use SourceID instead.
 
-            and RepositoryGitCredentialID is 0'
+            Password used in basic authentication. Required when RepositoryAuthentication
+            is true'
           example: myGitPassword
           type: string
         RepositoryProvider:
           allOf:
           - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
-          description: RepositoryProvider is the provider to use
+          description: 'Deprecated: use SourceID instead. RepositoryProvider is the
+            provider to use.'
           example: 0
         RepositoryReferenceName:
           description: Reference name of a Git repository hosting the Stack file
           example: refs/heads/master
           type: string
         RepositoryURL:
-          description: URL of a Git repository hosting the Stack file
+          description: 'Deprecated: use SourceID instead. URL of a Git repository
+            hosting the Stack file.'
           example: https://github.com/openfaas/faas
           type: string
         RepositoryUsername:
-          description: 'Username used in basic authentication. Required when RepositoryAuthentication
-            is true
+          description: 'Deprecated: use SourceID instead.
 
-            and RepositoryGitCredentialID is 0'
+            Username used in basic authentication. Required when RepositoryAuthentication
+            is true'
           example: myGitUsername
           type: string
+        SourceID:
+          description: 'SourceID references an existing Source for git credentials/URL.
+
+            When set, the inline URL and authentication fields are ignored.'
+          example: 1
+          type: integer
         SupportRelativePath:
           description: Whether the stack suppors relative path volume
           example: false
@@ -27057,12 +28353,12 @@ components:
           example: jpofkc0i9uo9wtx1zesuk649w
           type: string
         TLSSkipVerify:
-          description: TLSSkipVerify skips SSL verification when cloning the Git repository
+          description: 'Deprecated: use SourceID instead. TLSSkipVerify skips SSL
+            verification when cloning the Git repository.'
           example: false
           type: boolean
       required:
       - Name
-      - RepositoryURL
       - SwarmID
       type: object
     stacks.updateStackPayload:
@@ -27387,6 +28683,13 @@ components:
         Authorizations:
           $ref: '#/components/schemas/portainer.Authorizations'
       type: object
+    users.CurrentUserEndpointNamespaceAuthResponse:
+      properties:
+        namespaceAuthorizations:
+          additionalProperties:
+            $ref: '#/components/schemas/portainer.Authorizations'
+          type: object
+      type: object
     users.EffectiveAccessEntry:
       properties:
         accessLocation:
@@ -27454,11 +28757,6 @@ components:
       - Password
       - Username
       type: object
-    users.gitCredentialResponse:
-      properties:
-        gitCredential:
-          $ref: '#/components/schemas/users.shadowedGitCredential'
-      type: object
     users.helmUserRepositoryResponse:
       properties:
         GlobalRepository:
@@ -27473,34 +28771,6 @@ components:
         additionalProperties:
           $ref: '#/components/schemas/portainer.Authorizations'
         type: object
-      type: object
-    users.shadowedGitCredential:
-      properties:
-        authorizationType:
-          allOf:
-          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
-          description: Shadow to include the AuthType even if it's empty
-          example: 0
-        creationDate:
-          example: 1587399600
-          type: integer
-        id:
-          example: 1
-          type: integer
-        name:
-          type: string
-        password:
-          type: string
-        provider:
-          allOf:
-          - $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
-          description: Shadow to include Provider even if it's empty
-          example: 0
-        userId:
-          example: 1
-          type: integer
-        username:
-          type: string
       type: object
     users.themePayload:
       properties:
@@ -27555,26 +28825,6 @@ components:
       - Password
       - Role
       - Username
-      type: object
-    users.userGitCredentialCreatePayload:
-      properties:
-        authorizationType:
-          $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitCredentialAuthType'
-        name:
-          example: my-credential
-          type: string
-        password:
-          type: string
-        provider:
-          $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_git_types.GitProvider'
-        username:
-          type: string
-      required:
-      - authorizationType
-      - name
-      - password
-      - provider
-      - username
       type: object
     users.userUpdatePasswordPayload:
       properties:
@@ -27660,6 +28910,16 @@ components:
       - AppArmorProfileTypeUnconfined
       - AppArmorProfileTypeRuntimeDefault
       - AppArmorProfileTypeLocalhost
+    v1.AttachedVolume:
+      properties:
+        devicePath:
+          description: DevicePath represents the device path where the volume should
+            be available
+          type: string
+        name:
+          description: Name of the attached volume
+          type: string
+      type: object
     v1.CSIPersistentVolumeSource:
       properties:
         controllerExpandSecretRef:
@@ -27853,6 +29113,40 @@ components:
 
             +optional'
           type: boolean
+      type: object
+    v1.ConfigMapNodeConfigSource:
+      properties:
+        kubeletConfigKey:
+          description: 'KubeletConfigKey declares which key of the referenced ConfigMap
+            corresponds to the KubeletConfiguration structure
+
+            This field is required in all cases.'
+          type: string
+        name:
+          description: 'Name is the metadata.name of the referenced ConfigMap.
+
+            This field is required in all cases.'
+          type: string
+        namespace:
+          description: 'Namespace is the metadata.namespace of the referenced ConfigMap.
+
+            This field is required in all cases.'
+          type: string
+        resourceVersion:
+          description: 'ResourceVersion is the metadata.ResourceVersion of the referenced
+            ConfigMap.
+
+            This field is forbidden in Node.Spec, and required in Node.Status.
+
+            +optional'
+          type: string
+        uid:
+          description: 'UID is the metadata.UID of the referenced ConfigMap.
+
+            This field is forbidden in Node.Spec, and required in Node.Status.
+
+            +optional'
+          type: string
       type: object
     v1.Container:
       properties:
@@ -28295,6 +29589,25 @@ components:
             +optional'
           type: string
       type: object
+    v1.ContainerImage:
+      properties:
+        names:
+          description: 'Names by which this image is known.
+
+            e.g. ["kubernetes.example/hyperkube:v1.0.7", "cloud-vendor.registry.example/cloud-vendor/hyperkube:v1.0.7"]
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+        sizeBytes:
+          description: 'The size of the image in bytes.
+
+            +optional'
+          type: integer
+      type: object
     v1.ContainerPort:
       properties:
         containerPort:
@@ -28425,6 +29738,12 @@ components:
       x-enum-varnames:
       - ContainerRestartRuleOnExitCodesOpIn
       - ContainerRestartRuleOnExitCodesOpNotIn
+    v1.DaemonEndpoint:
+      properties:
+        Port:
+          description: Port number of the given endpoint.
+          type: integer
+      type: object
     v1.Descriptor:
       properties:
         annotations:
@@ -28470,21 +29789,6 @@ components:
           items:
             type: string
           type: array
-      type: object
-    v1.Duration:
-      properties:
-        time.Duration:
-          format: int64
-          type: integer
-          x-enum-varnames:
-          - minDuration
-          - maxDuration
-          - Nanosecond
-          - Microsecond
-          - Millisecond
-          - Second
-          - Minute
-          - Hour
       type: object
     v1.EnvFromSource:
       properties:
@@ -29076,6 +30380,533 @@ components:
             More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/
 
             +optional'
+      type: object
+    v1.NodeAddress:
+      properties:
+        address:
+          description: The node address.
+          type: string
+        type:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeAddressType'
+          description: Node address type, one of Hostname, ExternalIP or InternalIP.
+      type: object
+    v1.NodeAddressType:
+      enum:
+      - Hostname
+      - InternalIP
+      - ExternalIP
+      - InternalDNS
+      - ExternalDNS
+      type: string
+      x-enum-varnames:
+      - NodeHostName
+      - NodeInternalIP
+      - NodeExternalIP
+      - NodeInternalDNS
+      - NodeExternalDNS
+    v1.NodeCondition:
+      properties:
+        lastHeartbeatTime:
+          description: 'Last time we got an update on a given condition.
+
+            +optional'
+          type: string
+        lastTransitionTime:
+          description: 'Last time the condition transit from one status to another.
+
+            +optional'
+          type: string
+        message:
+          description: 'Human readable message indicating details about last transition.
+
+            +optional'
+          type: string
+        reason:
+          description: '(brief) reason for the condition''s last transition.
+
+            +optional'
+          type: string
+        status:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_core_v1.ConditionStatus'
+          description: Status of the condition, one of True, False, Unknown.
+        type:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeConditionType'
+          description: Type of node condition.
+      type: object
+    v1.NodeConditionType:
+      enum:
+      - Ready
+      - MemoryPressure
+      - DiskPressure
+      - PIDPressure
+      - NetworkUnavailable
+      type: string
+      x-enum-varnames:
+      - NodeReady
+      - NodeMemoryPressure
+      - NodeDiskPressure
+      - NodePIDPressure
+      - NodeNetworkUnavailable
+    v1.NodeConfigSource:
+      properties:
+        configMap:
+          allOf:
+          - $ref: '#/components/schemas/v1.ConfigMapNodeConfigSource'
+          description: ConfigMap is a reference to a Node's ConfigMap
+      type: object
+    v1.NodeConfigStatus:
+      properties:
+        active:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeConfigSource'
+          description: 'Active reports the checkpointed config the node is actively
+            using.
+
+            Active will represent either the current version of the Assigned config,
+
+            or the current LastKnownGood config, depending on whether attempting to
+            use the
+
+            Assigned config results in an error.
+
+            +optional'
+        assigned:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeConfigSource'
+          description: 'Assigned reports the checkpointed config the node will try
+            to use.
+
+            When Node.Spec.ConfigSource is updated, the node checkpoints the associated
+
+            config payload to local disk, along with a record indicating intended
+
+            config. The node refers to this record to choose its config checkpoint,
+            and
+
+            reports this record in Assigned. Assigned only updates in the status after
+
+            the record has been checkpointed to disk. When the Kubelet is restarted,
+
+            it tries to make the Assigned config the Active config by loading and
+
+            validating the checkpointed payload identified by Assigned.
+
+            +optional'
+        error:
+          description: 'Error describes any problems reconciling the Spec.ConfigSource
+            to the Active config.
+
+            Errors may occur, for example, attempting to checkpoint Spec.ConfigSource
+            to the local Assigned
+
+            record, attempting to checkpoint the payload associated with Spec.ConfigSource,
+            attempting
+
+            to load or validate the Assigned config, etc.
+
+            Errors may occur at different points while syncing config. Earlier errors
+            (e.g. download or
+
+            checkpointing errors) will not result in a rollback to LastKnownGood,
+            and may resolve across
+
+            Kubelet retries. Later errors (e.g. loading or validating a checkpointed
+            config) will result in
+
+            a rollback to LastKnownGood. In the latter case, it is usually possible
+            to resolve the error
+
+            by fixing the config assigned in Spec.ConfigSource.
+
+            You can find additional information for debugging by searching the error
+            message in the Kubelet log.
+
+            Error is a human-readable description of the error state; machines can
+            check whether or not Error
+
+            is empty, but should not rely on the stability of the Error text across
+            Kubelet versions.
+
+            +optional'
+          type: string
+        lastKnownGood:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeConfigSource'
+          description: 'LastKnownGood reports the checkpointed config the node will
+            fall back to
+
+            when it encounters an error attempting to use the Assigned config.
+
+            The Assigned config becomes the LastKnownGood config when the node determines
+
+            that the Assigned config is stable and correct.
+
+            This is currently implemented as a 10-minute soak period starting when
+            the local
+
+            record of Assigned config is updated. If the Assigned config is Active
+            at the end
+
+            of this period, it becomes the LastKnownGood. Note that if Spec.ConfigSource
+            is
+
+            reset to nil (use local defaults), the LastKnownGood is also immediately
+            reset to nil,
+
+            because the local default config is always assumed good.
+
+            You should not make assumptions about the node''s method of determining
+            config stability
+
+            and correctness, as this may change or become configurable in the future.
+
+            +optional'
+      type: object
+    v1.NodeDaemonEndpoints:
+      properties:
+        kubeletEndpoint:
+          allOf:
+          - $ref: '#/components/schemas/v1.DaemonEndpoint'
+          description: 'Endpoint on which Kubelet is listening.
+
+            +optional'
+      type: object
+    v1.NodeFeatures:
+      properties:
+        supplementalGroupsPolicy:
+          description: 'SupplementalGroupsPolicy is set to true if the runtime supports
+            SupplementalGroupsPolicy and ContainerUser.
+
+            +optional'
+          type: boolean
+      type: object
+    v1.NodePhase:
+      enum:
+      - Pending
+      - Running
+      - Terminated
+      type: string
+      x-enum-varnames:
+      - NodePending
+      - NodeRunning
+      - NodeTerminated
+    v1.NodeRuntimeHandler:
+      properties:
+        features:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeRuntimeHandlerFeatures'
+          description: 'Supported features.
+
+            +optional'
+        name:
+          description: 'Runtime handler name.
+
+            Empty for the default runtime handler.
+
+            +optional'
+          type: string
+      type: object
+    v1.NodeRuntimeHandlerFeatures:
+      properties:
+        recursiveReadOnlyMounts:
+          description: 'RecursiveReadOnlyMounts is set to true if the runtime handler
+            supports RecursiveReadOnlyMounts.
+
+            +optional'
+          type: boolean
+        userNamespaces:
+          description: 'UserNamespaces is set to true if the runtime handler supports
+            UserNamespaces, including for volumes.
+
+            +featureGate=UserNamespacesSupport
+
+            +optional'
+          type: boolean
+      type: object
+    v1.NodeSpec:
+      properties:
+        configSource:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeConfigSource'
+          description: 'Deprecated: Previously used to specify the source of the node''s
+            configuration for the DynamicKubeletConfig feature. This feature is removed.
+
+            +optional'
+        externalID:
+          description: 'Deprecated. Not all kubelets will set this field. Remove field
+            after 1.13.
+
+            see: https://issues.k8s.io/61966
+
+            +optional'
+          type: string
+        podCIDR:
+          description: 'PodCIDR represents the pod IP range assigned to the node.
+
+            +optional'
+          type: string
+        podCIDRs:
+          description: 'podCIDRs represents the IP ranges assigned to the node for
+            usage by Pods on that node. If this
+
+            field is specified, the 0th entry must match the podCIDR field. It may
+            contain at most 1 value for
+
+            each of IPv4 and IPv6.
+
+            +optional
+
+            +patchStrategy=merge
+
+            +listType=set'
+          items:
+            type: string
+          type: array
+        providerID:
+          description: 'ID of the node assigned by the cloud provider in the format:
+            <ProviderName>://<ProviderSpecificNodeID>
+
+            +optional'
+          type: string
+        taints:
+          description: 'If specified, the node''s taints.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.Taint'
+          type: array
+        unschedulable:
+          description: 'Unschedulable controls node schedulability of new pods. By
+            default, node is schedulable.
+
+            More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration
+
+            +optional'
+          type: boolean
+      type: object
+    v1.NodeStatus:
+      properties:
+        addresses:
+          description: 'List of addresses reachable to the node.
+
+            Queried from cloud provider, if available.
+
+            More info: https://kubernetes.io/docs/reference/node/node-status/#addresses
+
+            Note: This field is declared as mergeable, but the merge key is not sufficiently
+
+            unique, which can cause data corruption when it is merged. Callers should
+            instead
+
+            use a full-replacement patch. See https://pr.k8s.io/79391 for an example.
+
+            Consumers should assume that addresses can change during the
+
+            lifetime of a Node. However, there are some exceptions where this may
+            not
+
+            be possible, such as Pods that inherit a Node''s address in its own status
+            or
+
+            consumers of the downward API (status.hostIP).
+
+            +optional
+
+            +patchMergeKey=type
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=type'
+          items:
+            $ref: '#/components/schemas/v1.NodeAddress'
+          type: array
+        allocatable:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceList'
+          description: 'Allocatable represents the resources of a node that are available
+            for scheduling.
+
+            Defaults to Capacity.
+
+            +optional'
+        capacity:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceList'
+          description: 'Capacity represents the total resources of a node.
+
+            More info: https://kubernetes.io/docs/reference/node/node-status/#capacity
+
+            +optional'
+        conditions:
+          description: 'Conditions is an array of current observed node conditions.
+
+            More info: https://kubernetes.io/docs/reference/node/node-status/#condition
+
+            +optional
+
+            +patchMergeKey=type
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=type'
+          items:
+            $ref: '#/components/schemas/v1.NodeCondition'
+          type: array
+        config:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeConfigStatus'
+          description: 'Status of the config assigned to the node via the dynamic
+            Kubelet config feature.
+
+            +optional'
+        daemonEndpoints:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeDaemonEndpoints'
+          description: 'Endpoints of daemons running on the Node.
+
+            +optional'
+        declaredFeatures:
+          description: 'DeclaredFeatures represents the features related to feature
+            gates that are declared by the node.
+
+            +featureGate=NodeDeclaredFeatures
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+        features:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeFeatures'
+          description: 'Features describes the set of features implemented by the
+            CRI implementation.
+
+            +featureGate=SupplementalGroupsPolicy
+
+            +optional'
+        images:
+          description: 'List of container images on this node
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.ContainerImage'
+          type: array
+        nodeInfo:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeSystemInfo'
+          description: 'Set of ids/uuids to uniquely identify the node.
+
+            More info: https://kubernetes.io/docs/reference/node/node-status/#info
+
+            +optional'
+        phase:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodePhase'
+          description: 'NodePhase is the recently observed lifecycle phase of the
+            node.
+
+            More info: https://kubernetes.io/docs/concepts/nodes/node/#phase
+
+            The field is never populated, and now is deprecated.
+
+            +optional'
+        runtimeHandlers:
+          description: 'The available runtime handlers.
+
+            +featureGate=UserNamespacesSupport
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.NodeRuntimeHandler'
+          type: array
+        volumesAttached:
+          description: 'List of volumes that are attached to the node.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.AttachedVolume'
+          type: array
+        volumesInUse:
+          description: 'List of attachable volumes in use (mounted) by the node.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+      type: object
+    v1.NodeSwapStatus:
+      properties:
+        capacity:
+          description: 'Total amount of swap memory in bytes.
+
+            +optional'
+          type: integer
+      type: object
+    v1.NodeSystemInfo:
+      properties:
+        architecture:
+          description: The Architecture reported by the node
+          type: string
+        bootID:
+          description: Boot ID reported by the node.
+          type: string
+        containerRuntimeVersion:
+          description: ContainerRuntime Version reported by the node through runtime
+            remote API (e.g. containerd://1.4.2).
+          type: string
+        kernelVersion:
+          description: Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).
+          type: string
+        kubeProxyVersion:
+          description: 'Deprecated: KubeProxy Version reported by the node.'
+          type: string
+        kubeletVersion:
+          description: Kubelet Version reported by the node.
+          type: string
+        machineID:
+          description: 'MachineID reported by the node. For unique machine identification
+
+            in the cluster this field is preferred. Learn more from man(5)
+
+            machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html'
+          type: string
+        operatingSystem:
+          description: The Operating System reported by the node
+          type: string
+        osImage:
+          description: OS Image reported by the node from /etc/os-release (e.g. Debian
+            GNU/Linux 7 (wheezy)).
+          type: string
+        swap:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeSwapStatus'
+          description: Swap Info reported by the node.
+        systemUUID:
+          description: 'SystemUUID reported by the node. For unique machine identification
+
+            MachineID is preferred. This field is specific to Red Hat hosts
+
+            https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid'
+          type: string
       type: object
     v1.ObjectFieldSelector:
       properties:
@@ -30588,6 +32419,40 @@ components:
 
             Name must be an IANA_SVC_NAME.'
       type: object
+    v1.Taint:
+      properties:
+        effect:
+          allOf:
+          - $ref: '#/components/schemas/v1.TaintEffect'
+          description: 'Required. The effect of the taint on pods
+
+            that do not tolerate the taint.
+
+            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.'
+        key:
+          description: Required. The taint key to be applied to a node.
+          type: string
+        timeAdded:
+          description: 'TimeAdded represents the time at which the taint was added.
+
+            +optional'
+          type: string
+        value:
+          description: 'The taint value corresponding to the taint key.
+
+            +optional'
+          type: string
+      type: object
+    v1.TaintEffect:
+      enum:
+      - NoSchedule
+      - PreferNoSchedule
+      - NoExecute
+      type: string
+      x-enum-varnames:
+      - TaintEffectNoSchedule
+      - TaintEffectPreferNoSchedule
+      - TaintEffectNoExecute
     v1.TerminationMessagePolicy:
       enum:
       - File
@@ -30816,7 +32681,7 @@ components:
           - $ref: '#/components/schemas/v1.ResourceList'
           description: The memory usage is the memory working set.
         window:
-          $ref: '#/components/schemas/v1.Duration'
+          type: string
       type: object
     v1beta1.NodeMetricsList:
       properties:
@@ -30911,7 +32776,7 @@ components:
             collected from the interval [Timestamp-Window, Timestamp].'
           type: string
         window:
-          $ref: '#/components/schemas/v1.Duration'
+          type: string
       type: object
     v1beta1.PodMetricsList:
       properties:
@@ -30991,20 +32856,6 @@ components:
       - DeploymentPlatformDockerStandalone
       - DeploymentPlatformDockerSwarm
       - DeploymentPlatformKubernetes
-    workflows.Status:
-      enum:
-      - healthy
-      - syncing
-      - error
-      - paused
-      - unknown
-      type: string
-      x-enum-varnames:
-      - StatusHealthy
-      - StatusSyncing
-      - StatusError
-      - StatusPaused
-      - StatusUnknown
     workflows.StatusSummary:
       properties:
         error:
@@ -31028,7 +32879,7 @@ components:
           type: integer
         groupStatus:
           additionalProperties:
-            $ref: '#/components/schemas/workflows.Status'
+            $ref: '#/components/schemas/github_com_portainer_portainer_api_gitops_workflows.Status'
           type: object
         namespace:
           type: string
@@ -31067,13 +32918,20 @@ components:
           $ref: '#/components/schemas/workflows.Target'
         type:
           $ref: '#/components/schemas/workflows.Type'
+      required:
+      - id
+      - name
+      - platform
+      - status
+      - target
+      - type
       type: object
     workflows.WorkflowPhaseStatus:
       properties:
         error:
           type: string
         status:
-          $ref: '#/components/schemas/workflows.Status'
+          $ref: '#/components/schemas/github_com_portainer_portainer_api_gitops_workflows.Status'
       type: object
     workflows.WorkflowStatusObject:
       properties:

--- a/tests/test_patch_spec.py
+++ b/tests/test_patch_spec.py
@@ -24,29 +24,29 @@ def _spec(paths: dict | None = None, schemas: dict | None = None) -> dict:
 def test_excluded_operation_ids_are_removed():
     spec = _spec(
         paths={
-            "/git/{id}": {
-                "get": {"operationId": "SharedGitGet"},
-                "put": {"operationId": "SharedGitUpdate"},
-                "delete": {"operationId": "SharedGitDelete"},
+            "/cloud/{id}": {
+                "get": {"operationId": "providerInfo"},
+                "put": {"operationId": "provisionCluster"},
+                "delete": {"operationId": "UpdateKubernetesNamespaceDeprecated"},
             },
         }
     )
     patch(spec)
     # Path is removed entirely once all its methods drop out.
-    assert "/git/{id}" not in spec["paths"]
+    assert "/cloud/{id}" not in spec["paths"]
 
 
 def test_partial_method_drop_keeps_path():
     spec = _spec(
         paths={
-            "/git/{id}": {
-                "get": {"operationId": "SharedGitGet"},
+            "/cloud/{id}": {
+                "get": {"operationId": "provisionCluster"},
                 "post": {"operationId": "KeepMe"},
             },
         }
     )
     patch(spec)
-    assert spec["paths"]["/git/{id}"] == {"post": {"operationId": "KeepMe"}}
+    assert spec["paths"]["/cloud/{id}"] == {"post": {"operationId": "KeepMe"}}
 
 
 def test_unrelated_operations_are_kept():
@@ -77,42 +77,47 @@ def test_websocket_paths_are_dropped():
     assert set(spec["paths"]) == {"/endpoints"}
 
 
-# --- EXCLUDED_PATH_METHODS (edge-agent-only callbacks) ----------------------
+# --- edge-agent-only callbacks (tag-based) ----------------------------------
 
 
-def test_edge_agent_callbacks_dropped_even_without_operation_id():
-    # Two of the four agent-callback ops have no operationId in the spec —
-    # FastMCP names them from `summary`. The path-method filter catches them.
+def test_edge_agent_callbacks_dropped():
+    # Every op carrying the `edge_agent` tag is an agent-only callback that
+    # 403s for an MCP caller, so the patcher drops it regardless of
+    # operationId. `EndpointEdgeStackInspect` also carries `edge_stacks` (it
+    # would otherwise surface in the EDGE profile) and must still go.
     spec = _spec(
         paths={
             "/endpoints/{id}/edge/stacks/{stackId}": {
-                "get": {"summary": "Inspect an Edge Stack for an Environment(Endpoint)"},
+                "get": {
+                    "operationId": "EndpointEdgeStackInspect",
+                    "tags": ["edge_agent", "edge_stacks"],
+                },
             },
-            "/endpoints/{id}/edge/status": {
-                "get": {"operationId": "EndpointEdgeStatusInspect"},
+            "/endpoints/{id}/edge/async": {
+                "post": {"operationId": "endpointEdgeAsync", "tags": ["edge_agent"]},
             },
-            "/endpoints/{id}/edge/alerts": {
-                "post": {"operationId": "EndpointEdgeAlertsReceive"},
-            },
-            "/endpoints/{id}/edge/jobs/{jobID}/logs": {
-                "post": {"summary": "Update the logs collected from an Edge Job"},
+            # No operationId — still dropped by the tag.
+            "/endpoints/{id}/edge/charts": {
+                "get": {"summary": "Get edge charts", "tags": ["edge_agent"]},
             },
         }
     )
     patch(spec)
-    # All four paths had a single method each; after the drop the path
-    # itself is removed by the empty-path cleanup.
     assert spec["paths"] == {}
 
 
 def test_edge_admin_tools_are_kept():
     # `EdgeStackList` / `EdgeStackInspect` are admin-facing edge tools that
-    # do *not* require the agent header. They share the `edge` / `edge_stacks`
-    # tags with the callbacks but live on different paths — they must survive.
+    # do *not* require the agent header. They carry `edge_stacks` but not
+    # `edge_agent`, so they must survive.
     spec = _spec(
         paths={
-            "/edge_stacks": {"get": {"operationId": "EdgeStackList"}},
-            "/edge_stacks/{id}": {"get": {"operationId": "EdgeStackInspect"}},
+            "/edge_stacks": {
+                "get": {"operationId": "EdgeStackList", "tags": ["edge_stacks"]},
+            },
+            "/edge_stacks/{id}": {
+                "get": {"operationId": "EdgeStackInspect", "tags": ["edge_stacks"]},
+            },
         }
     )
     patch(spec)
@@ -120,52 +125,32 @@ def test_edge_admin_tools_are_kept():
 
 
 def test_path_with_remaining_methods_is_kept():
-    # If a future spec adds a non-agent method to one of the edge paths,
-    # the path must survive — only the targeted method is dropped.
+    # If a path mixes an agent callback with a non-agent method, only the
+    # tagged method is dropped — the path survives.
     spec = _spec(
         paths={
             "/endpoints/{id}/edge/status": {
-                "get": {"operationId": "EndpointEdgeStatusInspect"},
-                "put": {"operationId": "HypotheticalAdminWrite"},
+                "get": {
+                    "operationId": "EndpointEdgeStatusInspect",
+                    "tags": ["edge_agent"],
+                },
+                "put": {"operationId": "HypotheticalAdminWrite", "tags": ["endpoints"]},
             },
         }
     )
     patch(spec)
     assert spec["paths"]["/endpoints/{id}/edge/status"] == {
-        "put": {"operationId": "HypotheticalAdminWrite"},
+        "put": {"operationId": "HypotheticalAdminWrite", "tags": ["endpoints"]},
     }
 
 
 # --- ENUM_STRIPS ------------------------------------------------------------
 
 
-def test_top_level_enum_strip_os_filemode():
-    spec = _spec(schemas={"os.FileMode": {"type": "string", "enum": ["a", "b"]}})
-    patch(spec)
-    assert "enum" not in spec["components"]["schemas"]["os.FileMode"]
-    assert spec["components"]["schemas"]["os.FileMode"]["type"] == "string"
-
-
 def test_top_level_enum_strip_policy_type():
     spec = _spec(schemas={"policies.PolicyType": {"enum": [1, 2, 3]}})
     patch(spec)
     assert spec["components"]["schemas"]["policies.PolicyType"] == {}
-
-
-def test_nested_enum_strip_time_duration():
-    spec = _spec(
-        schemas={
-            "v1.Duration": {
-                "properties": {
-                    "time.Duration": {"type": "string", "enum": ["1s", "1m"]},
-                }
-            }
-        }
-    )
-    patch(spec)
-    node = spec["components"]["schemas"]["v1.Duration"]["properties"]["time.Duration"]
-    assert "enum" not in node
-    assert node["type"] == "string"
 
 
 def test_enum_strip_missing_schema_is_noop():

--- a/uv.lock
+++ b/uv.lock
@@ -678,7 +678,7 @@ wheels = [
 
 [[package]]
 name = "mcp-portainer"
-version = "2.42.6"
+version = "2.43.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Bumps the embedded Portainer EE spec to **2.43.0** (was 2.42.0) and cuts the matching MCP minor.

## Spec deltas (today's `spec_deltas.py`, apples-to-apples)
| | 2.42.0 | 2.43.0 |
|---|---|---|
| Total ops | 409 | 412 |
| DEFAULT (`BASE,DOCKER,KUBERNETES`) | 193 | 190 |
| Union (5 profiles) | 334 | 329 |

The DEFAULT/DOCKER dip is the **tagging defect being resolved upstream**: the Edge-agent callbacks moved off the `endpoints` tag onto a new dedicated `edge_agent` tag, so they no longer leak into DOCKER as dead tools. New `allowlist` orphan tag (2 ops).

## Patcher changes
- **Edge-agent exclusion is now tag-based** — `patch_spec.py` drops every op carrying `edge_agent` (eight agent-only callbacks that 403 without `X-PortainerAgent-EdgeID`), replacing the old four-op `(method, path)` matcher. Possible because 2.43.0 named 15 of 16 previously-unnamed operations.
- **Pruned dead entries**: `SharedGit{Get,Update,Delete}` operationIds and the `os.FileMode` / `v1.Duration` enum strips no longer match anything in 2.43.0 (`policies.PolicyType` still applies).

## Verification
- `uv run pytest` → 209 passed
- `build_server()` boots: `select` present on all 190 tools

Full deltas and the upstream-defect status are tracked in the (gitignored) local report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)