### PR TITLE
Fix container healthcheck to honour PORTAINER_MCP_HTTP_PORT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ the MCP server.
 
 ### Fixed
 
+- **Container healthcheck honours `PORTAINER_MCP_HTTP_PORT`** — the image
+  previously always probed `127.0.0.1:17717`, so overriding the MCP HTTP
+  port could report the wrong process as healthy or mark a healthy MCP
+  unhealthy. The probe now resolves the configured port at runtime. (#98)
+
 - **`images.Status` duplicate enum stripped** for consistency with
   `policies.PolicyType` — the same upstream swaggo defect (the varname list is
   emitted twice, leaving 12 values with 6 duplicated). It reaches only the

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,6 @@ USER portainer
 EXPOSE 17717
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('127.0.0.1', 17717)); s.close()"
+  CMD python -c "import os, socket; port=int(os.environ.get('PORTAINER_MCP_HTTP_PORT', '17717')); s=socket.socket(); s.settimeout(2); s.connect(('127.0.0.1', port)); s.close()"
 
 ENTRYPOINT ["mcp-portainer"]


### PR DESCRIPTION
Fixes #98

The container healthcheck currently always probes `127.0.0.1:17717`, even when `PORTAINER_MCP_HTTP_PORT` changes the MCP HTTP listener port. That can mark a healthy MCP instance unhealthy, or potentially report the wrong process as healthy if something else is listening on 17717.

This updates the Docker healthcheck to resolve `PORTAINER_MCP_HTTP_PORT` at runtime, falling back to `17717` when it is unset. The changelog documents the fix.

Validation completed against upstream `main` at `79ce50b98dd3f03a454a39f161b0abc20373dd0c`:

- full Python test suite: `284 passed, 1 warning`
- patched Docker image built successfully
- inspected built-image healthcheck contains the environment-aware port logic
- real Docker health smoke test passed on the default port `17717`
- real Docker health smoke test passed with `PORTAINER_MCP_HTTP_PORT=17718`
- `git diff --check` clean