### PR TITLE
Trim the per-tool `select` description, budget the tool catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ the MCP server.
 
 ## [Unreleased]
 
+### Added
+
+- **The tool catalog is measured and budgeted.** `tool_catalog_chars()`
+  sizes the serialized `tools/list` payload; `build_server` logs it at
+  startup and `tests/test_catalog.py` fails the build when the default
+  profile set exceeds `MAX_CATALOG_CHARS`. The catalog is the fixed context
+  cost every client pays on *every* request, before a byte of Portainer
+  data is fetched — and the one number that regresses silently when a
+  profile widens, a per-tool description grows, or the upstream spec does.
+
+### Changed
+
+- **`select`'s parameter description trimmed — the tool catalog shrinks
+  by 21%.** The description is repeated verbatim on all 205 generated
+  tools, so its length is multiplied across the whole payload: at 337
+  chars it was 69,085 chars, 27% of the entire `tools/list` response. Now
+  73 chars, taking the default catalog from 259,156 to 205,036 chars
+  (roughly 13–22k tokens saved per request). The worked examples,
+  non-JSON caveats and per-tool field names already live in the hygiene
+  guide that the guidance gate delivers before the first tool call, and
+  the truncation hint carries its own examples. The one retained example
+  isn't there to teach JMESPath — it encodes the two facts a model can't
+  infer: the response envelope is already unwrapped (`[]`, not
+  `result[]`), and Portainer fields are PascalCase.
+
 ## [2.43.3] — 2026-07-23
 
 Targets Portainer 2.43.x.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,15 @@ Key things to internalise before changing code:
   `_has_select` skip re-wrapping them). After registration, `build_server`
   asserts every tool exposes `select` and raises at startup if any are
   missing — keep that invariant.
+- **The tool catalog has a context budget.** `tool_catalog_chars()` measures
+  the serialized `tools/list` payload; `build_server` logs it at startup and
+  `tests/test_catalog.py` fails the build above `MAX_CATALOG_CHARS`. This is
+  the fixed cost every client pays on every request, so anything repeated
+  per-tool is multiplied by 200+ — `SELECT_DESCRIPTION` is deliberately terse
+  for this reason, with the worked examples living in the hygiene guide and
+  the truncation hint instead. When the budget trips, shrink the catalog
+  (narrower profiles, shorter descriptions); raise the constant only with a
+  note on what grew.
 - **Response cap sits below Claude Code's MCP output cap.** Default
   `PORTAINER_MAX_RESPONSE_CHARS=50_000` is sized so our truncation hint
   (which names `select` with examples) reaches the model before Claude

--- a/src/portainer_mcp/server.py
+++ b/src/portainer_mcp/server.py
@@ -62,6 +62,7 @@ import json
 import logging
 import os
 import sys
+from collections.abc import Sequence
 from importlib.resources import files
 from pathlib import Path
 
@@ -162,6 +163,38 @@ def _annotate_read_only(route: HTTPRoute, component: Tool) -> None:
         component.annotations = ToolAnnotations(
             readOnlyHint=route.method.upper() in _READ_ONLY_METHODS
         )
+
+
+def tool_catalog_chars(tools: Sequence[Tool]) -> int:
+    """Serialized size of the tool catalog, in characters.
+
+    This is the fixed context cost every client pays on *every* request,
+    before a single byte of Portainer data is fetched — and the one number
+    that regresses silently: a widened profile, a longer parameter
+    description repeated across 200+ generated tools, or an upstream spec
+    that grew all move it without failing anything. Logged at startup and
+    budgeted in the test suite for that reason.
+
+    Approximates rather than captures the wire payload (field naming and
+    ordering belong to the MCP SDK). It's a budget metric — consistency
+    between runs matters, exactness doesn't. Reported in chars to match
+    PORTAINER_MAX_RESPONSE_CHARS, the server's other size knob.
+    """
+    return sum(
+        len(
+            json.dumps(
+                {
+                    "name": tool.name,
+                    "description": tool.description or "",
+                    "inputSchema": tool.parameters,
+                    "annotations": tool.annotations.model_dump(exclude_none=True)
+                    if tool.annotations
+                    else None,
+                }
+            )
+        )
+        for tool in tools
+    )
 
 
 def _spec_tags(spec: dict) -> set[str]:
@@ -434,7 +467,11 @@ def build_server() -> FastMCP:
             f"SelectArgTransform did not reach {len(missing)} tool(s): "
             f"{missing[:5]}{'...' if len(missing) > 5 else ''}"
         )
