### PR TITLE
Re-audit spec-defect mitigations against upstream 2.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ the MCP server.
 
 ## [Unreleased]
 
+### Changed
+
+- **Re-audited the spec-defect mitigations against upstream 2.44.0** — a step
+  the 2.44.0 release skipped. Upstream fixes its defects silently, so nothing
+  failed when the workarounds went stale. Two of the three
+  `EXCLUDED_OPERATION_IDS` entries (`providerInfo`, `provisionCluster`) were
+  dead code: their quoted-enum defect was fixed in 2.43 and the operations
+  were deleted outright in 2.44. `UpdateKubernetesNamespaceDeprecated` had its
+  structural defect (a required `namespace` path param absent from its own
+  template) fixed in 2.43 too, so it stays excluded as a deliberate policy
+  call — it's upstream's superseded twin of `UpdateKubernetesNamespace` — and
+  the comment now says so. `ENUM_STRIPS` loses a nested-trail walk that only
+  ever traversed one level. Still load-bearing on 2.44 and unchanged: the
+  `tag:yaml.org,2002:value` constructor (`portaineree.ConditionOperator` ships
+  a bare `=`; a pristine `SafeLoader` raises on it), the `policies.PolicyType`
+  enum strip, and the `/websocket` + `edge_agent` drops. Verified by
+  regenerating the spec: byte-identical output, so no tool-surface change.
+
+### Fixed
+
+- **`images.Status` duplicate enum stripped** for consistency with
+  `policies.PolicyType` — the same upstream swaggo defect (the varname list is
+  emitted twice, leaving 12 values with 6 duplicated). It reaches only the
+  output schemas of `ServiceImageStatus`, `containerImageStatus` and
+  `stackImagesStatus`, so the effect is cosmetic; operation count is unchanged
+  at 428.
+
 ## [2.44.0] — 2026-07-30
 
 Targets Portainer 2.44.x.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,11 +224,19 @@ production, not relative paths). To regenerate:
 
 1. `make specs VERSION=<portainer-version>` — clones/refreshes
    `spec/upstream/` (sparse, single-version), then runs `spec/patch_spec.py`.
-2. `patch_spec.py` drops structurally broken operations (see
-   `EXCLUDED_OPERATION_IDS`), strips `/websocket/*` paths, normalises a
-   few malformed `enum` blocks, and rewrites stray tabs. Extend those
-   constants when the upstream spec ships new defects — don't hand-edit
-   `portainer-patched.yaml`.
+2. `patch_spec.py` drops operations that shouldn't reach the tool surface
+   (`EXCLUDED_OPERATION_IDS`, `EXCLUDED_TAGS`), strips `/websocket/*` paths,
+   normalises malformed `enum` blocks (`ENUM_STRIPS`), and rewrites stray
+   tabs. Extend those constants when the upstream spec ships new defects —
+   don't hand-edit `portainer-patched.yaml`.
+3. Re-audit the mitigations when the spec moves: upstream fixes its defects
+   silently, so entries go stale without failing anything. 2.43 fixed all
+   three original `EXCLUDED_OPERATION_IDS` defects and nobody noticed until
+   after the 2.44 release. The load-bearing ones as of 2.44: the `=`
+   value-tag constructor (`portaineree.ConditionOperator` still ships a bare
+   `=`, and a pristine `SafeLoader` raises on it), the `policies.PolicyType`
+   enum strip, and the websocket/`edge_agent` drops — those last two are
+   policy, not defect, so they stay regardless.
 
 ## Versioning
 

--- a/spec/patch_spec.py
+++ b/spec/patch_spec.py
@@ -1,11 +1,15 @@
 """Apply spec-defect mitigations to a Portainer OpenAPI spec.
 
-Drops operations whose path/parameter shape is structurally broken,
-drops `/websocket/*` paths (protocol upgrades, not REST), and strips
-malformed `enum` blocks that defeat naive generators.
+Drops operations that shouldn't reach the tool surface (deprecated
+duplicates, edge-agent-only callbacks), drops `/websocket/*` paths (protocol
+upgrades, not REST), and strips malformed `enum` blocks that defeat naive
+generators.
 
-Also normalises stray tab characters in scalar text (swaggo occasionally
-emits a literal `\t` inside a description string, which PyYAML rejects).
+Also normalises stray tab characters in scalar text — swaggo occasionally
+emits a literal tab inside a description string. Current specs keep them
+inside block scalars, where YAML tolerates them, so this is hygiene for the
+generated tool descriptions plus insurance against one landing in an
+indentation position, where it *would* be a parse error.
 """
 
 from __future__ import annotations
