### PR TITLE
Add GITOPS profile and include gitops in the default set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ the MCP server.
 
 ## [Unreleased]
 
+### Added
+
+- **New `GITOPS` profile** bundling the `gitops` tag (register/list/test git
+  sources, browse refs — the GitOps *source* management surface).
+
+### Changed
+
+- **`gitops` is now in the default profile set.** Since Portainer 2.43 a
+  registered GitOps source is required to deploy a git-backed stack, so
+  `gitops` now rides along inside both `DOCKER` and `KUBERNETES` (next to
+  `stacks`) and the default `PORTAINER_PROFILES` becomes
+  `BASE,DOCKER,KUBERNETES,GITOPS`. Without it, git-based stack deploys fail
+  for lack of a source. `gitops` is removed from the orphan-tag inventory in
+  [`docs/profiles.md`](docs/profiles.md).
+
 ## [2.43.0] — 2026-06-29
 
 Targets Portainer 2.43.x.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,7 @@ new proxy tools, shaping changes — all patch. See
 ## Profiles
 
 Spec exposes ~380 operations across 40+ tags; profiles in `profiles.py`
-bundle them. `PORTAINER_PROFILES` (default `BASE,DOCKER,KUBERNETES`)
+bundle them. `PORTAINER_PROFILES` (default `BASE,DOCKER,KUBERNETES,GITOPS`)
 selects which to enable; `PORTAINER_TAGS_EXTRA` appends raw tags as an
 escape hatch. `PORTAINER_PROFILES=ALL` disables the tag filter entirely.
 Unknown profile names fail at startup; unknown extras log a warning and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,7 +92,7 @@ silently downgrades.
 
 | Var | Default | Notes |
 |---|---|---|