-    logger.info("`select` arg present on all %d tools", len(tools))
+    logger.info(
+        "tool catalog: %d tools, `select` on all of them, ~%s chars per tools/list",
+        len(tools),
+        f"{tool_catalog_chars(tools):,}",
+    )
 
     mcp.add_middleware(
         _ContextualStructuredLogging(include_payload_length=True, cache=cache)

--- a/src/portainer_mcp/shaping.py
+++ b/src/portainer_mcp/shaping.py
@@ -44,12 +44,17 @@ logger = logging.getLogger("portainer_mcp")
 # PORTAINER_MAX_RESPONSE_CHARS.
 DEFAULT_MAX_RESPONSE_CHARS = 50_000
 
+# Repeated verbatim on every one of the 200+ generated tools, so its length is
+# multiplied across the whole tools/list payload the client pays for on every
+# request. Trim the prose, not the example: models already know JMESPath, but
+# the example is what carries the two server-specific facts they can't infer —
+# that the response envelope is already unwrapped (`[]`, not `result[]`) and
+# that Portainer fields are PascalCase. Everything else — worked examples,
+# non-JSON caveats, per-tool field names — lives in the hygiene guide, which
+# the guidance gate delivers before the first tool call; a model that skipped
+# `select` anyway gets corrected by ResponseCapMiddleware's truncation hint.
 SELECT_DESCRIPTION = (
-    "Optional JMESPath expression to project the response server-side. "
-    "Use it on noisy endpoints to drop fields you don't need — e.g. "
-    "`[].{id:Id,name:Name,type:Type}` for a list of environments, or "
-    "`{kind:Kind,name:metadata.name,phase:status.phase}` for a single K8s object. "
-    "Omit to receive the full response (subject to the global size cap)."
+    "JMESPath projection to shrink the response — e.g. `[].{id:Id,name:Name}`."
 )
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,63 @@
+"""Budget guard on the `tools/list` payload.
+
+The tool catalog is the fixed context cost every client pays on every
+request, before any Portainer data is fetched. It regresses silently — a
+widened profile, a longer parameter description multiplied across 200+
+generated tools, an upstream spec that grew — so the size is asserted here
+rather than merely observed at startup.
+
+This builds the real server against the bundled spec (no network: the httpx
+client is constructed but never used), so the number tracks the shipped
+default rather than a fixture.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from portainer_mcp import server
+
+# Calibrated 2026-07-27 against the default profile set
+# (BASE,DOCKER,KUBERNETES,GITOPS) at 205,036 chars over 205 tools, plus ~15%
+# headroom. Sized to bite: the pre-dedup SELECT_DESCRIPTION put the catalog at
+# 259,156, so reintroducing a paragraph-length per-tool description trips this.
+# Raise it only with a note on what grew and why that growth is worth the
+# context it costs every caller — shrinking the catalog is the intended
+# response to a red test here.
+MAX_CATALOG_CHARS = 235_000
+
+
+@pytest.fixture
+def default_env(monkeypatch):
+    """Boot config for the shipped default profile set, isolated from the
+    developer's shell.
+    """
+    # build_server() reconfigures global logging (propagate=False on the
+    # portainer_mcp/fastmcp/httpx loggers), which would break `caplog` for
+    # every test that runs after this module.
+    monkeypatch.setattr(server, "_setup_logging", lambda: None)
+    monkeypatch.setenv("PORTAINER_URL", "http://portainer.test")
+    monkeypatch.setenv("PORTAINER_API_KEY", "k" * 32)
+    for var in (
+        "PORTAINER_MCP_TRANSPORT",
+        "PORTAINER_PROFILES",
+        "PORTAINER_TAGS_EXTRA",
+        "PORTAINER_READ_ONLY",
+        "PORTAINER_NO_PROXY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_default_catalog_within_budget(default_env):
+    mcp = server.build_server()
+    tools = asyncio.run(mcp.list_tools())
+    size = server.tool_catalog_chars(tools)
+
+    assert size <= MAX_CATALOG_CHARS, (
+        f"tool catalog is {size:,} chars across {len(tools)} tools, over the "
+        f"{MAX_CATALOG_CHARS:,} char budget. This payload ships to the client "
+        f"on every request — prefer shrinking it (fewer tools via profiles, "
+        f"shorter parameter descriptions) over raising the budget."
+    )


### PR DESCRIPTION
The `tools/list` payload is the fixed context cost every client pays on every request, before a byte of Portainer data is fetched. At the default profile set that was 259,156 chars across 205 tools — and SELECT_DESCRIPTION, repeated verbatim on every generated tool, was 69,085 of them (27%) on its own.

- SELECT_DESCRIPTION drops from 337 to 73 chars, taking the default catalog to 205,036 (-54,120, -20.9%; roughly 13-22k tokens per request). The worked examples, non-JSON caveats and per-tool field names already live in the hygiene guide, which the guidance gate delivers before the first tool call, and ResponseCapMiddleware's truncation hint carries its own examples for a model that skipped `select` anyway. The one retained example is not there to teach JMESPath — it encodes the two facts a model cannot infer: the response envelope is already unwrapped (`[]`, not `result[]`), and Portainer fields are PascalCase.
- tool_catalog_chars() sizes the payload; build_server logs it at startup (replacing the bare `select`-invariant line, which it subsumes) and tests/test_catalog.py fails above MAX_CATALOG_CHARS — 235,000, the new baseline plus ~15%. Sized to bite: reverting the description trim trips it at 259,156.

The test builds the real server against the bundled spec rather than a fixture, so the number tracks what ships. It stubs _setup_logging, which would otherwise set propagate=False on the shared loggers and break caplog for every test module sorting after this one — verified by disabling the stub, which fails 5 tests across test_guidance, test_profiles and test_tls.