@@ -16,11 +20,15 @@ from pathlib import Path
 
 import yaml
 
-EXCLUDED_OPERATION_IDS = {
-    "UpdateKubernetesNamespaceDeprecated",
-    "providerInfo",
-    "provisionCluster",
-}
+# `UpdateKubernetesNamespaceDeprecated` (PUT /kubernetes/{id}/namespaces) is
+# upstream's superseded twin of `UpdateKubernetesNamespace`
+# (PUT /kubernetes/{id}/namespaces/{namespace}); it takes the target namespace
+# from the body instead of the path. Dropping it keeps the namespace-update
+# surface unambiguous for the model. Through 2.42 it was *also* structurally
+# broken — it declared a required `namespace` path param absent from its own
+# template — but upstream fixed that in 2.43, so this is now a deliberate
+# policy exclusion, not a defect workaround. New defects get added here.
+EXCLUDED_OPERATION_IDS = {"UpdateKubernetesNamespaceDeprecated"}
 
 # Edge-agent-only callbacks under `/endpoints/{id}/edge/*` (heartbeat/status,
 # async poll, alert + chart status, edge stack/job sync). They 403 for any
@@ -35,7 +43,19 @@ EXCLUDED_TAGS = frozenset({"edge_agent"})
 
 EXCLUDED_PATH_PREFIXES = ("/websocket",)
 