-| `PORTAINER_PROFILES` | `BASE,DOCKER,KUBERNETES` | Comma-separated named tag bundles. `ALL` disables the tag filter and exposes every operation. Unknown names will prevent the server from starting. Full list in [profiles.md](profiles.md). |
+| `PORTAINER_PROFILES` | `BASE,DOCKER,KUBERNETES,GITOPS` | Comma-separated named tag bundles. `ALL` disables the tag filter and exposes every operation. Unknown names will prevent the server from starting. Full list in [profiles.md](profiles.md). |
 | `PORTAINER_TAGS_EXTRA` | _empty_ | Escape hatch: comma-separated raw tags appended to the resolved set. Unknown tags log a warning and pass through (they just don't match anything). |
 
 ## Behaviour

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -6,7 +6,7 @@ The Portainer API spec exposes 400+ operations across 40+ tags. Auto-converting 
 
 | Env var | Default | Effect |
 |---|---|---|
-| `PORTAINER_PROFILES` | `BASE,DOCKER,KUBERNETES` | Comma-separated profiles to enable. Tag sets are union'd. Empty or unset → default. |
+| `PORTAINER_PROFILES` | `BASE,DOCKER,KUBERNETES,GITOPS` | Comma-separated profiles to enable. Tag sets are union'd. Empty or unset → default. |
 | `PORTAINER_TAGS_EXTRA` | _empty_ | Comma-separated extra tags appended to the union. Literal tag names only — no wildcards or globs. Escape hatch for orphan tags below. |
 | `PORTAINER_READ_ONLY` | `0` | `1` restricts to `GET`/`HEAD` operations only (strict — HTTP method is the read/write classifier). |
 | `PORTAINER_NO_PROXY` | `0` | `1` skips `docker_proxy` / `kubernetes_proxy` registration. |
@@ -18,8 +18,9 @@ Unknown profile names will prevent the server from starting. Unknown extras (tag
 | Profile | Tags | Use case |
 |---|---|---|
 | `BASE` | `auth`, `system`, `status`, `settings`, `motd` | Server identity, login, settings. Effectively required — most workflows assume these are present. |
-| `DOCKER` | `docker`, `endpoints`, `stacks` | Docker workloads on Portainer-managed environments. |
-| `KUBERNETES` | `kubernetes`, `helm`, `endpoints`, `stacks` | Kubernetes workloads, including Helm releases. Shares `endpoints`/`stacks` with `DOCKER` — union'd, no duplication. |
+| `DOCKER` | `docker`, `endpoints`, `stacks`, `gitops` | Docker workloads on Portainer-managed environments. |
+| `KUBERNETES` | `kubernetes`, `helm`, `endpoints`, `stacks`, `gitops` | Kubernetes workloads, including Helm releases. Shares `endpoints`/`stacks`/`gitops` with `DOCKER` — union'd, no duplication. |
+| `GITOPS` | `gitops` | GitOps source management (register/list/test git sources, browse refs). Since Portainer 2.43 a registered source is required to deploy a git-backed stack, so `gitops` also rides along inside `DOCKER`/`KUBERNETES`; this standalone profile is for source-management-only personas. |
 | `EDGE` | `edge`, `edge_stacks`, `edge_jobs`, `edge_groups`, `edge_update_schedules`, `edge_configs` | Portainer Edge fleet management. |
 | `ADMIN` | `users`, `teams`, `team_memberships`, `roles`, `ldap`, `license`, `backup`, `registries`, `endpoint_groups`, `policies`, `resource_controls`, `tags` | Platform administration: identity, registries, backups, RBAC. |
 
@@ -39,7 +40,6 @@ when you need them, or switch to `ALL`:
 
 | Count | Tag | Notes |
 |---:|---|---|
-| 15 | `gitops` | GitOps configuration surface. |
 | 15 | `observability` | Container/pod logs, metrics, stats. |
 | 13 | `omni` | Talos Kubernetes cluster management. |
 | 10 | `custom_templates` | User-defined app templates. |
@@ -58,8 +58,8 @@ when you need them, or switch to `ALL`:
 ## Examples
 
 ```bash
-# Default — Docker + Kubernetes workloads
-PORTAINER_PROFILES=BASE,DOCKER,KUBERNETES uv run portainer-mcp
+# Default — Docker + Kubernetes workloads, incl. GitOps source management
+PORTAINER_PROFILES=BASE,DOCKER,KUBERNETES,GITOPS uv run portainer-mcp
 
 # Edge-only fleet operator
 PORTAINER_PROFILES=BASE,EDGE uv run portainer-mcp
@@ -71,7 +71,7 @@ PORTAINER_PROFILES=ALL PORTAINER_READ_ONLY=1 uv run portainer-mcp
 PORTAINER_PROFILES=BASE,DOCKER PORTAINER_NO_PROXY=1 uv run portainer-mcp
 
 # Default + observability for a troubleshooting workflow
-PORTAINER_PROFILES=BASE,DOCKER,KUBERNETES PORTAINER_TAGS_EXTRA=observability \
+PORTAINER_PROFILES=BASE,DOCKER,KUBERNETES,GITOPS PORTAINER_TAGS_EXTRA=observability \
   uv run portainer-mcp
 ```
 

--- a/src/portainer_mcp/profiles.py
+++ b/src/portainer_mcp/profiles.py
@@ -19,8 +19,13 @@ ALL = "ALL"
 
 TAG_PROFILES: dict[str, tuple[str, ...]] = {
     "BASE": ("auth", "system", "status", "settings", "motd"),
-    "DOCKER": ("docker", "endpoints", "stacks"),
-    "KUBERNETES": ("kubernetes", "helm", "endpoints", "stacks"),
+    # `gitops` (source management) travels with `stacks`: since Portainer 2.43
+    # a registered GitOps source is required to deploy a git-backed stack, so
+    # any profile that can deploy stacks needs it too. Also exposed as a
+    # standalone GITOPS profile for source-management-only personas.
+    "DOCKER": ("docker", "endpoints", "stacks", "gitops"),
+    "KUBERNETES": ("kubernetes", "helm", "endpoints", "stacks", "gitops"),
+    "GITOPS": ("gitops",),
     "EDGE": (
         "edge",
         "edge_stacks",
@@ -45,7 +50,7 @@ TAG_PROFILES: dict[str, tuple[str, ...]] = {
     ),
 }
 
-DEFAULT_PROFILES = "BASE,DOCKER,KUBERNETES"
+DEFAULT_PROFILES = "BASE,DOCKER,KUBERNETES,GITOPS"
 
 
 def _split(s: str) -> list[str]:

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -14,15 +14,25 @@ from portainer_mcp import profiles
 
 
 def test_default_profiles_union_dedups_shared_tags():
-    # BASE ∪ DOCKER ∪ KUBERNETES. `endpoints` and `stacks` appear in both
-    # DOCKER and KUBERNETES — this proves the union deduplicates them.
+    # BASE ∪ DOCKER ∪ KUBERNETES ∪ GITOPS. `endpoints`, `stacks`, and `gitops`
+    # each appear in more than one profile — this proves the union dedups them.
     # Exact tag content is intentionally not asserted: that lives in
     # `TAG_PROFILES` and pinning the literal here would just duplicate the data.
     tags = profiles.resolve(profiles.DEFAULT_PROFILES)
     assert tags == tuple(sorted(set(tags)))
     assert tags.count("endpoints") == 1
     assert tags.count("stacks") == 1
-    assert {"auth", "docker", "kubernetes"} <= set(tags)
+    assert tags.count("gitops") == 1
+    assert {"auth", "docker", "kubernetes", "gitops"} <= set(tags)
+
+
+def test_gitops_travels_with_stacks_and_standalone():
+    # Since Portainer 2.43 a GitOps source is required to deploy a git-backed
+    # stack, so `gitops` must accompany `stacks` in any stack-capable profile,
+    # and also stand alone for a source-management-only persona.
+    assert "gitops" in profiles.resolve("DOCKER")
+    assert "gitops" in profiles.resolve("KUBERNETES")
+    assert profiles.resolve("GITOPS") == ("gitops",)
 
 
 def test_all_sentinel_returns_none():


### PR DESCRIPTION
## Why

A registered **GitOps source** is required to deploy a git-backed stack. The default profile set (`BASE,DOCKER,KUBERNETES`) exposed the stack-from-git tools (`stacks` tag) but **not** the `gitops` source-management surface they now depend on — so a git-based deploy fails for lack of a source. This closes that gap.

## What

- **`profiles.py`**
  - New standalone **`GITOPS`** profile (`gitops` tag) for source-management-only personas.
  - `gitops` folded into **`DOCKER`** and **`KUBERNETES`** (next to `stacks`) so it can't be dropped when stack deploy is enabled — the union dedups.
  - Default is now **`BASE,DOCKER,KUBERNETES,GITOPS`**.
- **Tests** — cover `gitops` dedup in the default union and the standalone `GITOPS` profile.
- **Docs** (`profiles.md`, `configuration.md`, `CLAUDE.md`) — update the default, add the `GITOPS` row, and remove `gitops` from the orphan-tag inventory.
- **CHANGELOG** — recorded under `[Unreleased]`.

## Notes

- **Patch-level** change (no embedded-spec move) → targets `2.43.1`; `pyproject.toml` version bump intentionally left for the release step.
- Full suite green (`210 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)