### PR TITLE
Bump the 2.43 version pins Release 2.44.0 missed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ UPSTREAM_DIR  := spec/upstream
 .PHONY: specs dev
 
 # Refresh src/portainer_mcp/data/portainer-patched.yaml from upstream
-# Usage: make specs VERSION=2.43.0
+# Usage: make specs VERSION=2.44.0
 specs:
 	@if [ -z "$(VERSION)" ]; then \
-		echo "VERSION is required, e.g. make specs VERSION=2.43.0" >&2; \
+		echo "VERSION is required, e.g. make specs VERSION=2.44.0" >&2; \
 		exit 1; \
 	fi
 	@if [ -d $(UPSTREAM_DIR)/.git ]; then \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Official MCP server for Portainer, generated from the Portainer OpenAPI spec via
 
 This MCP server exposes the Portainer REST API as MCP tools: list and inspect environments, manage GitOps workflows, troubleshoot Docker and Kubernetes resources. It also supports proxying requests to the underlying Docker and K8s APIs of each environment.
 
-Match the MCP server's minor version to your Portainer instance's minor — e.g. MCP server 2.43.x with Portainer 2.43.x. See [Version compatibility](#version-compatibility) for details.
+Match the MCP server's minor version to your Portainer instance's minor — e.g. MCP server 2.44.x with Portainer 2.44.x. See [Version compatibility](#version-compatibility) for details.
 
 ## Getting started
 
@@ -44,7 +44,7 @@ Register with Claude Code:
 claude mcp add portainer \
   -e PORTAINER_URL=https://portainer.example.com \
   -e PORTAINER_API_KEY=ptr_xxxxxxxxxxxxxxxx \
-  -- uvx --from "mcp-portainer~=2.43.0" mcp-portainer
+  -- uvx --from "mcp-portainer~=2.44.0" mcp-portainer
 ````
 
 For other clients, see
@@ -82,7 +82,7 @@ docker run -d --name portainer-mcp -p 17717:17717 \
 	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com:17717 \
 	-e PORTAINER_MCP_TLS_CERT=/tls/cert.pem \
 	-e PORTAINER_MCP_TLS_KEY=/tls/key.pem \
-	portainer/portainer-mcp:2.43
+	portainer/portainer-mcp:2.44
 ````
 
 Then connect your client:
@@ -112,7 +112,7 @@ docker run -d --name portainer-mcp \
 	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com \
 	-e PORTAINER_MCP_TRUST_PROXY_TLS=1 \
 	-e PORTAINER_MCP_FORWARDED_ALLOW_IPS=172.18.0.0/16 \
-	portainer/portainer-mcp:2.43
+	portainer/portainer-mcp:2.44
 ````
 
 Then connect your client:
@@ -137,7 +137,7 @@ docker run -d --name portainer-mcp -p 17717:17717 \
 	-e PORTAINER_MCP_AUTH_TOKEN="$TOKEN" \
 	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com:17717 \
 	-e PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1 \
-	portainer/portainer-mcp:2.43
+	portainer/portainer-mcp:2.44
 ````
 
 Then connect your client:
@@ -164,7 +164,7 @@ docker run -d --name portainer-mcp \
 	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com \
 	-e PORTAINER_MCP_TRUST_PROXY_TLS=1 \
 	-e PORTAINER_MCP_FORWARDED_ALLOW_IPS=172.18.0.0/16 \
-	portainer/portainer-mcp:2.43
+	portainer/portainer-mcp:2.44
 ````
 
 No gate token is configured: the request is admitted by proxy attestation (it must arrive from `PORTAINER_MCP_FORWARDED_ALLOW_IPS` — inherited as the trust boundary, `*` refuses to boot) and by the caller's validated Portainer key. If the MCP server terminates TLS itself instead of the proxy, set `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS=<proxy ip/cidr>` in place of the two `TRUST_PROXY_TLS`/`FORWARDED_ALLOW_IPS` lines. See [`docs/configuration.md`](https://github.com/portainer/portainer-mcp/blob/main/docs/configuration.md#auth-posture-identity-aware-proxies) for the full posture rules.
@@ -186,6 +186,7 @@ For restricting or expanding this set of capabilities, see [`docs/profiles.md`](
 
 | Server version | Portainer (CE / EE) |
 | -------------- | ------------------- |
+| `2.44.x`       | `2.44.x`            |
 | `2.43.x`       | `2.43.x`            |
 | `2.42.x`       | `2.42.x`            |
 | `2.41.x`       | `2.41.x`            |

--- a/docs/distribution/claude-desktop.md
+++ b/docs/distribution/claude-desktop.md
@@ -22,7 +22,7 @@ Claude Desktop > Settings > Developer > Edit Config and choose one of the path b
   "mcpServers": {
     "portainer": {
       "command": "uvx",
-      "args": ["--from", "mcp-portainer~=2.43.0", "mcp-portainer"],
+      "args": ["--from", "mcp-portainer~=2.44.0", "mcp-portainer"],
       "env": {
         "PORTAINER_URL": "https://portainer.example.com",
         "PORTAINER_API_KEY": "ptr_xxxxxxxxxxxxxxxx"

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -3,14 +3,14 @@
 **Major+minor tracks the Portainer API; patch is the MCP server's to spend.**
 
 - Tag format: `<portainer-major>.<portainer-minor>.<mcp-patch>`.
-- Compatibility statement: **"MCP 2.43.x ↔ Portainer 2.43.x"** — minor
+- Compatibility statement: **"MCP 2.44.x ↔ Portainer 2.44.x"** — minor
   granularity.
 - Spec cadence: regenerate `src/portainer_mcp/data/portainer-patched.yaml` against the
   **latest patch** of the targeted Portainer minor (e.g. `make specs
-  VERSION=2.43.0` when 2.43.0 is current).
+  VERSION=2.44.0` when 2.44.0 is current).
 - MCP-internal iterations (shaping fixes, new profiles, transform changes,
-  dep bumps, doc-only changes) burn the patch slot — e.g. `2.43.1` is an
-  MCP-only release still targeting Portainer 2.43.x.
+  dep bumps, doc-only changes) burn the patch slot — e.g. `2.44.1` is an
+  MCP-only release still targeting Portainer 2.44.x.
 
 ## What does *not* bump the minor
 


### PR DESCRIPTION
Stacks on top of #93. `Release 2.44.0` moved `pyproject.toml`, `uv.lock`,
the CHANGELOG, `docs/profiles.md` and the skill footer, but left the
operator-facing version pins on 2.43 — so a user following the README
after 2.44.0 ships would install 2.43 against a 2.44 Portainer.

This mirrors exactly the file set the previous minor bump touched
(849f949, `Release 2.43.0`):

| File | Change |
|---|---|
| `README.md` | Intro compat line, `uvx --from` pin, 4× `portainer/portainer-mcp:2.43` image tags, new `2.44.x` compat-table row (appended, 2.43/2.42/2.41 retained) |
| `docs/distribution/claude-desktop.md` | `mcp-portainer~=2.44.0` |
| `docs/versioning.md` | Example versions → 2.44 |
| `Makefile` | `make specs VERSION=2.44.0` usage comment |

No CHANGELOG entry — 849f949 folded pin updates into the release commit
without one.

## Verification
- `uv run pytest` → 284 passed
- `make specs VERSION=2.44.0` reproduces the committed spec byte-identically
- Smoke-tested against a local Portainer 2.44.0 EE instance: 211 tools
  registered, guidance gate serves the 2.44.0 skill, and the new
  `GitOpsWorkflowGet` / `GitOpsSourceWorkflowsList` tools return correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