-ENUM_STRIPS = (("policies.PolicyType",),)
+# Schemas whose `enum` lists every value twice (swaggo emits the varname list
+# a second time). The duplicates parse fine, but FastMCP folds the schema into
+# an `allOf` whose inner enum then contradicts the outer one — visible on
+# `PolicyUpdate`'s `Type` property. Dropping the enum leaves a plain string.
+# `images.Status` reaches only *output* schemas (`ServiceImageStatus`,
+# `containerImageStatus`, `stackImagesStatus`), so it's cosmetic there — listed
+# for consistency, since it's the same upstream defect.
+ENUM_STRIPS = frozenset(
+    {
+        "policies.PolicyType",
+        "github_com_portainer_portainer-ee_api_docker_images.Status",
+    }
+)
 
 DEFAULT_OUTPUT = (
     Path(__file__).resolve().parents[1]
@@ -70,10 +90,8 @@ def patch(spec: dict) -> dict:
             paths.pop(path)
 
     schemas = spec.get("components", {}).get("schemas", {})
-    for trail in ENUM_STRIPS:
-        node = schemas.get(trail[0])
-        for key in trail[1:]:
-            node = node.get(key) if isinstance(node, dict) else None
+    for name in ENUM_STRIPS:
+        node = schemas.get(name)
         if isinstance(node, dict):
             node.pop("enum", None)
     return spec

--- a/src/portainer_mcp/data/portainer-patched.yaml
+++ b/src/portainer_mcp/data/portainer-patched.yaml
@@ -18722,19 +18722,6 @@ components:
           type: string
       type: object
     github_com_portainer_portainer-ee_api_docker_images.Status:
-      enum:
-      - processing
-      - outdated
-      - updated
-      - skipped
-      - preparing
-      - error
-      - processing
-      - outdated
-      - updated
-      - skipped
-      - preparing
-      - error
       type: string
       x-enum-varnames:
       - Processing

--- a/tests/test_patch_spec.py
+++ b/tests/test_patch_spec.py
@@ -24,29 +24,31 @@ def _spec(paths: dict | None = None, schemas: dict | None = None) -> dict:
 def test_excluded_operation_ids_are_removed():
     spec = _spec(
         paths={
-            "/cloud/{id}": {
-                "get": {"operationId": "providerInfo"},
-                "put": {"operationId": "provisionCluster"},
-                "delete": {"operationId": "UpdateKubernetesNamespaceDeprecated"},
+            "/kubernetes/{id}/namespaces": {
+                "put": {"operationId": "UpdateKubernetesNamespaceDeprecated"},
             },
         }
     )
     patch(spec)
     # Path is removed entirely once all its methods drop out.
-    assert "/cloud/{id}" not in spec["paths"]
+    assert "/kubernetes/{id}/namespaces" not in spec["paths"]
 
 
 def test_partial_method_drop_keeps_path():
+    # The live `UpdateKubernetesNamespace` shares no path with its deprecated
+    # twin, but sibling methods on the deprecated one's path must survive.
     spec = _spec(
         paths={
-            "/cloud/{id}": {
-                "get": {"operationId": "provisionCluster"},
-                "post": {"operationId": "KeepMe"},
+            "/kubernetes/{id}/namespaces": {
+                "put": {"operationId": "UpdateKubernetesNamespaceDeprecated"},
+                "get": {"operationId": "GetKubernetesNamespaces"},
             },
         }
     )
     patch(spec)
-    assert spec["paths"]["/cloud/{id}"] == {"post": {"operationId": "KeepMe"}}
+    assert spec["paths"]["/kubernetes/{id}/namespaces"] == {
+        "get": {"operationId": "GetKubernetesNamespaces"},
+    }
 
 
 def test_unrelated_operations_are_kept():


### PR DESCRIPTION
The 2.44.0 release bumped the embedded spec without checking whether the defects `spec/patch_spec.py` works around are still present upstream. Upstream fixes them silently — nothing in CI fails when a workaround goes stale — so two entries had been dead for a full minor.

Audited every mitigation against upstream 2.44.0.

## Stale, removed

- **`providerInfo` / `provisionCluster`** — excluded because their `{provider}` path param emitted quote-wrapped enum values (`'"amazon"'`). Fixed in 2.43; the operations were deleted outright in 2.44 along with the rest of the KaaS provisioning surface.
- **`ENUM_STRIPS` nested-trail walk** — the tuple-of-trails structure supported nested key traversal that was only ever used one level deep.

## Kept, reclassified

- **`UpdateKubernetesNamespaceDeprecated`** — was structurally broken through 2.42 (declared a required `namespace` path param absent from its own template); 2.43 fixed it. Retaining it now builds a clean tool (`required: ['id']`, body fields flattened), so the exclusion is a deliberate policy call — it's upstream's superseded twin of `UpdateKubernetesNamespace`, which takes the namespace from the path instead of the body — not a defect workaround. Comment updated to say so rather than implying a defect that no longer exists.

## Still load-bearing on 2.44

- the `tag:yaml.org,2002:value` constructor — `portaineree.ConditionOperator` still ships a bare `=`, and a pristine `SafeLoader` raises `ConstructorError` on it
- the `policies.PolicyType` enum strip — without it FastMCP folds the schema into an `allOf` whose 24-value inner enum contradicts the outer 10-value one on `PolicyUpdate`'s `Type` property
- the `/websocket` and `edge_agent` drops — policy, not defect, so they stay regardless; 2.44 adds a fifth websocket path (`/websocket/node-shell`) that the prefix already covers
- tab normalisation, though no longer parse-critical: the remaining tabs sit inside block scalars where YAML tolerates them, so it's description hygiene plus insurance against one landing in an indentation position. The docstring claimed PyYAML rejects them; corrected.

## Also

Strips the duplicate `images.Status` enum for consistency with `policies.PolicyType` (same swaggo defect — the varname list emitted twice, 12 values with 6 duplicated). It reaches only the output schemas of `ServiceImageStatus`, `containerImageStatus` and `stackImagesStatus`, so the effect is cosmetic.

`CLAUDE.md` gains the re-audit-on-spec-bump step, so this isn't missed a third time.

## Verification

- Regenerating from upstream 2.44.0 with the slimmed patcher produces a **byte-identical** spec apart from the `images.Status` enum block — no tool-surface change, operation count unchanged at 428.
- `uv run pytest`: 284 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
