### PR TITLE
Fail the guidance gate open for callers with churning session ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ the MCP server.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Guidance gate no longer locks out bridges that re-initialize per request**
+  ([#75](https://github.com/portainer/portainer-mcp/issues/75)). Over HTTP the
+  gate keys on `Mcp-Session-Id`; a stateless bridge (e.g. a Cloudflare-worker
+  OAuth proxy) that performs a fresh MCP handshake on every call presents a
+  new id each time, so `get_guidance` could never unlock the session the
+  retry arrived in and every tool call bounced forever. The gate now detects
+  that pattern per caller (scoped by the SHA-256 of the per-user
+  `X-Portainer-API-Key` the HTTP transport already requires): on the third
+  distinct fresh session within a five-minute window *following* a successful
+  `get_guidance` (i.e. after two bounced round-trips), the caller is admitted
+  ungated with a WARNING naming the likely cause; the flag expires after an
+  hour so a false positive self-heals. Session-preserving clients are
+  unaffected — fetching guidance in the same session that was bounced clears
+  the counter, so per-session gating semantics (including a second concurrent
+  conversation by the same user) are unchanged for them.
+
 ## [2.43.1] — 2026-07-02
 
 Targets Portainer 2.43.x.

--- a/src/portainer_mcp/guidance.py
+++ b/src/portainer_mcp/guidance.py
@@ -9,6 +9,7 @@ progressive disclosure rebuilt inside MCP.
 from __future__ import annotations
 
 import logging
+import time
 from typing import Annotated
 
 from fastmcp import FastMCP
@@ -17,7 +18,7 @@ from fastmcp.tools.tool import ToolResult
 from mcp.types import TextContent, ToolAnnotations
 from pydantic import Field
 
-from portainer_mcp import request_context
+from portainer_mcp import passthrough, request_context
 from portainer_mcp.shaping import SELECT_DESCRIPTION
 
 logger = logging.getLogger("portainer_mcp")
@@ -27,6 +28,17 @@ GUIDANCE_TOOL_NAME = "get_guidance"
 # Synthetic session key for stdio, where there is no HTTP request and the
 # process lifetime *is* the session (one client connection per process).
 _STDIO_KEY = "__stdio__"
+
+# Distinct fresh post-guidance sessions within _CHURN_WINDOW before the gate
+# concludes a caller's session ids are unstable and fails open for it. The
+# tripping call is admitted, so a caller eats threshold-1 bounced round-trips.
+# A real re-initializing bridge accumulates these in seconds; the window keeps
+# occasional bounced-then-abandoned sessions from adding up into a false
+# positive over a long process lifetime, and the flag TTL lets a false
+# positive decay (a true bridge just re-trips cheaply after expiry).
+_CHURN_THRESHOLD = 3
+_CHURN_WINDOW = 300.0
+_UNSTABLE_TTL = 3600.0
 
 
 def register(mcp: FastMCP, guide: str) -> None:
@@ -91,13 +103,41 @@ class GuidanceGateMiddleware(Middleware):
     be scoped (and can't be marked seen without bouncing forever), so the gate
     fails open and admits it — logged once. Stateless streamable-HTTP clients are
     uncommon in practice.
+
+    A degenerate-but-legal variant of statelessness is a bridge that
+    re-initializes per request: every call presents a fresh, *valid*
+    `Mcp-Session-Id`, so `get_guidance` can never unlock the session the retry
+    arrives in and the caller is locked out of every tool (#75). A single such
+    request is indistinguishable from a genuinely new conversation, so the gate
+    detects the pattern instead, scoped per caller by the SHA-256 of the
+    per-user `X-Portainer-API-Key` the HTTP transport already requires. The
+    discriminating signature: a session-preserving client that gets bounced
+    fetches guidance *in that same session*, which proves ids are stable and
+    clears the caller's suspicion; an id-churning bridge fetches guidance in
+    yet another fresh session, so its post-guidance bounces accumulate. On the
+    `_CHURN_THRESHOLD`-th distinct session within `_CHURN_WINDOW` the gate
+    fails open for that caller — the tripping call is admitted (the caller
+    eats threshold-1 bounced round-trips), logged once with the likely cause.
+    The window keeps rare bounced-then-abandoned sessions from accumulating
+    into a false positive over a long process lifetime, and the flag expires
+    after `_UNSTABLE_TTL` so a false positive decays. The caller key scopes
+    only this detector, never the gate itself: per-session semantics are
+    unchanged for every session-preserving client, including a second
+    concurrent conversation by the same user.
     """
+
+    # Seam for tests; also the clock ValidationCache already uses.
+    _now = staticmethod(time.monotonic)
 
     def __init__(self, *, is_http: bool) -> None:
         super().__init__()
         self._is_http = is_http
         self._seen: set[str] = set()
         self._warned_sessionless = False
+        # Churn-detector state, keyed by caller digest (never the raw key).
+        self._guided_callers: set[str] = set()
+        self._bounced_sessions: dict[str, dict[str, float]] = {}
+        self._unstable_callers: dict[str, float] = {}
 
     def _session_key(self) -> str | None:
         sid = request_context.snapshot().get("session_id")
@@ -106,6 +146,45 @@ class GuidanceGateMiddleware(Middleware):
         # No session id: stdio is legitimately keyless (gate via the synthetic
         # key); HTTP means a stateless client we can't scope (fail open).
         return None if self._is_http else _STDIO_KEY
+
+    @staticmethod
+    def _caller_key() -> str | None:
+        key = passthrough.key_from_request()
+        return passthrough.digest(key) if key else None
+
+    def _register_bounce(self, caller: str, sid: str) -> bool:
+        """Record a gated bounce for `caller` in session `sid`; True admits.
+
+        Only post-guidance bounces count — a bounce before the caller has ever
+        fetched guidance is the normal first-contact flow, and fresh sessions
+        alone are not churn evidence.
+        """
+        now = self._now()
+        flagged_at = self._unstable_callers.get(caller)
+        if flagged_at is not None:
+            if now - flagged_at < _UNSTABLE_TTL:
+                return True
+            del self._unstable_callers[caller]
+        if caller not in self._guided_callers:
+            return False
+        bounced = self._bounced_sessions.setdefault(caller, {})
+        for stale in [s for s, t in bounced.items() if now - t >= _CHURN_WINDOW]:
+            del bounced[stale]
+        bounced[sid] = now
+        if len(bounced) < _CHURN_THRESHOLD:
+            return False
+        del self._bounced_sessions[caller]
+        self._unstable_callers[caller] = now
+        logger.warning(
+            "guidance gate: caller %s… seen in %d distinct fresh sessions "
+            "within %ds of fetching guidance — Mcp-Session-Id appears unstable "
+            "(bridge re-initializing per request?); admitting this caller "
+            "ungated",
+            caller[:12],
+            _CHURN_THRESHOLD,
+            int(_CHURN_WINDOW),
+        )
+        return True
 
     async def on_call_tool(
         self,
@@ -118,6 +197,14 @@ class GuidanceGateMiddleware(Middleware):
         if tool == GUIDANCE_TOOL_NAME:
             if key is not None:
                 self._seen.add(key)
+            caller = self._caller_key()
+            if caller is not None:
+                self._guided_callers.add(caller)
+                bounced = self._bounced_sessions.get(caller)
+                if bounced is not None and key in bounced:
+                    # Guidance arrived in a session we previously bounced:
+                    # this caller's session ids are stable after all.
+                    del self._bounced_sessions[caller]
             return await call_next(context)
 
         if key is None:
@@ -130,6 +217,10 @@ class GuidanceGateMiddleware(Middleware):
             return await call_next(context)
 
         if key in self._seen:
+            return await call_next(context)
+
+        caller = self._caller_key()
+        if caller is not None and self._register_bounce(caller, key):
             return await call_next(context)
 
         return _gate_notice(tool)

--- a/src/portainer_mcp/passthrough.py
+++ b/src/portainer_mcp/passthrough.py
@@ -78,7 +78,9 @@ def resolve_ttl() -> int:
     return ttl
 
 
-def _digest(key: str) -> str:
+def digest(key: str) -> str:
+    """SHA-256 of an API key — the only form a key is ever held under
+    outside the in-flight request (cache keys, gate scoping)."""
     return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
 
@@ -101,19 +103,19 @@ class ValidationCache:
     def get(self, key: str) -> Identity | None:
         if self._ttl == 0:
             return None
-        entry = self._entries.get(_digest(key))
+        entry = self._entries.get(digest(key))
         if entry is None:
             return None
         expiry, identity = entry
         if time.monotonic() >= expiry:
-            self._entries.pop(_digest(key), None)
+            self._entries.pop(digest(key), None)
             return None
         return identity
 
     def put(self, key: str, identity: Identity) -> None:
         if self._ttl == 0:
             return
-        self._entries[_digest(key)] = (time.monotonic() + self._ttl, identity)
+        self._entries[digest(key)] = (time.monotonic() + self._ttl, identity)
 
 
 def _parse_identity(response: httpx.Response) -> Identity:

--- a/tests/test_guidance.py
+++ b/tests/test_guidance.py
@@ -2,7 +2,11 @@
 
 The gate forces `get_guidance` to be called once per session before any other
 tool runs. Scoping is transport-aware: stdio uses a single synthetic key, HTTP
-keys on `Mcp-Session-Id`, and a sessionless HTTP client fails open.
+keys on `Mcp-Session-Id`, and a sessionless HTTP client fails open. A caller
+whose session ids churn (a bridge re-initializing per request, #75) is
+detected per user-key digest and failed open on the `_CHURN_THRESHOLD`-th
+distinct post-guidance session inside `_CHURN_WINDOW`; the flag decays after
+`_UNSTABLE_TTL`.
 """
 
 from __future__ import annotations
@@ -13,7 +17,7 @@ import pytest
 from fastmcp.tools.tool import ToolResult
 from mcp.types import TextContent
 
-from portainer_mcp import guidance, request_context
+from portainer_mcp import guidance, passthrough, request_context
 
 _REAL = ToolResult(content=[TextContent(type="text", text="REAL")])
 
@@ -40,6 +44,10 @@ def _set_session(monkeypatch, sid: str | None) -> None:
     monkeypatch.setattr(
         request_context, "snapshot", lambda: {"session_id": sid} if sid else {}
     )
+
+
+def _set_caller(monkeypatch, key: str | None) -> None:
+    monkeypatch.setattr(passthrough, "key_from_request", lambda: key)
 
 
 def _is_notice(result: ToolResult) -> bool:
@@ -96,6 +104,172 @@ async def test_http_scopes_per_session(monkeypatch):
     await _run(mw, guidance.GUIDANCE_TOOL_NAME)
     passed, _ = await _run(mw, "EndpointList")
     assert passed
+
+
+# --- HTTP, session-id churn (bridge re-initializing per request, #75) --------
+
+
+async def test_http_churning_bridge_fails_open_after_threshold(monkeypatch, caplog):
+    mw = guidance.GuidanceGateMiddleware(is_http=True)
+    _set_caller(monkeypatch, "user-key-1")
+
+    # Every request arrives in a fresh session, so get_guidance can never
+    # unlock the session the retry lands in — the #75 lockout.
+    _set_session(monkeypatch, "sess-1")
+    passed, _ = await _run(mw, "StackList")
+    assert not passed  # pre-guidance bounce: normal first contact, not counted
+
+    _set_session(monkeypatch, "sess-2")
+    await _run(mw, guidance.GUIDANCE_TOOL_NAME)
+
+    with caplog.at_level("WARNING", logger="portainer_mcp"):
+        _set_session(monkeypatch, "sess-3")
+        passed, _ = await _run(mw, "StackList")
+        assert not passed
+        _set_session(monkeypatch, "sess-4")
+        passed, _ = await _run(mw, "StackList")
+        assert not passed
+        # The third distinct post-guidance session trips the detector; the
+        # tripping call itself is admitted.
+        _set_session(monkeypatch, "sess-5")
+        passed, result = await _run(mw, "StackList")
+        assert passed
+        assert result is _REAL
+
+        # Caller stays admitted in yet another fresh session.
+        _set_session(monkeypatch, "sess-6")
+        passed, _ = await _run(mw, "StackList")
+        assert passed
+
+    warnings = [r for r in caplog.records if "unstable" in r.message]
+    assert len(warnings) == 1
+    # The raw key never appears in the log; only its digest prefix does.
+    assert "user-key-1" not in warnings[0].getMessage()
+    assert passthrough.digest("user-key-1")[:12] in warnings[0].getMessage()
+
+
+async def test_http_multi_window_user_never_flagged(monkeypatch, caplog):
+    """A session-preserving client opening many conversations is bounced once
+    per session (by design) and never trips the detector: fetching guidance in
+    the same session it was bounced in clears the suspicion each time."""
+    mw = guidance.GuidanceGateMiddleware(is_http=True)
+    _set_caller(monkeypatch, "user-key-1")
+
+    with caplog.at_level("WARNING", logger="portainer_mcp"):
+        for n in range(6):
+            _set_session(monkeypatch, f"sess-{n}")
+            passed, result = await _run(mw, "StackList")
+            assert not passed
+            assert _is_notice(result)
+            await _run(mw, guidance.GUIDANCE_TOOL_NAME)
+            passed, _ = await _run(mw, "StackList")
+            assert passed
+
+    assert not [r for r in caplog.records if "unstable" in r.message]
+    # Per-session semantics intact: the next window is still gated.
+    _set_session(monkeypatch, "sess-final")
+    passed, result = await _run(mw, "StackList")
+    assert not passed
+    assert _is_notice(result)
+
+
+async def test_http_pre_guidance_churn_never_fails_open(monkeypatch, caplog):
+    """A caller that never fetches guidance keeps getting bounced — fresh
+    sessions alone are not churn evidence."""
+    mw = guidance.GuidanceGateMiddleware(is_http=True)
+    _set_caller(monkeypatch, "user-key-1")
+
+    with caplog.at_level("WARNING", logger="portainer_mcp"):
+        for n in range(6):
+            _set_session(monkeypatch, f"sess-{n}")
+            passed, result = await _run(mw, "StackList")
+            assert not passed
+            assert _is_notice(result)
+
+    assert not [r for r in caplog.records if "unstable" in r.message]
+
+
+async def test_http_churn_detector_scoped_per_caller(monkeypatch):
+    mw = guidance.GuidanceGateMiddleware(is_http=True)
+
+    # Caller A churns: guidance in sess-1, bounces in sess-2 and sess-3, then
+    # the third post-guidance session trips the detector and is admitted.
+    _set_caller(monkeypatch, "key-A")
+    _set_session(monkeypatch, "sess-1")
+    await _run(mw, guidance.GUIDANCE_TOOL_NAME)
+    for n in (2, 3):
+        _set_session(monkeypatch, f"sess-{n}")
+        passed, _ = await _run(mw, "StackList")
+        assert not passed
+    _set_session(monkeypatch, "sess-4")
+    passed, _ = await _run(mw, "StackList")
+    assert passed
+
+    # Caller B is unaffected by A's flag.
+    _set_caller(monkeypatch, "key-B")
+    _set_session(monkeypatch, "sess-5")
+    passed, result = await _run(mw, "StackList")
+    assert not passed
+    assert _is_notice(result)
+
+
+async def test_http_stale_bounces_age_out(monkeypatch, caplog):
+    """Bounced-then-abandoned sessions spread over a long process lifetime are
+    not churn evidence: only bounces inside _CHURN_WINDOW count."""
+    mw = guidance.GuidanceGateMiddleware(is_http=True)
+    _set_caller(monkeypatch, "user-key-1")
+    clock = 0.0
+    mw._now = lambda: clock
+
+    _set_session(monkeypatch, "sess-0")
+    await _run(mw, guidance.GUIDANCE_TOOL_NAME)
+
+    with caplog.at_level("WARNING", logger="portainer_mcp"):
+        # Two abandoned bounces, then a long quiet stretch.
+        for sid, t in (("sess-1", 10.0), ("sess-2", 20.0)):
+            clock = t
+            _set_session(monkeypatch, sid)
+            passed, _ = await _run(mw, "StackList")
+            assert not passed
+        # Well past the window: the old evidence has aged out, so this is
+        # bounce #1 again, not the tripping third session.
+        clock = 20.0 + guidance._CHURN_WINDOW
+        _set_session(monkeypatch, "sess-3")
+        passed, result = await _run(mw, "StackList")
+        assert not passed
+        assert _is_notice(result)
+
+        # A real bridge inside the window still trips: two more fresh
+        # sessions in quick succession reach the threshold and are admitted.
+        for sid in ("sess-4", "sess-5"):
+            clock += 1.0
+            _set_session(monkeypatch, sid)
+            passed, _ = await _run(mw, "StackList")
+        assert passed
+
+    assert len([r for r in caplog.records if "unstable" in r.message]) == 1
+
+
+async def test_http_unstable_flag_expires(monkeypatch):
+    """A flagged caller returns to normal per-session gating after
+    _UNSTABLE_TTL — a false positive decays; a real bridge just re-trips."""
+    mw = guidance.GuidanceGateMiddleware(is_http=True)
+    _set_caller(monkeypatch, "user-key-1")
+    clock = 0.0
+    mw._now = lambda: clock
+
+    _set_session(monkeypatch, "sess-0")
+    await _run(mw, guidance.GUIDANCE_TOOL_NAME)
+    for n in (1, 2, 3):
+        _set_session(monkeypatch, f"sess-{n}")
+        passed, _ = await _run(mw, "StackList")
+    assert passed  # flagged on the third session
+
+    clock = guidance._UNSTABLE_TTL + 1.0
+    _set_session(monkeypatch, "sess-4")
+    passed, result = await _run(mw, "StackList")
+    assert not passed
+    assert _is_notice(result)
 
 
 # --- HTTP, stateless (no session id) ----------------------------------------


### PR DESCRIPTION
Fixes #75.

## Problem

Over HTTP the guidance gate keys on `Mcp-Session-Id`. A bridge that re-initializes per request (e.g. a Cloudflare-worker OAuth proxy that performs a fresh MCP handshake on every call) presents a fresh, *valid* session id each time, so `get_guidance` can never unlock the session the retry arrives in — the caller is permanently locked out of every tool. A single such request is indistinguishable from a genuinely new conversation, so the gate can't fix this per-request; it has to detect the pattern.

## Fix

A per-caller churn detector, scoped by the SHA-256 of the per-user `X-Portainer-API-Key` the HTTP transport already requires (the digest only ever reaches the middleware post-auth, so it always corresponds to a Portainer-validated key). The discriminating signature:

- A **session-preserving client** that gets bounced fetches guidance *in that same session* — which proves ids are stable and clears the caller's suspicion.
- An **id-churning bridge** fetches guidance in yet another fresh session, so its post-guidance bounces accumulate.

On the third distinct post-guidance session inside a five-minute window (two bounced round-trips), the gate fails open for that caller — the tripping call is admitted immediately, and a one-time WARNING names the likely cause (`Mcp-Session-Id` appears unstable; bridge re-initializing per request?). The flag expires after an hour so a false positive decays, while a real bridge just re-trips cheaply. The time window keeps rare bounced-then-abandoned sessions from accumulating into a false positive over a long process lifetime.

The caller digest scopes **only the detector, never the gate itself**: per-session gating semantics are unchanged for every session-preserving client, including a second concurrent conversation by the same user. Stdio is untouched (no HTTP request → detector inert). Pre-guidance bounces never count, so fresh sessions alone are not churn evidence. Memory is bounded (≤3 entries per caller, deleted on flag or clear; one digest per distinct valid key otherwise — same order as the existing `ValidationCache`), and session ids stored are server-minted (stateful streamable-HTTP 404s unknown ids before dispatch), so the structures aren't attacker-inflatable.

Also renames `passthrough._digest` → `passthrough.digest` since it's now the shared cross-module "only form a key is ever held" helper. The raw key is never logged — the WARNING carries a 12-char digest prefix, regression-tested.

## Tests

Six new tests: the #75 reproduction (churning bridge admitted on the third post-guidance session, exactly one WARNING, raw key absent / digest prefix present); a multi-window user opening six conversations who is bounced once per window and never flagged, with the next window still gated; a caller who never fetches guidance and is bounced indefinitely; caller isolation (A's flag doesn't ungate B); stale bounces aging out past the window; and the unstable flag expiring back to normal gating. 217 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)