### PR TITLE
Add trust-proxy auth posture for identity-aware proxies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@
 # Required
 PORTAINER_URL=https://portainer.example.com
 # Generate with: openssl rand -hex 32
+# (Behind an identity-aware proxy that owns Authorization, leave this unset
+# and declare the trust-proxy auth posture below instead — never both.)
 PORTAINER_MCP_AUTH_TOKEN=
 
 # PORTAINER_API_KEY is the stdio-only credential. Do NOT set it here: the HTTP
@@ -29,3 +31,14 @@ PORTAINER_MCP_AUTH_TOKEN=
 # PORTAINER_MCP_FORWARDED_ALLOW_IPS=10.0.0.0/8
 #   3. DANGER: serve plaintext (unencrypted) — trusted private networks only
 # PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1
+
+# Auth posture (HTTP only). Default is the gate token above. Behind an
+# identity-aware proxy that performs the MCP OAuth flow and owns the
+# Authorization header (e.g. Pomerium in MCP server mode), unset the token
+# and declare trust-proxy auth instead — the per-user X-Portainer-API-Key
+# is still required and validated either way:
+#   with TLS posture 2, this one line is enough (the peer allowlist is
+#   inherited from PORTAINER_MCP_FORWARDED_ALLOW_IPS; '*' refuses to boot)
+# PORTAINER_MCP_TRUST_PROXY_AUTH=1
+#   with TLS posture 1 (server-terminated), also name the proxy's IPs/subnets
+# PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS=10.0.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ the MCP server.
   `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS` socket-peer allowlist when the
   server terminates TLS itself. Exactly one auth posture must be declared
   (gate token XOR trust-proxy); every degenerate combination — both, neither,
-  trust + plaintext opt-out, wildcard allowlists — refuses to boot, and the
+  trust + plaintext opt-out, wildcard allowlists (`*` or zero-prefix CIDRs),
+  a server-held cert alongside the inherited shape, a peer allowlist without
+  the trust flag — refuses to boot, and the
   per-user `X-Portainer-API-Key` validation floor is unchanged. New audit
   outcomes `untrusted_scheme` / `untrusted_peer`; audit records under this
   posture carry `auth_posture: "trust_proxy"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ the MCP server.
 
 ## [Unreleased]
 
+### Added
+
+- **Trust-proxy auth posture** (`PORTAINER_MCP_TRUST_PROXY_AUTH=1`) for
+  deployments behind an identity-aware proxy that owns the `Authorization`
+  header (e.g. Pomerium in MCP server mode) —
+  [#76](https://github.com/portainer/portainer-mcp/issues/76). The gate-token
+  compare is replaced by per-request proxy attestation: inherited from the
+  `PORTAINER_MCP_TRUST_PROXY_TLS` + `PORTAINER_MCP_FORWARDED_ALLOW_IPS`
+  declaration behind a TLS-terminating proxy, or an explicit
+  `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS` socket-peer allowlist when the
+  server terminates TLS itself. Exactly one auth posture must be declared
+  (gate token XOR trust-proxy); every degenerate combination — both, neither,
+  trust + plaintext opt-out, wildcard allowlists — refuses to boot, and the
+  per-user `X-Portainer-API-Key` validation floor is unchanged. New audit
+  outcomes `untrusted_scheme` / `untrusted_peer`; audit records under this
+  posture carry `auth_posture: "trust_proxy"`.
+
 ## [2.43.1] — 2026-07-02
 
 Targets Portainer 2.43.x.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,13 @@ Key things to internalise before changing code:
   *socket peer* (`PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS` + server-terminated
   TLS; resolve() emits `proxy_headers: False` so the peer stays raw).
   Hard-fails: both postures declared, neither, trust + plaintext opt-out,
-  wildcard in the effective allowlist, `TRUSTED_PROXY_AUTH_IPS` combined
-  with `TRUST_PROXY_TLS`/`FORWARDED_ALLOW_IPS`, missing `ALLOWED_HOSTS` on
-  a non-loopback bind. The per-user `X-Portainer-API-Key` floor is
+  wildcard in the effective allowlist (`*` or zero-prefix CIDR like
+  `0.0.0.0/0`), `TLS_CERT` alongside the inherited shape (a server-held
+  cert lets any direct connection present https, voiding the attestation),
+  `TRUSTED_PROXY_AUTH_IPS` combined with `TRUST_PROXY_TLS`/
+  `FORWARDED_ALLOW_IPS` or set without the trust flag, missing
+  `ALLOWED_HOSTS` on a non-loopback bind. `PeerMatcher` unmaps IPv4-mapped
+  IPv6 peers (dual-stack binds). The per-user `X-Portainer-API-Key` floor is
   unchanged — trust-proxy drops the gate, never authentication. New audit
   outcomes `untrusted_scheme` / `untrusted_peer`; records carry
   `auth_posture: "trust_proxy"`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,27 @@ Key things to internalise before changing code:
   (min 32 chars, ASCII printable, no whitespace) — loud-fail like the
   unknown-profile check. Don't relax this for "convenience"; the strict
   rule eliminates the make-dev-no-token footgun.
+- **Auth posture is an enum: gate token XOR trust-proxy.** `auth_posture.
+  resolve()` (mirrors `tls.resolve_posture`) runs before the verifier is
+  built. `PORTAINER_MCP_TRUST_PROXY_AUTH=1` serves identity-aware proxies
+  that own `Authorization` (issue #76, Pomerium MCP mode): the bearer value
+  is ignored (`auth.TrustedProxyVerifier`; `_EnsureBearerMiddleware` injects
+  a placeholder when the proxy strips the header, because the SDK 401s
+  header-less requests before `verify_token`) and the gate compare is
+  replaced by per-request proxy attestation. Two shapes, because uvicorn
+  rewrites `scope["client"]` from XFF for trusted peers so socket-peer and
+  forwarded-header trust are mutually exclusive signals: *inherited*
+  (requires `TRUST_PROXY_TLS=1`; attestation is `scheme == "https"`, which
+  only a `FORWARDED_ALLOW_IPS` peer can produce since no cert is held) and
+  *socket peer* (`PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS` + server-terminated
+  TLS; resolve() emits `proxy_headers: False` so the peer stays raw).
+  Hard-fails: both postures declared, neither, trust + plaintext opt-out,
+  wildcard in the effective allowlist, `TRUSTED_PROXY_AUTH_IPS` combined
+  with `TRUST_PROXY_TLS`/`FORWARDED_ALLOW_IPS`, missing `ALLOWED_HOSTS` on
+  a non-loopback bind. The per-user `X-Portainer-API-Key` floor is
+  unchanged — trust-proxy drops the gate, never authentication. New audit
+  outcomes `untrusted_scheme` / `untrusted_peer`; records carry
+  `auth_posture: "trust_proxy"`.
 - **HTTP is per-user passthrough, not a shared upstream key.** Over HTTP
   the verifier is `auth.PassthroughVerifier` (subclass of
   `StaticBearerVerifier`), and `PORTAINER_API_KEY` is *not* loaded — it's

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ claude mcp add portainer --transport http http://mcp.example.com:17717/mcp \
 
 #### Option D - Identity-aware proxy (MCP OAuth)
 
-If your users authenticate through an identity-aware proxy that speaks the MCP OAuth flow (e.g. [Pomerium in MCP server mode](https://www.pomerium.com/docs/capabilities/mcp)), the proxy mints its own access token and **owns** the `Authorization` header — a static gate token can't survive the hop. Declare the trust-proxy auth posture instead of `PORTAINER_MCP_AUTH_TOKEN`:
+If your users authenticate through an identity-aware proxy that speaks the MCP OAuth flow (such as [Pomerium in MCP server mode](https://www.pomerium.com/docs/capabilities/mcp)), the proxy mints its own access token and **owns** the `Authorization` header. Declare the trust-proxy auth posture instead of `PORTAINER_MCP_AUTH_TOKEN`:
 
 > [!NOTE]
 > Same rules as Option B: don't publish the container port (only the proxy may reach it), and make sure the proxy forwards the original `Host` and `X-Forwarded-Proto: https` headers.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The recommended way to have multiple users interacting with your Portainer insta
 
 See more info below about the different deployment scenarios. For any of these scenarios:
 * Set `PORTAINER_MCP_ALLOWED_HOSTS` to the hostname or IP address that users will use to reach the MCP — otherwise the DNS-rebinding allowlist 421-rejects the request.
-* `PORTAINER_MCP_AUTH_TOKEN` is **required** in HTTP mode. It's the shared front-gate secret you distribute to your users; their MCP client sends it via the `Authorization` header. It only admits the request — what each user can *do* is governed by their own Portainer API key.
+* `PORTAINER_MCP_AUTH_TOKEN` is **required** in HTTP mode. It's the shared front-gate secret you distribute to your users; their MCP client sends it via the `Authorization` header. It only admits the request — what each user can *do* is governed by their own Portainer API key. The one exception: behind an identity-aware proxy that owns the `Authorization` header, use `PORTAINER_MCP_TRUST_PROXY_AUTH=1` instead (see Option D).
 
 
 #### Option A - BYO certificates
@@ -147,6 +147,27 @@ claude mcp add portainer --transport http http://mcp.example.com:17717/mcp \
   --header "Authorization: Bearer <gate-token>" \
   --header "X-Portainer-API-Key: <ptr_user_key>"
 ````
+
+#### Option D - Identity-aware proxy (MCP OAuth)
+
+If your users authenticate through an identity-aware proxy that speaks the MCP OAuth flow (e.g. [Pomerium in MCP server mode](https://www.pomerium.com/docs/capabilities/mcp)), the proxy mints its own access token and **owns** the `Authorization` header — a static gate token can't survive the hop. Declare the trust-proxy auth posture instead of `PORTAINER_MCP_AUTH_TOKEN`:
+
+> [!NOTE]
+> Same rules as Option B: don't publish the container port (only the proxy may reach it), and make sure the proxy forwards the original `Host` and `X-Forwarded-Proto: https` headers.
+>
+> Each request still needs the caller's own Portainer API key in `X-Portainer-API-Key` — have the proxy inject it per-user, or have each client send it. The proxy handles *who gets in*; the Portainer key governs *what they can do*.
+
+````bash
+docker run -d --name portainer-mcp \
+	-e PORTAINER_URL=https://portainer.example.com \
+	-e PORTAINER_MCP_TRUST_PROXY_AUTH=1 \
+	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com \
+	-e PORTAINER_MCP_TRUST_PROXY_TLS=1 \
+	-e PORTAINER_MCP_FORWARDED_ALLOW_IPS=172.18.0.0/16 \
+	portainer/portainer-mcp:2.43
+````
+
+No gate token is configured: the request is admitted by proxy attestation (it must arrive from `PORTAINER_MCP_FORWARDED_ALLOW_IPS` — inherited as the trust boundary, `*` refuses to boot) and by the caller's validated Portainer key. If the MCP server terminates TLS itself instead of the proxy, set `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS=<proxy ip/cidr>` in place of the two `TRUST_PROXY_TLS`/`FORWARDED_ALLOW_IPS` lines. See [`docs/configuration.md`](https://github.com/portainer/portainer-mcp/blob/main/docs/configuration.md#auth-posture-identity-aware-proxies) for the full posture rules.
 
 ## Restricting and expanding the MCP server capabilities
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,9 +146,12 @@ the proxy's forwarded headers" are mutually exclusive signals:
    `PORTAINER_MCP_TRUST_PROXY_TLS=1` + `FORWARDED_ALLOW_IPS`; no extra
    variable. The attestation is `scheme == "https"`: uvicorn sets it only
    from a trusted peer's `X-Forwarded-Proto`, and this shape holds no cert,
-   so a direct connection can never present it. A wildcard
-   `FORWARDED_ALLOW_IPS='*'` is a startup error here — inheritance turns
-   that list into the auth boundary.
+   so a direct connection can never present it. Because "holds no cert" is
+   load-bearing, `TLS_CERT` set alongside this shape is a startup error —
+   a server-held cert would let every direct TLS connection self-attest.
+   A wildcard in `FORWARDED_ALLOW_IPS` (`*` or a zero-prefix network like
+   `0.0.0.0/0`) is likewise a startup error here — inheritance turns that
+   list into the auth boundary.
 2. **Socket peer** (server-terminated TLS, end-to-end encrypted):
    `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS=<ip/cidr,…>` names the proxy
    directly; `resolve()` returns `proxy_headers: False` so uvicorn never
@@ -161,7 +164,9 @@ the proxy's forwarded headers" are mutually exclusive signals:
 Degenerate combinations all hard-fail: gate token + trust flag (ambiguous),
 trust flag + plaintext opt-out (the per-user key would be the only credential
 and it must not cross plaintext), trust flag without
-`PORTAINER_MCP_ALLOWED_HOSTS` on a non-loopback bind. Failed attestation
+`PORTAINER_MCP_ALLOWED_HOSTS` on a non-loopback bind, and
+`TRUSTED_PROXY_AUTH_IPS` without the trust flag (silently dead security
+config). Failed attestation
 audits as `untrusted_peer` / `untrusted_scheme` (per-request, uncached), and
 every audit record under this posture carries `auth_posture: "trust_proxy"`.
 The per-user `X-Portainer-API-Key` floor is untouched in both postures —

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,8 +83,9 @@ stdio-only credential). Two layered checks run on every request, both inside
    it (min 32 chars, ASCII printable, no whitespace, loud-fail on any defect),
    and the verifier constant-time-compares the request's `Authorization: Bearer`
    against it (`hmac.compare_digest`). A miss returns `None` → FastMCP renders
-   401 + `WWW-Authenticate`. The gate is mandatory (no opt-out) and stops
-   credential-less floods at a cheap local 401 before they reach Portainer.
+   401 + `WWW-Authenticate`. The gate stops credential-less floods at a cheap
+   local 401 before they reach Portainer. It has exactly one alternative — the
+   trust-proxy auth posture below — and never a silent opt-out.
 2. **Per-user validation.** The caller's own Portainer key rides in a separate
    `X-Portainer-API-Key` header. The verifier validates it against
    `GET /users/me?noEndpointAuthorizations=true` (`passthrough.validate`) and
@@ -118,6 +119,55 @@ window), not every admitted request; cache hits admit silently. The failure
 outcomes `mismatch` / `no_user_key` / `invalid_user_key` are uncached and fire
 on every failing request. The attempted gate-token bytes and the per-user key
 are **never** logged (regression-tested).
+
+### Auth posture — `auth_posture.py`
+
+An identity-aware proxy that performs the MCP OAuth flow (e.g. Pomerium in
+MCP server mode) mints its own access token and *owns* the `Authorization`
+header on the upstream request — a static gate token cannot survive that hop
+([#76](https://github.com/portainer/portainer-mcp/issues/76)). `resolve()`
+runs at startup (mirroring `tls.resolve_posture`) and requires **exactly one**
+auth posture; both or neither refuse to boot:
+
+- **Gate token** (default) — `PORTAINER_MCP_AUTH_TOKEN`, the flow above.
+- **Trust-proxy auth** — `PORTAINER_MCP_TRUST_PROXY_AUTH=1`. The bearer value
+  is ignored entirely (`TrustedProxyVerifier`; a small pre-auth middleware
+  injects a placeholder when the proxy strips `Authorization` outright, since
+  the SDK's bearer backend 401s header-less requests before `verify_token`).
+  What replaces the gate compare is per-request proof the request transited
+  the proxy, in one of two shapes.
+
+The two shapes exist because uvicorn's proxy-header middleware rewrites
+`scope["client"]` from `X-Forwarded-For` for connections arriving from
+`PORTAINER_MCP_FORWARDED_ALLOW_IPS` — so "check the socket peer" and "trust
+the proxy's forwarded headers" are mutually exclusive signals:
+
+1. **Inherited** (TLS-terminating proxy, the common shape): requires
+   `PORTAINER_MCP_TRUST_PROXY_TLS=1` + `FORWARDED_ALLOW_IPS`; no extra
+   variable. The attestation is `scheme == "https"`: uvicorn sets it only
+   from a trusted peer's `X-Forwarded-Proto`, and this shape holds no cert,
+   so a direct connection can never present it. A wildcard
+   `FORWARDED_ALLOW_IPS='*'` is a startup error here — inheritance turns
+   that list into the auth boundary.
+2. **Socket peer** (server-terminated TLS, end-to-end encrypted):
+   `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS=<ip/cidr,…>` names the proxy
+   directly; `resolve()` returns `proxy_headers: False` so uvicorn never
+   rewrites the peer, and the verifier checks `scope["client"]` against the
+   allowlist (`PeerMatcher`; wildcard and non-IP entries hard-fail).
+   Incompatible with `TRUST_PROXY_TLS`/`FORWARDED_ALLOW_IPS` (the rewrite
+   would corrupt the peer signal) and requires `TLS_CERT`/`_TLS_KEY` on a
+   non-loopback bind.
+
+Degenerate combinations all hard-fail: gate token + trust flag (ambiguous),
+trust flag + plaintext opt-out (the per-user key would be the only credential
+and it must not cross plaintext), trust flag without
+`PORTAINER_MCP_ALLOWED_HOSTS` on a non-loopback bind. Failed attestation
+audits as `untrusted_peer` / `untrusted_scheme` (per-request, uncached), and
+every audit record under this posture carries `auth_posture: "trust_proxy"`.
+The per-user `X-Portainer-API-Key` floor is untouched in both postures —
+trust-proxy auth drops the *gate*, never authentication — and IP/scheme
+attestation is weaker than a secret in flat container networks: the operator
+owns keeping the proxy the only workload that can reach the bind address.
 
 ### HTTP security — `http_security.py`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,8 +63,10 @@ Combinations that refuse to boot, by design:
 
 - `PORTAINER_MCP_AUTH_TOKEN` together with `PORTAINER_MCP_TRUST_PROXY_AUTH=1` — ambiguous posture.
 - `PORTAINER_MCP_TRUST_PROXY_AUTH=1` with `PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1` — the per-user key becomes the only credential the server sees; it must never cross the wire in plaintext.
-- A wildcard (`*`) anywhere in the effective peer allowlist — it is the auth boundary in this posture.
+- A wildcard anywhere in the effective peer allowlist — `*` or a zero-prefix network (`0.0.0.0/0`, `::/0`) — it is the auth boundary in this posture.
+- The inherited shape with `PORTAINER_MCP_TLS_CERT` also set — a server-held cert lets every direct TLS connection present `https`, voiding the attestation; use `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS` instead.
 - `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS` together with `PORTAINER_MCP_TRUST_PROXY_TLS`/`PORTAINER_MCP_FORWARDED_ALLOW_IPS` — the `X-Forwarded-For` rewrite would corrupt the socket-peer signal; behind a TLS-terminating proxy use inheritance instead.
+- `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS` without `PORTAINER_MCP_TRUST_PROXY_AUTH=1` — the allowlist would be silently dead config.
 - `PORTAINER_MCP_TRUST_PROXY_AUTH=1` on a non-loopback bind without `PORTAINER_MCP_ALLOWED_HOSTS` set to the proxy-fronted hostname.
 
 > [!IMPORTANT]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,9 @@ The server will not start if `PORTAINER_URL` is missing, if `PORTAINER_API_KEY` 
 | `PORTAINER_MCP_TRANSPORT` | `stdio` | `stdio` or `http`. The container image overrides to `http`. |
 | `PORTAINER_MCP_HTTP_HOST` | `127.0.0.1` | Bind address when `transport=http`. Container image overrides to `0.0.0.0` so it's reachable from outside the container. |
 | `PORTAINER_MCP_HTTP_PORT` | `17717` | Bind port when `transport=http`. |
-| `PORTAINER_MCP_AUTH_TOKEN` | _required for http_ | Shared bearer **gate** secret. ≥32 ASCII-printable characters, no whitespace. Generate with `openssl rand -hex 32`. Ignored under stdio. Admits the request; the caller's own Portainer key is then validated and forwarded (see below). |
+| `PORTAINER_MCP_AUTH_TOKEN` | _required for http_ | Shared bearer **gate** secret. ≥32 ASCII-printable characters, no whitespace. Generate with `openssl rand -hex 32`. Ignored under stdio. Admits the request; the caller's own Portainer key is then validated and forwarded (see below). The one alternative is the [trust-proxy auth posture](#auth-posture-identity-aware-proxies); setting both refuses to boot. |
+| `PORTAINER_MCP_TRUST_PROXY_AUTH` | `0` | Replace the gate-token compare with per-request **proxy attestation**, for identity-aware proxies that own the `Authorization` header (e.g. Pomerium in MCP server mode). See [Auth posture](#auth-posture-identity-aware-proxies). |
+| `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS` | _unset_ | Socket-peer allowlist (IPs/CIDRs) backing `PORTAINER_MCP_TRUST_PROXY_AUTH` when **this server terminates TLS itself**. Behind a TLS-terminating proxy leave it unset — the `PORTAINER_MCP_FORWARDED_ALLOW_IPS` attestation is inherited. `*` refuses to boot. |
 | `PORTAINER_MCP_AUTH_CACHE_TTL` | `60` | Seconds to cache a validated per-user key. Positive results only; `0` disables caching (validate every request). HTTP only. |
 
 The stdio transport ignores everything in this section except `PORTAINER_MCP_TRANSPORT` itself.
@@ -43,6 +45,30 @@ claude mcp add portainer --transport http http://mcp.example.com:17717/mcp \
 
 A missing/invalid gate token **or** missing/invalid per-user key returns 401 — there is no fallback to a shared key. This gives each user Portainer's own RBAC and per-user attribution in both Portainer's audit log and the MCP audit log.
 
+### Auth posture (identity-aware proxies)
+
+Exactly **one** auth posture must be declared under HTTP — the server refuses to boot with both or neither:
+
+1. **Gate token** (default) — `PORTAINER_MCP_AUTH_TOKEN`, as above.
+2. **Trust-proxy auth** — `PORTAINER_MCP_TRUST_PROXY_AUTH=1`, for deployments behind an identity-aware proxy that performs the MCP OAuth flow itself (Pomerium in MCP server mode, and similar). Such proxies mint their own access token and **own** the `Authorization` header on the upstream request, so a static gate token cannot survive the hop. Under this posture the `Authorization` value is ignored (never compared, never logged) and the gate is replaced by per-request proof that the request came through the proxy. The per-user `X-Portainer-API-Key` validation is unchanged — it remains the credential that actually authenticates each caller (the proxy can inject it, or each client supplies its own).
+
+The proxy attestation takes one of two shapes:
+
+| Your TLS posture | What to set | How the request is attested |
+|---|---|---|
+| TLS-terminating proxy (`PORTAINER_MCP_TRUST_PROXY_TLS=1` + `PORTAINER_MCP_FORWARDED_ALLOW_IPS`) | Just `PORTAINER_MCP_TRUST_PROXY_AUTH=1` — the peer allowlist is **inherited** from `PORTAINER_MCP_FORWARDED_ALLOW_IPS` | Request scheme must be `https`, which uvicorn only sets from an allowlisted peer's `X-Forwarded-Proto` — and this shape holds no cert, so a direct connection can never present it |
+| Server-terminated TLS (`PORTAINER_MCP_TLS_CERT`/`_TLS_KEY`) | `PORTAINER_MCP_TRUST_PROXY_AUTH=1` + `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS=<proxy ip/cidr>` | The **socket peer** must be in the allowlist (uvicorn's `X-Forwarded-*` rewriting is disabled in this shape so the peer stays observable) |
+
+Combinations that refuse to boot, by design:
+
+- `PORTAINER_MCP_AUTH_TOKEN` together with `PORTAINER_MCP_TRUST_PROXY_AUTH=1` — ambiguous posture.
+- `PORTAINER_MCP_TRUST_PROXY_AUTH=1` with `PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1` — the per-user key becomes the only credential the server sees; it must never cross the wire in plaintext.
+- A wildcard (`*`) anywhere in the effective peer allowlist — it is the auth boundary in this posture.
+- `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS` together with `PORTAINER_MCP_TRUST_PROXY_TLS`/`PORTAINER_MCP_FORWARDED_ALLOW_IPS` — the `X-Forwarded-For` rewrite would corrupt the socket-peer signal; behind a TLS-terminating proxy use inheritance instead.
+- `PORTAINER_MCP_TRUST_PROXY_AUTH=1` on a non-loopback bind without `PORTAINER_MCP_ALLOWED_HOSTS` set to the proxy-fronted hostname.
+
+> [!IMPORTANT]
+> IP/scheme attestation is weaker than a shared secret on a flat network: any workload that can reach the bind address from an allowlisted IP skips the gate. Keep the proxy the **only** thing that can reach the container (don't publish its port; keep the allowlisted subnet free of untrusted workloads). The floor still holds — every request must carry a valid Portainer API key — so a bypass admits only what that caller's own Portainer RBAC allows, but it does skip the proxy's own authorization policy.
 
 ## Hardening (HTTP transport only)
 
@@ -124,7 +150,7 @@ Audit and structured-request records both carry the same per-request context fie
 distinguishes Claude Code / Inspector / custom scripts), and `session_id` (the MCP `Mcp-Session-Id` assigned at `initialize` —
 absent on the `initialize` request itself, present on every subsequent request in the session). With a single shared gate bearer the audit deliberately omits `token_fp` since it would be a constant; failed attempts likewise carry no token content, and the per-user `X-Portainer-API-Key` is never logged.
 
-The audit `outcome` is one of `ok`, `mismatch` (wrong gate token), `no_user_key` (gate passed but no `X-Portainer-API-Key`), or `invalid_user_key` (key rejected by `/users/me` or Portainer unreachable). A successful `ok` — and every matching structured-request record — is attributed with the validated Portainer identity: `portainer_user_id`, `portainer_username`. This is the per-user attribution the passthrough model buys; the key that resolves to that identity is never recorded. Structured-request records for a `tools/call` also carry the `tool` name (the `method` field alone is just `tools/call`).
+The audit `outcome` is one of `ok`, `mismatch` (wrong gate token), `no_user_key` (gate passed but no `X-Portainer-API-Key`), or `invalid_user_key` (key rejected by `/users/me` or Portainer unreachable). Under the trust-proxy auth posture, `mismatch` is replaced by `untrusted_scheme` (request didn't transit the attested TLS-terminating proxy) or `untrusted_peer` (socket peer not in `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS`; the record carries the rejected `peer`), and every audit record additionally carries `auth_posture: "trust_proxy"`. A successful `ok` — and every matching structured-request record — is attributed with the validated Portainer identity: `portainer_user_id`, `portainer_username`. This is the per-user attribution the passthrough model buys; the key that resolves to that identity is never recorded. Structured-request records for a `tools/call` also carry the `tool` name (the `method` field alone is just `tools/call`).
 
 ### Audit & traceability
 

--- a/src/portainer_mcp/auth.py
+++ b/src/portainer_mcp/auth.py
@@ -3,8 +3,10 @@
 A shared secret gates the HTTP `/mcp` endpoint (`StaticBearerVerifier`).
 Over HTTP that gate is layered with per-user key validation
 (`PassthroughVerifier`): the gate admits the request, then the caller's own
-Portainer key is validated before the request is trusted. Stdio transport is
-unaffected (no auth).
+Portainer key is validated before the request is trusted. Under the
+trust-proxy auth posture (`auth_posture`), the gate compare is replaced by
+per-request proxy attestation (`TrustedProxyVerifier`) — the per-user key
+layer is identical. Stdio transport is unaffected (no auth).
 """
 
 from __future__ import annotations
@@ -12,12 +14,18 @@ from __future__ import annotations
 import hmac
 import json
 import logging
+from typing import TYPE_CHECKING
 
 import httpx
 from fastmcp.server.auth import AccessToken, TokenVerifier
+from fastmcp.server.dependencies import get_http_request
 from starlette.middleware import Middleware
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from . import passthrough, request_context
+
+if TYPE_CHECKING:
+    from .auth_posture import PeerMatcher
 
 ENV_VAR = "PORTAINER_MCP_AUTH_TOKEN"
 MIN_TOKEN_LENGTH = 32
@@ -33,10 +41,21 @@ audit_logger = logging.getLogger("portainer_mcp.audit")
 # admitted crossed the wire unencrypted.
 _insecure_transport = False
 
+# Set once at boot under PORTAINER_MCP_TRUST_PROXY_AUTH=1 so every audit
+# record says which posture admitted it — a reader must be able to tell a
+# gate-token `ok` from a proxy-attested one without consulting the deploy
+# config that was live at the time.
+_trust_proxy_auth = False
+
 
 def mark_insecure_transport() -> None:
     global _insecure_transport
     _insecure_transport = True
+
+
+def mark_trust_proxy_auth() -> None:
+    global _trust_proxy_auth
+    _trust_proxy_auth = True
 
 
 def _audit(outcome: str, level: int, **extra: object) -> None:
@@ -48,6 +67,8 @@ def _audit(outcome: str, level: int, **extra: object) -> None:
     record: dict[str, object] = {"event": "auth", "outcome": outcome}
     if _insecure_transport:
         record["insecure_transport"] = True
+    if _trust_proxy_auth:
+        record["auth_posture"] = "trust_proxy"
     audit_logger.log(
         level, json.dumps({**record, **request_context.snapshot(), **extra})
     )
@@ -62,7 +83,9 @@ def require_token(raw: str | None) -> str:
     if not raw:
         raise SystemExit(
             f"{ENV_VAR} is required when PORTAINER_MCP_TRANSPORT=http "
-            f"(generate one with `openssl rand -hex 32`)"
+            f"(generate one with `openssl rand -hex 32`). Behind an "
+            f"identity-aware proxy that owns the Authorization header, set "
+            f"PORTAINER_MCP_TRUST_PROXY_AUTH=1 instead."
         )
     if len(raw) < MIN_TOKEN_LENGTH:
         raise SystemExit(
@@ -171,6 +194,12 @@ class PassthroughVerifier(StaticBearerVerifier):
         if not self._matches(token):
             _audit("mismatch", logging.WARNING)
             return None
+        return await self._admit_user_key(token)
+
+    async def _admit_user_key(self, token: str) -> AccessToken | None:
+        """Layer 2, shared with `TrustedProxyVerifier`: validate the caller's
+        own Portainer key and admit the request under that identity.
+        """
         key = passthrough.key_from_request()
         if not key:
             # Gate passed but no per-user key — the request can't act as anyone.
@@ -190,3 +219,86 @@ class PassthroughVerifier(StaticBearerVerifier):
         if validated_now:
             _audit("ok", logging.INFO, **identity.audit_fields())
         return self._access_token(token)
+
+
+# Stand-in bearer under the trust-proxy posture: injected when the proxy
+# strips Authorization, and used as the AccessToken label. Not a secret —
+# the posture's admission signal is the proxy attestation, never this value.
+_PROXY_PLACEHOLDER = "proxy-attested"
+
+
+class _EnsureBearerMiddleware:
+    """Inject a placeholder `Authorization` when the request carries none.
+
+    The MCP SDK's `BearerAuthBackend` never calls `verify_token` without a
+    `Bearer` header — it 401s first. Under the trust-proxy posture the
+    header's value is ignored anyway, so a proxy that strips `Authorization`
+    (rather than replacing it with its own minted token) must not be locked
+    out. Installed only by `TrustedProxyVerifier`.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and not any(
+            k == b"authorization" for k, _ in scope["headers"]
+        ):
+            scope["headers"] = [
+                *scope["headers"],
+                (b"authorization", b"Bearer " + _PROXY_PLACEHOLDER.encode()),
+            ]
+        await self.app(scope, receive, send)
+
+
+class TrustedProxyVerifier(PassthroughVerifier):
+    """Trust-proxy auth posture: the gate compare is replaced by attestation.
+
+    An identity-aware proxy in front performs authn/authz and owns the
+    `Authorization` header (it carries the proxy's own minted OAuth token) —
+    the value is never compared and never logged. What replaces the gate is
+    per-request proof the request transited the proxy:
+
+    - `peer_matcher` set (server-terminated TLS shape): the socket peer must
+      be in the allowlist. `auth_posture` disables uvicorn's proxy-header
+      rewrite in this shape so `scope["client"]` stays the raw peer.
+    - `peer_matcher` None (inherited, TLS-terminating-proxy shape): the
+      request scheme must be `https`, which uvicorn sets only from a trusted
+      peer's `X-Forwarded-Proto` — and this shape holds no cert, so a direct
+      connection can never present it.
+
+    The per-user `X-Portainer-API-Key` layer is inherited unchanged; it is
+    what actually authenticates the caller.
+    """
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        cache: passthrough.ValidationCache,
+        peer_matcher: PeerMatcher | None = None,
+    ) -> None:
+        # The parent's expected-gate compare is never reached (verify_token
+        # is overridden); the placeholder just satisfies its constructor.
+        super().__init__(_PROXY_PLACEHOLDER, client, cache)
+        self._peers = peer_matcher
+
+    def get_middleware(self) -> list:
+        return [Middleware(_EnsureBearerMiddleware), *super().get_middleware()]
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        try:
+            request = get_http_request()
+        except RuntimeError:
+            request = None
+        if self._peers is not None:
+            peer = request.client.host if request and request.client else None
+            if peer is None or not self._peers.matches(peer):
+                _audit("untrusted_peer", logging.WARNING, peer=peer)
+                return None
+        elif request is None or request.scope.get("scheme") != "https":
+            _audit("untrusted_scheme", logging.WARNING)
+            return None
+        # Admit under the placeholder, not `token`: the proxy's minted bearer
+        # must not leak into AccessToken (even fingerprinted, it's the proxy's
+        # credential, not ours to record).
+        return await self._admit_user_key(_PROXY_PLACEHOLDER)

--- a/src/portainer_mcp/auth.py
+++ b/src/portainer_mcp/auth.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import hmac
 import json
 import logging
+import secrets
 from typing import TYPE_CHECKING
 
 import httpx
@@ -278,8 +279,10 @@ class TrustedProxyVerifier(PassthroughVerifier):
         peer_matcher: PeerMatcher | None = None,
     ) -> None:
         # The parent's expected-gate compare is never reached (verify_token
-        # is overridden); the placeholder just satisfies its constructor.
-        super().__init__(_PROXY_PLACEHOLDER, client, cache)
+        # is overridden). Satisfy its constructor with a per-process random
+        # nonce, not the public placeholder — so no knowable string could
+        # ever match if a refactor re-routed through the parent path.
+        super().__init__(secrets.token_hex(32), client, cache)
         self._peers = peer_matcher
 
     def get_middleware(self) -> list:

--- a/src/portainer_mcp/auth_posture.py
+++ b/src/portainer_mcp/auth_posture.py
@@ -28,10 +28,12 @@ from `PORTAINER_MCP_FORWARDED_ALLOW_IPS` — so "check the socket peer" and
     directly and uvicorn's proxy-header rewrite is disabled so
     `scope["client"]` stays the raw transport peer.
 
-Whichever shape, `*` is a startup error — a wildcard peer allowlist would
-admit any host that can reach the bind address — and the per-user
-`X-Portainer-API-Key` validation floor is untouched: trust-proxy auth drops
-the gate, never authentication.
+Whichever shape, a wildcard peer allowlist (`*` or a zero-prefix network
+like `0.0.0.0/0`) is a startup error — it would admit any host that can
+reach the bind address — and the inherited shape refuses a server-held TLS
+cert (it would let every direct connection present `https` and void the
+attestation). The per-user `X-Portainer-API-Key` validation floor is
+untouched: trust-proxy auth drops the gate, never authentication.
 """
 
 from __future__ import annotations
@@ -47,6 +49,19 @@ TRUST_PROXY_AUTH_ENV = "PORTAINER_MCP_TRUST_PROXY_AUTH"
 PEER_IPS_ENV = "PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS"
 
 
+def _admits_any_peer(entry: str) -> bool:
+    """True for allowlist spellings that admit every peer: the literal `*`
+    and zero-prefix networks (`0.0.0.0/0`, `::/0`), which are wildcards in
+    CIDR clothing.
+    """
+    if entry == "*":
+        return True
+    try:
+        return ipaddress.ip_network(entry, strict=False).prefixlen == 0
+    except ValueError:
+        return False
+
+
 class PeerMatcher:
     """Validated IP/CIDR allowlist matched against the socket peer.
 
@@ -56,7 +71,7 @@ class PeerMatcher:
     """
 
     def __init__(self, raw: str) -> None:
-        entries = [e.strip() for e in raw.split(",") if e.strip()]
+        entries = http_security._split_csv(raw)
         if not entries:
             raise SystemExit(f"{PEER_IPS_ENV} is set but empty")
         self._networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
@@ -69,18 +84,30 @@ class PeerMatcher:
                     f"subnet."
                 )
             try:
-                self._networks.append(ipaddress.ip_network(entry, strict=False))
+                network = ipaddress.ip_network(entry, strict=False)
             except ValueError:
                 raise SystemExit(
                     f"{PEER_IPS_ENV} entry {entry!r} is not an IP address or "
                     f"CIDR network"
                 )
+            if network.prefixlen == 0:
+                raise SystemExit(
+                    f"{PEER_IPS_ENV} entry {entry!r} is a zero-prefix network "
+                    f"— a wildcard in CIDR spelling, admitting any host that "
+                    f"can reach the bind address. Pin the proxy's IP or subnet."
+                )
+            self._networks.append(network)
 
     def matches(self, host: str) -> bool:
         try:
             ip = ipaddress.ip_address(host)
         except ValueError:
             return False
+        # A dual-stack bind surfaces IPv4 peers as IPv4-mapped IPv6
+        # (::ffff:10.0.0.5), which is version-strict-unequal to any IPv4
+        # network — unmap so IPv4 allowlist entries match.
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
+            ip = ip.ipv4_mapped
         return any(ip in net for net in self._networks)
 
 
@@ -104,8 +131,16 @@ def resolve(bind_host: str) -> AuthPosture:
     ambiguous or degenerate combination, so no flag combination boots an
     ungated server.
     """
-    trust = tls._flag(TRUST_PROXY_AUTH_ENV)
+    trust = tls.flag(TRUST_PROXY_AUTH_ENV)
+    peer_ips = os.environ.get(PEER_IPS_ENV)
     if not trust:
+        if peer_ips:
+            raise SystemExit(
+                f"{PEER_IPS_ENV} is set but {TRUST_PROXY_AUTH_ENV} is not — "
+                f"the allowlist would be silently ignored under the gate-token "
+                f"posture. Set {TRUST_PROXY_AUTH_ENV}=1 or remove "
+                f"{PEER_IPS_ENV}."
+            )
         # Gate mode. A missing token still hard-fails, in auth.require_token —
         # its error names this posture as the alternative.
         return AuthPosture("gate", None, {}, "shared gate token")
@@ -116,7 +151,7 @@ def resolve(bind_host: str) -> AuthPosture:
             f"auth posture. The gate token cannot survive a proxy that owns "
             f"the Authorization header; declare exactly one."
         )
-    if tls._flag(tls.ALLOW_PLAINTEXT_ENV):
+    if tls.flag(tls.ALLOW_PLAINTEXT_ENV):
         raise SystemExit(
             f"{TRUST_PROXY_AUTH_ENV}=1 makes each caller's X-Portainer-API-Key "
             f"the only credential this server sees — it must never cross the "
@@ -130,8 +165,7 @@ def resolve(bind_host: str) -> AuthPosture:
             f"localhost defaults would 421-reject every proxied request)."
         )
 
-    peer_ips = os.environ.get(PEER_IPS_ENV)
-    trust_proxy_tls = tls._flag(tls.TRUST_PROXY_ENV)
+    trust_proxy_tls = tls.flag(tls.TRUST_PROXY_ENV)
     forwarded = os.environ.get(tls.FORWARDED_IPS_ENV)
 
     if peer_ips:
@@ -171,16 +205,26 @@ def resolve(bind_host: str) -> AuthPosture:
     if not forwarded:
         # tls.resolve_posture repeats this check, but it runs after the
         # verifier is built — fail at the earliest read.
+        raise SystemExit(tls.TRUST_PROXY_REQUIRES_IPS)
+    if any(_admits_any_peer(e) for e in http_security._split_csv(forwarded)):
         raise SystemExit(
-            f"{tls.TRUST_PROXY_ENV}=1 requires {tls.FORWARDED_IPS_ENV}="
-            f"<proxy ip/subnet>"
+            f"a wildcard (or zero-prefix network like 0.0.0.0/0) in "
+            f"{tls.FORWARDED_IPS_ENV} cannot back {TRUST_PROXY_AUTH_ENV}=1 — "
+            f"the inherited allowlist becomes the auth boundary, and it would "
+            f"admit any peer that can reach the bind address. Pin the proxy's "
+            f"IP or subnet."
         )
-    if any(e.strip() == "*" for e in forwarded.split(",")):
+    if os.environ.get(tls.CERT_ENV):
+        # The inherited attestation only means "came through the proxy"
+        # because no cert is held: uvicorn can then set scheme=https solely
+        # from a trusted peer's X-Forwarded-Proto. A server-held cert makes
+        # every direct TLS connection present https and the attestation
+        # attests nothing.
         raise SystemExit(
-            f"{tls.FORWARDED_IPS_ENV}='*' cannot back {TRUST_PROXY_AUTH_ENV}=1 "
-            f"— the inherited allowlist becomes the auth boundary, and a "
-            f"wildcard would admit any peer that can reach the bind address. "
-            f"Pin the proxy's IP or subnet."
+            f"{tls.CERT_ENV} is set: this server terminates TLS itself, so "
+            f"any direct connection presents scheme=https and the inherited "
+            f"proxy attestation is void. Use {PEER_IPS_ENV}=<proxy ip/cidr> "
+            f"(socket-peer shape) instead of {tls.TRUST_PROXY_ENV}=1."
         )
     return AuthPosture(
         "trust_proxy",

--- a/src/portainer_mcp/auth_posture.py
+++ b/src/portainer_mcp/auth_posture.py
@@ -1,0 +1,191 @@
+"""Auth posture resolution for the HTTP transport.
+
+Exactly one of two auth postures must be declared, mirroring the TLS posture
+pattern (`tls.resolve_posture`): the server never boots with an ambiguous or
+absent auth boundary.
+
+  - gate token (default): `PORTAINER_MCP_AUTH_TOKEN` — a shared bearer in
+    `Authorization` admits the request (`auth.PassthroughVerifier`).
+  - trust-proxy auth: `PORTAINER_MCP_TRUST_PROXY_AUTH=1` — an identity-aware
+    proxy in front (e.g. Pomerium in MCP server mode) performs the MCP OAuth
+    flow and *owns* the `Authorization` header, so a static gate token cannot
+    survive the hop (issue #76). The gate compare is replaced by per-request
+    proof that the request transited the proxy.
+
+That proof takes one of two shapes, because uvicorn's proxy-header handling
+rewrites `scope["client"]` from `X-Forwarded-For` for connections arriving
+from `PORTAINER_MCP_FORWARDED_ALLOW_IPS` — so "check the socket peer" and
+"trust the proxy's forwarded headers" are mutually exclusive signals:
+
+  - inherited (TLS-terminating proxy, the common shape): requires
+    `PORTAINER_MCP_TRUST_PROXY_TLS=1` + `PORTAINER_MCP_FORWARDED_ALLOW_IPS`.
+    The attestation is the request scheme: uvicorn sets `https` only from a
+    trusted peer's `X-Forwarded-Proto`, and this shape holds no cert, so no
+    direct connection can present `https`. The allowlist is inherited — no
+    extra variable to configure.
+  - socket peer (server-terminated TLS, the end-to-end-encrypted shape):
+    `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS=<ip/cidr,...>` names the proxy
+    directly and uvicorn's proxy-header rewrite is disabled so
+    `scope["client"]` stays the raw transport peer.
+
+Whichever shape, `*` is a startup error — a wildcard peer allowlist would
+admit any host that can reach the bind address — and the per-user
+`X-Portainer-API-Key` validation floor is untouched: trust-proxy auth drops
+the gate, never authentication.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from typing import NamedTuple
+
+from . import http_security, tls
+from .auth import ENV_VAR as TOKEN_ENV
+
+TRUST_PROXY_AUTH_ENV = "PORTAINER_MCP_TRUST_PROXY_AUTH"
+PEER_IPS_ENV = "PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS"
+
+
+class PeerMatcher:
+    """Validated IP/CIDR allowlist matched against the socket peer.
+
+    Loud-fails at construction on a wildcard, an empty list, or an entry
+    that isn't an IP address or CIDR network — this list is the auth
+    boundary, so a typo must stop the boot, not silently never match.
+    """
+
+    def __init__(self, raw: str) -> None:
+        entries = [e.strip() for e in raw.split(",") if e.strip()]
+        if not entries:
+            raise SystemExit(f"{PEER_IPS_ENV} is set but empty")
+        self._networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+        for entry in entries:
+            if entry == "*":
+                raise SystemExit(
+                    f"{PEER_IPS_ENV} must not contain '*' — this allowlist is "
+                    f"the auth boundary, and a wildcard would admit any host "
+                    f"that can reach the bind address. Pin the proxy's IP or "
+                    f"subnet."
+                )
+            try:
+                self._networks.append(ipaddress.ip_network(entry, strict=False))
+            except ValueError:
+                raise SystemExit(
+                    f"{PEER_IPS_ENV} entry {entry!r} is not an IP address or "
+                    f"CIDR network"
+                )
+
+    def matches(self, host: str) -> bool:
+        try:
+            ip = ipaddress.ip_address(host)
+        except ValueError:
+            return False
+        return any(ip in net for net in self._networks)
+
+
+class AuthPosture(NamedTuple):
+    """Resolved auth posture. `peer_matcher` is set only for the socket-peer
+    shape; `uvicorn_kwargs` is merged into the uvicorn config (it disables
+    proxy-header rewriting when the socket peer is the attestation);
+    `description` is the operator-facing startup log fragment.
+    """
+
+    mode: str  # "gate" | "trust_proxy"
+    peer_matcher: PeerMatcher | None
+    uvicorn_kwargs: dict[str, object]
+    description: str
+
+
+def resolve(bind_host: str) -> AuthPosture:
+    """Validate the declared auth posture and return the resolved config.
+
+    Raises `SystemExit` (loud-fail, like `tls.resolve_posture`) on every
+    ambiguous or degenerate combination, so no flag combination boots an
+    ungated server.
+    """
+    trust = tls._flag(TRUST_PROXY_AUTH_ENV)
+    if not trust:
+        # Gate mode. A missing token still hard-fails, in auth.require_token —
+        # its error names this posture as the alternative.
+        return AuthPosture("gate", None, {}, "shared gate token")
+
+    if os.environ.get(TOKEN_ENV):
+        raise SystemExit(
+            f"{TOKEN_ENV} and {TRUST_PROXY_AUTH_ENV}=1 are both set — ambiguous "
+            f"auth posture. The gate token cannot survive a proxy that owns "
+            f"the Authorization header; declare exactly one."
+        )
+    if tls._flag(tls.ALLOW_PLAINTEXT_ENV):
+        raise SystemExit(
+            f"{TRUST_PROXY_AUTH_ENV}=1 makes each caller's X-Portainer-API-Key "
+            f"the only credential this server sees — it must never cross the "
+            f"wire in plaintext. Remove {tls.ALLOW_PLAINTEXT_ENV}."
+        )
+    bind_is_loopback = bind_host in http_security.LOOPBACK_BINDS
+    if not bind_is_loopback and not os.environ.get(http_security.ALLOWED_HOSTS_ENV):
+        raise SystemExit(
+            f"{TRUST_PROXY_AUTH_ENV}=1 requires {http_security.ALLOWED_HOSTS_ENV} "
+            f"to name the hostname the proxy fronts this server with (the "
+            f"localhost defaults would 421-reject every proxied request)."
+        )
+
+    peer_ips = os.environ.get(PEER_IPS_ENV)
+    trust_proxy_tls = tls._flag(tls.TRUST_PROXY_ENV)
+    forwarded = os.environ.get(tls.FORWARDED_IPS_ENV)
+
+    if peer_ips:
+        if trust_proxy_tls or forwarded:
+            raise SystemExit(
+                f"{PEER_IPS_ENV} attests the socket peer, but "
+                f"{tls.TRUST_PROXY_ENV}/{tls.FORWARDED_IPS_ENV} make uvicorn "
+                f"rewrite the peer from X-Forwarded-For — the two attestations "
+                f"are incompatible. Behind a TLS-terminating proxy, drop "
+                f"{PEER_IPS_ENV}: {TRUST_PROXY_AUTH_ENV}=1 inherits "
+                f"{tls.FORWARDED_IPS_ENV} as the peer allowlist."
+            )
+        if not bind_is_loopback and not os.environ.get(tls.CERT_ENV):
+            raise SystemExit(
+                f"{PEER_IPS_ENV} is the server-terminated-TLS shape (auth proxy "
+                f"in front, this server holds the cert) — set {tls.CERT_ENV} + "
+                f"{tls.KEY_ENV}, or drop {PEER_IPS_ENV} and set "
+                f"{tls.TRUST_PROXY_ENV}=1 to inherit the proxy attestation."
+            )
+        return AuthPosture(
+            "trust_proxy",
+            PeerMatcher(peer_ips),
+            # The socket peer is the attestation, so uvicorn must not rewrite
+            # scope["client"] from X-Forwarded-For (its default trusts
+            # 127.0.0.1, which would corrupt the signal for a local proxy).
+            {"proxy_headers": False},
+            f"socket-peer allowlist {peer_ips}",
+        )
+
+    if not trust_proxy_tls:
+        raise SystemExit(
+            f"{TRUST_PROXY_AUTH_ENV}=1 needs a per-request proxy attestation: "
+            f"either {tls.TRUST_PROXY_ENV}=1 + {tls.FORWARDED_IPS_ENV} "
+            f"(TLS-terminating proxy — the allowlist is inherited) or "
+            f"{PEER_IPS_ENV}=<proxy ip/cidr> (server-terminated TLS)."
+        )
+    if not forwarded:
+        # tls.resolve_posture repeats this check, but it runs after the
+        # verifier is built — fail at the earliest read.
+        raise SystemExit(
+            f"{tls.TRUST_PROXY_ENV}=1 requires {tls.FORWARDED_IPS_ENV}="
+            f"<proxy ip/subnet>"
+        )
+    if any(e.strip() == "*" for e in forwarded.split(",")):
+        raise SystemExit(
+            f"{tls.FORWARDED_IPS_ENV}='*' cannot back {TRUST_PROXY_AUTH_ENV}=1 "
+            f"— the inherited allowlist becomes the auth boundary, and a "
+            f"wildcard would admit any peer that can reach the bind address. "
+            f"Pin the proxy's IP or subnet."
+        )
+    return AuthPosture(
+        "trust_proxy",
+        None,
+        {},
+        f"attested TLS proxy, peers inherited from {tls.FORWARDED_IPS_ENV}"
+        f"={forwarded}",
+    )

--- a/src/portainer_mcp/server.py
+++ b/src/portainer_mcp/server.py
@@ -19,9 +19,18 @@ and refuses to boot if PORTAINER_API_KEY is set. Tunables:
 - PORTAINER_MCP_HTTP_HOST — bind host when transport=http (default 127.0.0.1).
 - PORTAINER_MCP_HTTP_PORT — bind port when transport=http (default 17717).
 - PORTAINER_MCP_AUTH_TOKEN — shared bearer gate secret. Required when
-  transport=http; ignored for stdio. Over HTTP it admits the request; the
-  caller's own Portainer key (X-Portainer-API-Key header) is then validated
-  and forwarded upstream as X-API-KEY.
+  transport=http (unless PORTAINER_MCP_TRUST_PROXY_AUTH=1); ignored for
+  stdio. Over HTTP it admits the request; the caller's own Portainer key
+  (X-Portainer-API-Key header) is then validated and forwarded upstream
+  as X-API-KEY.
+- PORTAINER_MCP_TRUST_PROXY_AUTH=1 — trust an identity-aware proxy that owns
+  the Authorization header (e.g. Pomerium in MCP server mode): the gate-token
+  compare is replaced by per-request proxy attestation. Mutually exclusive
+  with PORTAINER_MCP_AUTH_TOKEN; see auth_posture.py for the fail matrix.
+- PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS — socket-peer allowlist backing
+  TRUST_PROXY_AUTH when this server terminates TLS itself. Behind a
+  TLS-terminating proxy leave it unset — the FORWARDED_ALLOW_IPS attestation
+  is inherited.
 - PORTAINER_MCP_AUTH_CACHE_TTL — seconds to cache a validated per-user key
   (default 60, positive results only, 0 disables). HTTP only.
 - PORTAINER_MCP_ALLOWED_HOSTS — comma-separated `Host` allowlist for
@@ -61,6 +70,7 @@ from starlette.middleware import Middleware
 
 from portainer_mcp import (
     auth,
+    auth_posture,
     guidance,
     http_security,
     passthrough,
@@ -169,6 +179,10 @@ def _resolve_log_format() -> str:
             f"PORTAINER_MCP_LOG_FORMAT must be 'text' or 'json' (got {raw!r})"
         )
     return raw
+
+
+def _resolve_bind_host() -> str:
+    return os.environ.get("PORTAINER_MCP_HTTP_HOST") or "127.0.0.1"
 
 
 def _resolve_transport() -> str:
@@ -308,7 +322,7 @@ def build_server() -> FastMCP:
                 "the HTTP transport forwards each client's own key from the "
                 "X-Portainer-API-Key header — remove PORTAINER_API_KEY"
             )
-        token = auth.require_token(os.environ.get(auth.ENV_VAR))
+        posture = auth_posture.resolve(_resolve_bind_host())
         ttl = passthrough.resolve_ttl()
         cache = passthrough.ValidationCache(ttl)
         # No baked X-API-KEY: the per-request hook injects the caller's own key.
@@ -318,12 +332,24 @@ def build_server() -> FastMCP:
             timeout=30,
             event_hooks={"request": [passthrough.inject_api_key]},
         )
-        auth_provider = auth.PassthroughVerifier(token, client, cache)
-        logger.info(
-            "HTTP auth: per-user passthrough (gate %s, validation cache ttl=%ds)",
-            auth.fingerprint(token),
-            ttl,
-        )
+        if posture.mode == "trust_proxy":
+            auth.mark_trust_proxy_auth()
+            auth_provider = auth.TrustedProxyVerifier(
+                client, cache, posture.peer_matcher
+            )
+            logger.info(
+                "HTTP auth: trust-proxy passthrough (%s, validation cache ttl=%ds)",
+                posture.description,
+                ttl,
+            )
+        else:
+            token = auth.require_token(os.environ.get(auth.ENV_VAR))
+            auth_provider = auth.PassthroughVerifier(token, client, cache)
+            logger.info(
+                "HTTP auth: per-user passthrough (gate %s, validation cache ttl=%ds)",
+                auth.fingerprint(token),
+                ttl,
+            )
     else:
         client = httpx.AsyncClient(
             base_url=base,
@@ -425,7 +451,7 @@ def main() -> None:
     if transport == "stdio":
         server.run(show_banner=False)
         return
-    host = os.environ.get("PORTAINER_MCP_HTTP_HOST") or "127.0.0.1"
+    host = _resolve_bind_host()
     port = int(os.environ.get("PORTAINER_MCP_HTTP_PORT") or 17717)
     settings = http_security.build_settings(
         hosts=os.environ.get(http_security.ALLOWED_HOSTS_ENV),
@@ -438,6 +464,11 @@ def main() -> None:
     warning = http_security.misconfig_warning(host, settings)
     if warning is not None:
         logger.warning(warning)
+
+    # Resolved a second time (build_server validated it before wiring the
+    # verifier); here it contributes its uvicorn kwargs — the socket-peer
+    # shape disables proxy-header rewriting so scope["client"] stays raw.
+    auth_post = auth_posture.resolve(host)
 
     posture = tls.resolve_posture(host)
     for line in posture.warnings:
@@ -468,7 +499,11 @@ def main() -> None:
         # Uvicorn calls logging.config.dictConfig at server start, which
         # would overwrite the handlers we attached to uvicorn.* loggers.
         # Skip it so a single formatter owns every record.
-        uvicorn_config={"log_config": None, **posture.uvicorn_kwargs},
+        uvicorn_config={
+            "log_config": None,
+            **posture.uvicorn_kwargs,
+            **auth_post.uvicorn_kwargs,
+        },
     )
 
 

--- a/src/portainer_mcp/tls.py
+++ b/src/portainer_mcp/tls.py
@@ -46,11 +46,22 @@ FORWARDED_IPS_ENV = "PORTAINER_MCP_FORWARDED_ALLOW_IPS"
 ALLOW_PLAINTEXT_ENV = "PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP"
 
 
-# Mirrors server.py's `_env_flag`; not shared because `server` imports this
-# module, so importing back would be circular.
-def _flag(name: str) -> bool:
+# Mirrors server.py's `_env_flag` (not importable from there — `server`
+# imports this module, so importing back would be circular). Public because
+# `auth_posture` shares it.
+def flag(name: str) -> bool:
     raw = os.environ.get(name)
     return raw is not None and raw not in {"0", "false", "False"}
+
+
+# Raised from two resolvers (`resolve_posture` here, `auth_posture.resolve`
+# earlier in boot) — one constant so the same misconfiguration can't produce
+# two divergent messages.
+TRUST_PROXY_REQUIRES_IPS = (
+    f"{TRUST_PROXY_ENV}=1 requires {FORWARDED_IPS_ENV}=<proxy ip/subnet> "
+    f"so the runtime scheme check only trusts X-Forwarded-Proto from "
+    f"the proxy"
+)
 
 
 class Posture(NamedTuple):
@@ -110,9 +121,9 @@ def resolve_posture(bind_host: str) -> Posture:
     """
     cert = os.environ.get(CERT_ENV)
     key = os.environ.get(KEY_ENV)
-    trust_proxy = _flag(TRUST_PROXY_ENV)
+    trust_proxy = flag(TRUST_PROXY_ENV)
     forwarded_ips = os.environ.get(FORWARDED_IPS_ENV)
-    allow_plaintext = _flag(ALLOW_PLAINTEXT_ENV)
+    allow_plaintext = flag(ALLOW_PLAINTEXT_ENV)
     bind_is_loopback = bind_host in LOOPBACK_BINDS
 
     uvicorn_kwargs: dict[str, str] = {}
@@ -137,11 +148,7 @@ def resolve_posture(bind_host: str) -> Posture:
             )
 
     if trust_proxy and not forwarded_ips:
-        raise SystemExit(
-            f"{TRUST_PROXY_ENV}=1 requires {FORWARDED_IPS_ENV}=<proxy ip/subnet> "
-            f"so the runtime scheme check only trusts X-Forwarded-Proto from "
-            f"the proxy"
-        )
+        raise SystemExit(TRUST_PROXY_REQUIRES_IPS)
     if forwarded_ips:
         uvicorn_kwargs["forwarded_allow_ips"] = forwarded_ips
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -16,7 +16,7 @@ import pytest
 from fastmcp.server.http import set_http_request
 from starlette.requests import Request
 
-from portainer_mcp import auth, passthrough
+from portainer_mcp import auth, auth_posture, passthrough
 
 
 # --- require_token -----------------------------------------------------------
@@ -209,16 +209,21 @@ GATE = "g" * 64
 ALICE = {"Id": 7, "Username": "alice", "Role": 1}
 
 
-def _request(headers: dict[str, str] | None = None) -> Request:
+def _request(
+    headers: dict[str, str] | None = None,
+    scheme: str = "http",
+    client_host: str = "203.0.113.7",
+) -> Request:
     raw = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
     return Request(
         {
             "type": "http",
             "method": "POST",
+            "scheme": scheme,
             "path": "/mcp",
             "raw_path": b"/mcp",
             "query_string": b"",
-            "client": ("203.0.113.7", 51234),
+            "client": (client_host, 51234),
             "headers": raw,
         }
     )
@@ -298,6 +303,196 @@ async def test_passthrough_ok_fires_only_on_validation_not_cache_hits(caplog):
     assert len(oks) == 1
     assert json.loads(oks[0].message)["outcome"] == "ok"
     assert handler_calls["n"] == 1  # only the cache miss hit Portainer
+
+
+# --- TrustedProxyVerifier ----------------------------------------------------
+
+
+def _trusted_verifier(peers: str | None = None, handler=None):
+    if handler is None:
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=ALICE)
+
+    client = httpx.AsyncClient(
+        base_url="http://portainer/api", transport=httpx.MockTransport(handler)
+    )
+    matcher = auth_posture.PeerMatcher(peers) if peers else None
+    return auth.TrustedProxyVerifier(
+        client, passthrough.ValidationCache(ttl=60), matcher
+    )
+
+
+async def test_trusted_proxy_ignores_bearer_value_when_scheme_attested(caplog):
+    # The proxy's own minted OAuth token rides in Authorization — any value
+    # must admit, and must never survive into logs or the AccessToken.
+    minted = "pomerium-minted-opaque-token-value"
+    verifier = _trusted_verifier()
+    request = _request({"X-Portainer-API-Key": "ptr_alice"}, scheme="https")
+    with set_http_request(request):
+        with caplog.at_level(logging.INFO, logger="portainer_mcp.audit"):
+            access = await verifier.verify_token(minted)
+    assert access is not None
+    assert minted not in access.token
+    for record in caplog.records:
+        assert minted not in record.message
+    payload = json.loads(caplog.records[0].message)
+    assert payload["outcome"] == "ok"
+    assert payload["portainer_username"] == "alice"
+
+
+async def test_trusted_proxy_inherited_rejects_plain_scheme(caplog):
+    # Without the trusted proxy's X-Forwarded-Proto rewrite the scheme stays
+    # http — the request did not transit the attested proxy.
+    verifier = _trusted_verifier()
+    request = _request({"X-Portainer-API-Key": "ptr_alice"}, scheme="http")
+    with set_http_request(request):
+        with caplog.at_level(logging.WARNING, logger="portainer_mcp.audit"):
+            assert await verifier.verify_token("whatever") is None
+    outcomes = [json.loads(r.message)["outcome"] for r in caplog.records]
+    assert outcomes == ["untrusted_scheme"]
+
+
+async def test_trusted_proxy_inherited_rejects_without_request_context(caplog):
+    verifier = _trusted_verifier()
+    with caplog.at_level(logging.WARNING, logger="portainer_mcp.audit"):
+        assert await verifier.verify_token("whatever") is None
+    outcomes = [json.loads(r.message)["outcome"] for r in caplog.records]
+    assert outcomes == ["untrusted_scheme"]
+
+
+async def test_trusted_proxy_peer_allowlist_admits_listed_peer(caplog):
+    verifier = _trusted_verifier(peers="203.0.113.0/24")
+    request = _request({"X-Portainer-API-Key": "ptr_alice"}, scheme="https")
+    with set_http_request(request):
+        with caplog.at_level(logging.INFO, logger="portainer_mcp.audit"):
+            access = await verifier.verify_token("whatever")
+    assert access is not None
+    assert json.loads(caplog.records[0].message)["outcome"] == "ok"
+
+
+async def test_trusted_proxy_peer_allowlist_rejects_unlisted_peer(caplog):
+    verifier = _trusted_verifier(peers="10.0.0.5")
+    request = _request(
+        {"X-Portainer-API-Key": "ptr_alice"}, scheme="https", client_host="203.0.113.7"
+    )
+    with set_http_request(request):
+        with caplog.at_level(logging.WARNING, logger="portainer_mcp.audit"):
+            assert await verifier.verify_token("whatever") is None
+    payload = json.loads(caplog.records[0].message)
+    assert payload["outcome"] == "untrusted_peer"
+    assert payload["peer"] == "203.0.113.7"
+
+
+async def test_trusted_proxy_still_requires_user_key(caplog):
+    # Attestation replaces the gate, never the per-user key floor.
+    verifier = _trusted_verifier()
+    with set_http_request(_request({}, scheme="https")):
+        with caplog.at_level(logging.WARNING, logger="portainer_mcp.audit"):
+            assert await verifier.verify_token("whatever") is None
+    outcomes = [json.loads(r.message)["outcome"] for r in caplog.records]
+    assert outcomes == ["no_user_key"]
+
+
+async def test_trusted_proxy_rejects_invalid_user_key(caplog):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"message": "invalid token"})
+
+    verifier = _trusted_verifier(handler=handler)
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_bad"}, scheme="https")):
+        with caplog.at_level(logging.WARNING, logger="portainer_mcp.audit"):
+            assert await verifier.verify_token("whatever") is None
+    outcomes = [json.loads(r.message)["outcome"] for r in caplog.records]
+    assert outcomes == ["invalid_user_key"]
+
+
+async def test_audit_marks_trust_proxy_posture(caplog, monkeypatch):
+    monkeypatch.setattr(auth, "_trust_proxy_auth", True)
+    verifier = _trusted_verifier()
+    with set_http_request(_request({"X-Portainer-API-Key": "ptr_alice"}, scheme="https")):
+        with caplog.at_level(logging.INFO, logger="portainer_mcp.audit"):
+            await verifier.verify_token("whatever")
+    payload = json.loads(caplog.records[0].message)
+    assert payload["auth_posture"] == "trust_proxy"
+
+
+def test_trusted_proxy_full_stack_issue_76_scenario():
+    # The deployment from issue #76: an identity-aware proxy (Pomerium MCP
+    # mode) terminates TLS and OAuth, then forwards with its own minted token
+    # in Authorization. Exercise the real middleware chain — request-context,
+    # placeholder injection, SDK bearer backend, verifier — not the verifier
+    # in isolation.
+    from fastmcp.server.http import RequestContextMiddleware
+    from starlette.applications import Starlette
+    from starlette.middleware import Middleware
+    from starlette.responses import PlainTextResponse
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=ALICE)
+
+    client = httpx.AsyncClient(
+        base_url="http://portainer/api", transport=httpx.MockTransport(handler)
+    )
+    verifier = auth.TrustedProxyVerifier(client, passthrough.ValidationCache(ttl=60))
+
+    async def endpoint(request):
+        return PlainTextResponse(
+            "authed" if request.user.is_authenticated else "anon"
+        )
+
+    app = Starlette(
+        routes=[Route("/mcp", endpoint, methods=["POST"])],
+        middleware=[
+            Middleware(RequestContextMiddleware),
+            *verifier.get_middleware(),
+        ],
+    )
+    key = {"X-Portainer-API-Key": "ptr_alice"}
+    minted = {"Authorization": "Bearer pomerium-minted-token"}
+
+    with TestClient(app, base_url="https://testserver") as tc:
+        # The proxy's own token in Authorization — admitted by attestation.
+        assert tc.post("/mcp", headers={**minted, **key}).text == "authed"
+        # Proxy stripped Authorization — the placeholder keeps it verifiable.
+        assert tc.post("/mcp", headers=key).text == "authed"
+        # No per-user key — the floor holds regardless of attestation.
+        assert tc.post("/mcp", headers=minted).text == "anon"
+    with TestClient(app, base_url="http://testserver") as tc:
+        # Plain scheme: the request did not transit the attested proxy.
+        assert tc.post("/mcp", headers={**minted, **key}).text == "anon"
+
+
+# --- _EnsureBearerMiddleware ---------------------------------------------------
+
+
+async def _run_ensure_bearer(headers: list[tuple[bytes, bytes]]) -> list:
+    seen: dict = {}
+
+    async def app(scope, receive, send):
+        seen["headers"] = scope["headers"]
+
+    middleware = auth._EnsureBearerMiddleware(app)
+    await middleware({"type": "http", "headers": headers}, None, None)
+    return seen["headers"]
+
+
+async def test_ensure_bearer_injects_placeholder_when_absent():
+    headers = await _run_ensure_bearer([(b"host", b"mcp.example.com")])
+    assert (b"authorization", b"Bearer proxy-attested") in headers
+
+
+async def test_ensure_bearer_leaves_existing_authorization_untouched():
+    original = [(b"authorization", b"Bearer pomerium-minted")]
+    headers = await _run_ensure_bearer(list(original))
+    assert headers == original
+
+
+async def test_trusted_proxy_get_middleware_prepends_ensure_bearer():
+    verifier = _trusted_verifier()
+    stack = verifier.get_middleware()
+    assert stack[0].cls is auth._EnsureBearerMiddleware
 
 
 async def test_passthrough_never_logs_the_user_key(caplog):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -229,16 +229,21 @@ def _request(
     )
 
 
-def _verifier(handler=None) -> auth.PassthroughVerifier:
+def _mock_client(handler=None) -> httpx.AsyncClient:
     if handler is None:
 
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=ALICE)
 
-    client = httpx.AsyncClient(
+    return httpx.AsyncClient(
         base_url="http://portainer/api", transport=httpx.MockTransport(handler)
     )
-    return auth.PassthroughVerifier(GATE, client, passthrough.ValidationCache(ttl=60))
+
+
+def _verifier(handler=None) -> auth.PassthroughVerifier:
+    return auth.PassthroughVerifier(
+        GATE, _mock_client(handler), passthrough.ValidationCache(ttl=60)
+    )
 
 
 async def test_passthrough_rejects_gate_mismatch():
@@ -309,17 +314,9 @@ async def test_passthrough_ok_fires_only_on_validation_not_cache_hits(caplog):
 
 
 def _trusted_verifier(peers: str | None = None, handler=None):
-    if handler is None:
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json=ALICE)
-
-    client = httpx.AsyncClient(
-        base_url="http://portainer/api", transport=httpx.MockTransport(handler)
-    )
     matcher = auth_posture.PeerMatcher(peers) if peers else None
     return auth.TrustedProxyVerifier(
-        client, passthrough.ValidationCache(ttl=60), matcher
+        _mock_client(handler), passthrough.ValidationCache(ttl=60), matcher
     )
 
 
@@ -429,13 +426,9 @@ def test_trusted_proxy_full_stack_issue_76_scenario():
     from starlette.routing import Route
     from starlette.testclient import TestClient
 
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json=ALICE)
-
-    client = httpx.AsyncClient(
-        base_url="http://portainer/api", transport=httpx.MockTransport(handler)
+    verifier = auth.TrustedProxyVerifier(
+        _mock_client(), passthrough.ValidationCache(ttl=60)
     )
-    verifier = auth.TrustedProxyVerifier(client, passthrough.ValidationCache(ttl=60))
 
     async def endpoint(request):
         return PlainTextResponse(

--- a/tests/test_auth_posture.py
+++ b/tests/test_auth_posture.py
@@ -64,6 +64,15 @@ def test_gate_mode_ignores_token_value(clean_env):
     assert auth_posture.resolve("0.0.0.0").mode == "gate"
 
 
+def test_gate_mode_rejects_dangling_peer_allowlist(clean_env):
+    # A peer allowlist without the trust flag would be silently dead security
+    # config — loud-fail like every other half-configured posture.
+    clean_env.setenv(auth.ENV_VAR, "x" * 64)
+    clean_env.setenv(auth_posture.PEER_IPS_ENV, "10.0.0.5")
+    with pytest.raises(SystemExit, match="silently ignored"):
+        auth_posture.resolve("0.0.0.0")
+
+
 # --- mutual exclusion ---------------------------------------------------------
 
 
@@ -123,11 +132,26 @@ def test_inherited_shape_requires_forwarded_ips(clean_env):
         auth_posture.resolve("0.0.0.0")
 
 
-@pytest.mark.parametrize("forwarded", ["*", "10.0.0.5,*", " * "])
+@pytest.mark.parametrize(
+    "forwarded",
+    ["*", "10.0.0.5,*", " * ", "0.0.0.0/0", "::/0", "10.0.0.5,0.0.0.0/0"],
+)
 def test_inherited_shape_rejects_wildcard_forwarded_ips(clean_env, forwarded):
+    # Both the literal '*' and zero-prefix networks admit every peer once the
+    # list becomes the auth boundary.
     _inherited_env(clean_env)
     clean_env.setenv(tls.FORWARDED_IPS_ENV, forwarded)
     with pytest.raises(SystemExit, match="wildcard"):
+        auth_posture.resolve("0.0.0.0")
+
+
+def test_inherited_shape_rejects_server_held_cert(clean_env):
+    # With a server-held cert, every direct TLS connection presents
+    # scheme=https and the inherited attestation attests nothing.
+    _inherited_env(clean_env)
+    clean_env.setenv(tls.CERT_ENV, "/tls/cert.pem")
+    clean_env.setenv(tls.KEY_ENV, "/tls/key.pem")
+    with pytest.raises(SystemExit, match="attestation is void"):
         auth_posture.resolve("0.0.0.0")
 
 
@@ -201,9 +225,25 @@ def test_peer_matcher_non_ip_peer_never_matches():
     assert not matcher.matches("proxy.internal")
 
 
+def test_peer_matcher_unmaps_ipv4_mapped_ipv6_peers():
+    # A dual-stack bind surfaces IPv4 peers as ::ffff:a.b.c.d — they must
+    # match their IPv4 allowlist entry.
+    matcher = auth_posture.PeerMatcher("10.0.0.5")
+    assert matcher.matches("::ffff:10.0.0.5")
+    assert not matcher.matches("::ffff:10.0.0.6")
+
+
 def test_peer_matcher_rejects_wildcard():
     with pytest.raises(SystemExit, match="must not contain '\\*'"):
         auth_posture.PeerMatcher("10.0.0.5,*")
+
+
+@pytest.mark.parametrize("entry", ["0.0.0.0/0", "::/0", "10.0.0.5/0"])
+def test_peer_matcher_rejects_zero_prefix_networks(entry):
+    # Wildcards in CIDR spelling ("10.0.0.5/0" normalizes to 0.0.0.0/0 under
+    # strict=False) must stop the boot like the literal '*'.
+    with pytest.raises(SystemExit, match="zero-prefix"):
+        auth_posture.PeerMatcher(entry)
 
 
 def test_peer_matcher_rejects_garbage_entry():

--- a/tests/test_auth_posture.py
+++ b/tests/test_auth_posture.py
@@ -1,0 +1,216 @@
+"""Unit tests for `src/portainer_mcp/auth_posture.py`.
+
+The resolution fail matrix is the security property here: no combination of
+env vars may boot an ungated HTTP server, and every ambiguous declaration
+must stop the boot with an actionable message.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from portainer_mcp import auth, auth_posture, http_security, tls
+
+ALL_VARS = (
+    auth.ENV_VAR,
+    auth_posture.TRUST_PROXY_AUTH_ENV,
+    auth_posture.PEER_IPS_ENV,
+    tls.TRUST_PROXY_ENV,
+    tls.FORWARDED_IPS_ENV,
+    tls.CERT_ENV,
+    tls.KEY_ENV,
+    tls.ALLOW_PLAINTEXT_ENV,
+    http_security.ALLOWED_HOSTS_ENV,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for var in ALL_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+def _inherited_env(monkeypatch):
+    """The issue-#76 deployment: TLS-terminating identity-aware proxy."""
+    monkeypatch.setenv(auth_posture.TRUST_PROXY_AUTH_ENV, "1")
+    monkeypatch.setenv(tls.TRUST_PROXY_ENV, "1")
+    monkeypatch.setenv(tls.FORWARDED_IPS_ENV, "10.0.0.5")
+    monkeypatch.setenv(http_security.ALLOWED_HOSTS_ENV, "mcp.example.com")
+
+
+def _peer_ips_env(monkeypatch):
+    """Server-terminated TLS with an auth proxy in front."""
+    monkeypatch.setenv(auth_posture.TRUST_PROXY_AUTH_ENV, "1")
+    monkeypatch.setenv(auth_posture.PEER_IPS_ENV, "10.0.0.5")
+    monkeypatch.setenv(tls.CERT_ENV, "/tls/cert.pem")
+    monkeypatch.setenv(tls.KEY_ENV, "/tls/key.pem")
+    monkeypatch.setenv(http_security.ALLOWED_HOSTS_ENV, "mcp.example.com:17717")
+
+
+# --- gate mode (default) ------------------------------------------------------
+
+
+def test_gate_mode_when_trust_flag_unset(clean_env):
+    posture = auth_posture.resolve("0.0.0.0")
+    assert posture.mode == "gate"
+    assert posture.peer_matcher is None
+    assert posture.uvicorn_kwargs == {}
+
+
+def test_gate_mode_ignores_token_value(clean_env):
+    # Token presence/strength is require_token's job; resolve only picks a mode.
+    clean_env.setenv(auth.ENV_VAR, "x" * 64)
+    assert auth_posture.resolve("0.0.0.0").mode == "gate"
+
+
+# --- mutual exclusion ---------------------------------------------------------
+
+
+def test_both_token_and_trust_proxy_refuse_to_boot(clean_env):
+    _inherited_env(clean_env)
+    clean_env.setenv(auth.ENV_VAR, "x" * 64)
+    with pytest.raises(SystemExit, match="ambiguous auth posture"):
+        auth_posture.resolve("0.0.0.0")
+
+
+def test_trust_proxy_plus_plaintext_refuses_to_boot(clean_env):
+    _inherited_env(clean_env)
+    clean_env.setenv(tls.ALLOW_PLAINTEXT_ENV, "1")
+    with pytest.raises(SystemExit, match="plaintext"):
+        auth_posture.resolve("0.0.0.0")
+
+
+# --- ALLOWED_HOSTS requirement ------------------------------------------------
+
+
+def test_trust_proxy_requires_allowed_hosts_on_non_loopback(clean_env):
+    _inherited_env(clean_env)
+    clean_env.delenv(http_security.ALLOWED_HOSTS_ENV)
+    with pytest.raises(SystemExit, match="PORTAINER_MCP_ALLOWED_HOSTS"):
+        auth_posture.resolve("0.0.0.0")
+
+
+def test_trust_proxy_loopback_bind_exempt_from_allowed_hosts(clean_env):
+    _inherited_env(clean_env)
+    clean_env.delenv(http_security.ALLOWED_HOSTS_ENV)
+    assert auth_posture.resolve("127.0.0.1").mode == "trust_proxy"
+
+
+# --- inherited shape (TLS-terminating proxy) ----------------------------------
+
+
+def test_inherited_shape_resolves(clean_env):
+    _inherited_env(clean_env)
+    posture = auth_posture.resolve("0.0.0.0")
+    assert posture.mode == "trust_proxy"
+    assert posture.peer_matcher is None
+    assert posture.uvicorn_kwargs == {}
+    assert "10.0.0.5" in posture.description
+
+
+def test_inherited_shape_requires_trust_proxy_tls(clean_env):
+    clean_env.setenv(auth_posture.TRUST_PROXY_AUTH_ENV, "1")
+    clean_env.setenv(http_security.ALLOWED_HOSTS_ENV, "mcp.example.com")
+    with pytest.raises(SystemExit, match="per-request proxy attestation"):
+        auth_posture.resolve("0.0.0.0")
+
+
+def test_inherited_shape_requires_forwarded_ips(clean_env):
+    _inherited_env(clean_env)
+    clean_env.delenv(tls.FORWARDED_IPS_ENV)
+    with pytest.raises(SystemExit, match="PORTAINER_MCP_FORWARDED_ALLOW_IPS"):
+        auth_posture.resolve("0.0.0.0")
+
+
+@pytest.mark.parametrize("forwarded", ["*", "10.0.0.5,*", " * "])
+def test_inherited_shape_rejects_wildcard_forwarded_ips(clean_env, forwarded):
+    _inherited_env(clean_env)
+    clean_env.setenv(tls.FORWARDED_IPS_ENV, forwarded)
+    with pytest.raises(SystemExit, match="wildcard"):
+        auth_posture.resolve("0.0.0.0")
+
+
+# --- socket-peer shape (server-terminated TLS) --------------------------------
+
+
+def test_peer_ips_shape_resolves_and_disables_proxy_headers(clean_env):
+    _peer_ips_env(clean_env)
+    posture = auth_posture.resolve("0.0.0.0")
+    assert posture.mode == "trust_proxy"
+    assert posture.peer_matcher is not None
+    assert posture.peer_matcher.matches("10.0.0.5")
+    assert posture.uvicorn_kwargs == {"proxy_headers": False}
+
+
+def test_peer_ips_conflicts_with_trust_proxy_tls(clean_env):
+    _peer_ips_env(clean_env)
+    clean_env.setenv(tls.TRUST_PROXY_ENV, "1")
+    with pytest.raises(SystemExit, match="incompatible"):
+        auth_posture.resolve("0.0.0.0")
+
+
+def test_peer_ips_conflicts_with_forwarded_ips(clean_env):
+    _peer_ips_env(clean_env)
+    clean_env.setenv(tls.FORWARDED_IPS_ENV, "10.0.0.5")
+    with pytest.raises(SystemExit, match="incompatible"):
+        auth_posture.resolve("0.0.0.0")
+
+
+def test_peer_ips_requires_cert_on_non_loopback(clean_env):
+    _peer_ips_env(clean_env)
+    clean_env.delenv(tls.CERT_ENV)
+    with pytest.raises(SystemExit, match="server-terminated-TLS"):
+        auth_posture.resolve("0.0.0.0")
+
+
+def test_peer_ips_on_loopback_needs_no_cert(clean_env):
+    clean_env.setenv(auth_posture.TRUST_PROXY_AUTH_ENV, "1")
+    clean_env.setenv(auth_posture.PEER_IPS_ENV, "127.0.0.1")
+    posture = auth_posture.resolve("127.0.0.1")
+    assert posture.mode == "trust_proxy"
+    assert posture.peer_matcher.matches("127.0.0.1")
+
+
+# --- PeerMatcher --------------------------------------------------------------
+
+
+def test_peer_matcher_single_ip():
+    matcher = auth_posture.PeerMatcher("10.0.0.5")
+    assert matcher.matches("10.0.0.5")
+    assert not matcher.matches("10.0.0.6")
+
+
+def test_peer_matcher_cidr_and_multiple_entries():
+    matcher = auth_posture.PeerMatcher("172.18.0.0/16, 10.0.0.5")
+    assert matcher.matches("172.18.4.2")
+    assert matcher.matches("10.0.0.5")
+    assert not matcher.matches("192.168.1.1")
+
+
+def test_peer_matcher_ipv6():
+    matcher = auth_posture.PeerMatcher("fd00::/8,::1")
+    assert matcher.matches("fd00::1")
+    assert matcher.matches("::1")
+    assert not matcher.matches("2001:db8::1")
+
+
+def test_peer_matcher_non_ip_peer_never_matches():
+    # A unix-socket peer or unparsable host must fail closed.
+    matcher = auth_posture.PeerMatcher("10.0.0.5")
+    assert not matcher.matches("proxy.internal")
+
+
+def test_peer_matcher_rejects_wildcard():
+    with pytest.raises(SystemExit, match="must not contain '\\*'"):
+        auth_posture.PeerMatcher("10.0.0.5,*")
+
+
+def test_peer_matcher_rejects_garbage_entry():
+    with pytest.raises(SystemExit, match="not an IP address or CIDR"):
+        auth_posture.PeerMatcher("proxy.internal")
+
+
+def test_peer_matcher_rejects_empty():
+    with pytest.raises(SystemExit, match="empty"):
+        auth_posture.PeerMatcher(" , ")


### PR DESCRIPTION
Closes #76.

## Problem

Identity-aware proxies that terminate the MCP OAuth flow (Pomerium in MCP server mode, per the issue) mint their own access token and **own** the `Authorization` header on the upstream request — a statically injected `PORTAINER_MCP_AUTH_TOKEN` cannot survive the hop, so every request 401s. Both components assume they are the auth boundary, and neither yields.

## Approach

Auth becomes a **posture enum resolved at startup** (new `auth_posture.py`, mirroring `tls.resolve_posture`): exactly one of

1. **Gate token** — `PORTAINER_MCP_AUTH_TOKEN`, unchanged, still the default.
2. **Trust-proxy auth** — `PORTAINER_MCP_TRUST_PROXY_AUTH=1`. The bearer value is ignored (never compared, never logged — a small pre-auth middleware injects a placeholder when the proxy strips `Authorization` entirely, since the SDK's bearer backend 401s header-less requests before `verify_token`). The gate compare is replaced by per-request proof the request transited the proxy.

The attestation has two shapes because uvicorn's proxy-header middleware rewrites `scope["client"]` from `X-Forwarded-For` for connections from `FORWARDED_ALLOW_IPS` — socket-peer trust and forwarded-header trust are mutually exclusive signals:

| TLS posture | Config | Per-request attestation |
|---|---|---|
| TLS-terminating proxy (the issue's deployment) | just add `PORTAINER_MCP_TRUST_PROXY_AUTH=1` — the peer allowlist is **inherited** from `PORTAINER_MCP_FORWARDED_ALLOW_IPS` | `scheme == "https"`, which uvicorn sets only from an allowlisted peer's `X-Forwarded-Proto`; this shape holds no cert, so a direct connection can never present it |
| Server-terminated TLS | `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS=<proxy ip/cidr>` | socket peer ∈ allowlist; `proxy_headers` rewriting is disabled in this shape so the peer stays observable |

For the issue's chain (Claude → Cloudflare → Traefik → Pomerium → portainer-mcp), the delta over a working Option-B deployment is **one env var**.

## No combination boots ungated

Startup hard-fails (loud, actionable messages) on: both postures declared; trust-proxy + `DANGEROUSLY_ALLOW_PLAINTEXT_HTTP` (the per-user key becomes the only credential and must not cross plaintext); `*` anywhere in the effective peer allowlist (it becomes the auth boundary); `TRUSTED_PROXY_AUTH_IPS` combined with `TRUST_PROXY_TLS`/`FORWARDED_ALLOW_IPS` (the XFF rewrite would corrupt the peer signal); trust-proxy on a non-loopback bind without `ALLOWED_HOSTS`. There is deliberately no "dangerously allow no auth" option from the issue — the trust-proxy shape covers the described deployments.

The per-user `X-Portainer-API-Key` validation floor is untouched in both postures: trust-proxy drops the *gate*, never authentication. The proxy decides who gets in; each caller's own Portainer key (proxy-injected or client-supplied) still governs what they can do.

## Auditability

- New per-request, uncached failure outcomes: `untrusted_scheme` / `untrusted_peer` (with the rejected `peer`).
- Every audit record under this posture carries `auth_posture: "trust_proxy"` so an `ok` row is distinguishable from a gate-token admission after the fact.
- The proxy's minted bearer never reaches logs or `AccessToken` (regression-tested).

## Tests

- `tests/test_auth_posture.py`: the full resolution fail matrix + `PeerMatcher` (IP/CIDR/IPv6, wildcard/garbage/empty hard-fails, non-IP peers fail closed).
- `tests/test_auth.py`: `TrustedProxyVerifier` unit coverage (both shapes, floor intact, bearer-hygiene) plus a full-stack Starlette test replaying the issue's exact scenario — proxy-minted bearer admitted, stripped `Authorization` admitted, missing user key rejected, plain-scheme (direct) request rejected.

`uv run pytest`: 247 passed.

@JB09 this should unblock your Pomerium deployment as described — happy to hear whether it holds up against the real chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)