### PR TITLE
Release 2.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ the MCP server.
 
 ## [Unreleased]
 
+## [2.45.0] — 2026-08-27
+
+### Added
+
+- **Regenerated the embedded spec against upstream Portainer 2.45.0**
+  (`make specs VERSION=2.45.0`) — 428→466 operations. Re-audited every
+  spec-defect mitigation against the new spec: all five (the
+  `UpdateKubernetesNamespaceDeprecated` exclusion, the `edge_agent` tag
+  drop, the `/websocket` path drop, the `policies.PolicyType` and
+  `images.Status` duplicate-enum strips, and the `portaineree.ConditionOperator`
+  bare-`=` value-tag workaround) are still load-bearing and unchanged —
+  none of the underlying upstream defects were fixed in 2.45. `addons`
+  grew 5→17 ops and `omni` grew 13→14; default profile coverage
+  (`BASE,DOCKER,KUBERNETES,GITOPS`) is now 233 ops, six-profile union 372.
+
 ### Changed
 
 - **Re-audited the spec-defect mitigations against upstream 2.44.0** — a step

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,24 +11,29 @@ the MCP server.
 
 ## [2.45.0] — 2026-08-27
 
-### Added
-
-- **Regenerated the embedded spec against upstream Portainer 2.45.0**
-  (`make specs VERSION=2.45.0`) — 428→466 operations. Re-audited every
-  spec-defect mitigation against the new spec: all five (the
-  `UpdateKubernetesNamespaceDeprecated` exclusion, the `edge_agent` tag
-  drop, the `/websocket` path drop, the `policies.PolicyType` and
-  `images.Status` duplicate-enum strips, and the `portaineree.ConditionOperator`
-  bare-`=` value-tag workaround) are still load-bearing and unchanged —
-  none of the underlying upstream defects were fixed in 2.45. `addons`
-  grew 5→17 ops and `omni` grew 13→14; default profile coverage
-  (`BASE,DOCKER,KUBERNETES,GITOPS`) is now 233 ops, six-profile union 372.
+Targets Portainer 2.45.x.
 
 ### Changed
 
+- **Embedded spec bumped to Portainer EE 2.45.0** (was 2.44.0). Total
+  operations 428 → 466. `kubernetes` grows 95 → 119 — the largest delta by
+  far, and the only one landing in the default profile; the orphan tags
+  `addons` (5 → 17) and `omni` (13 → 14) account for most of the rest.
+  Default `BASE,DOCKER,KUBERNETES,GITOPS` coverage moves 211 → 236 and the
+  six-profile union 350 → 375. Upstream added and removed no tags this
+  minor, so [`docs/profiles.md`](docs/profiles.md)'s orphan table needed
+  only the two recounts. Re-audited every spec-defect mitigation against
+  the new spec: all six (the `UpdateKubernetesNamespaceDeprecated`
+  exclusion, the `edge_agent` tag drop, the `/websocket` path drop, the
+  `policies.PolicyType` and `images.Status` duplicate-enum strips, and the
+  `portaineree.ConditionOperator` bare-`=` value-tag workaround) are still
+  load-bearing and unchanged — none of the underlying upstream defects were
+  fixed in 2.45.
+
 - **Re-audited the spec-defect mitigations against upstream 2.44.0** — a step
-  the 2.44.0 release skipped. Upstream fixes its defects silently, so nothing
-  failed when the workarounds went stale. Two of the three
+  the 2.44.0 release skipped. (This landed mid-cycle, before the spec bump
+  above; its operation counts refer to 2.44.0.) Upstream fixes its defects
+  silently, so nothing failed when the workarounds went stale. Two of the three
   `EXCLUDED_OPERATION_IDS` entries (`providerInfo`, `provisionCluster`) were
   dead code: their quoted-enum defect was fixed in 2.43 and the operations
   were deleted outright in 2.44. `UpdateKubernetesNamespaceDeprecated` had its
@@ -48,8 +53,8 @@ the MCP server.
   `policies.PolicyType` — the same upstream swaggo defect (the varname list is
   emitted twice, leaving 12 values with 6 duplicated). It reaches only the
   output schemas of `ServiceImageStatus`, `containerImageStatus` and
-  `stackImagesStatus`, so the effect is cosmetic; operation count is unchanged
-  at 428.
+  `stackImagesStatus`, so the effect is cosmetic; it left the then-current
+  operation count unchanged at 428.
 
 ## [2.44.0] — 2026-07-30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,7 @@ new proxy tools, shaping changes — all patch. See
 
 ## Profiles
 
-Spec exposes ~380 operations across 40+ tags; profiles in `profiles.py`
+Spec exposes 400+ operations across 40+ tags; profiles in `profiles.py`
 bundle them. `PORTAINER_PROFILES` (default `BASE,DOCKER,KUBERNETES,GITOPS`)
 selects which to enable; `PORTAINER_TAGS_EXTRA` appends raw tags as an
 escape hatch. `PORTAINER_PROFILES=ALL` disables the tag filter entirely.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,11 +232,12 @@ production, not relative paths). To regenerate:
 3. Re-audit the mitigations when the spec moves: upstream fixes its defects
    silently, so entries go stale without failing anything. 2.43 fixed all
    three original `EXCLUDED_OPERATION_IDS` defects and nobody noticed until
-   after the 2.44 release. The load-bearing ones as of 2.44: the `=`
-   value-tag constructor (`portaineree.ConditionOperator` still ships a bare
-   `=`, and a pristine `SafeLoader` raises on it), the `policies.PolicyType`
-   enum strip, and the websocket/`edge_agent` drops — those last two are
-   policy, not defect, so they stay regardless.
+   after the 2.44 release. The load-bearing ones as of 2.45 (re-audited,
+   unchanged from 2.44): the `=` value-tag constructor (`portaineree.ConditionOperator`
+   still ships a bare `=`, and a pristine `SafeLoader` raises on it), the
+   `policies.PolicyType` and `images.Status` duplicate-enum strips, and the
+   websocket/`edge_agent` drops — those last two are policy, not defect, so
+   they stay regardless.
 
 ## Versioning
 

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ UPSTREAM_DIR  := spec/upstream
 .PHONY: specs dev
 
 # Refresh src/portainer_mcp/data/portainer-patched.yaml from upstream
-# Usage: make specs VERSION=2.44.0
+# Usage: make specs VERSION=2.45.0
 specs:
 	@if [ -z "$(VERSION)" ]; then \
-		echo "VERSION is required, e.g. make specs VERSION=2.44.0" >&2; \
+		echo "VERSION is required, e.g. make specs VERSION=2.45.0" >&2; \
 		exit 1; \
 	fi
 	@if [ -d $(UPSTREAM_DIR)/.git ]; then \

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ For restricting or expanding this set of capabilities, see [`docs/profiles.md`](
 | `2.44.x`       | `2.44.x`            |
 | `2.43.x`       | `2.43.x`            |
 | `2.42.x`       | `2.42.x`            |
+| `2.41.x`       | `2.41.x`            |
 
 For more information about the versioning policy, see [`docs/versioning.md`](https://github.com/portainer/portainer-mcp/blob/main/docs/versioning.md).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Official MCP server for Portainer, generated from the Portainer OpenAPI spec via
 
 This MCP server exposes the Portainer REST API as MCP tools: list and inspect environments, manage GitOps workflows, troubleshoot Docker and Kubernetes resources. It also supports proxying requests to the underlying Docker and K8s APIs of each environment.
 
-Match the MCP server's minor version to your Portainer instance's minor — e.g. MCP server 2.44.x with Portainer 2.44.x. See [Version compatibility](#version-compatibility) for details.
+Match the MCP server's minor version to your Portainer instance's minor — e.g. MCP server 2.45.x with Portainer 2.45.x. See [Version compatibility](#version-compatibility) for details.
 
 ## Getting started
 
@@ -44,7 +44,7 @@ Register with Claude Code:
 claude mcp add portainer \
   -e PORTAINER_URL=https://portainer.example.com \
   -e PORTAINER_API_KEY=ptr_xxxxxxxxxxxxxxxx \
-  -- uvx --from "mcp-portainer~=2.44.0" mcp-portainer
+  -- uvx --from "mcp-portainer~=2.45.0" mcp-portainer
 ````
 
 For other clients, see
@@ -82,7 +82,7 @@ docker run -d --name portainer-mcp -p 17717:17717 \
 	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com:17717 \
 	-e PORTAINER_MCP_TLS_CERT=/tls/cert.pem \
 	-e PORTAINER_MCP_TLS_KEY=/tls/key.pem \
-	portainer/portainer-mcp:2.44
+	portainer/portainer-mcp:2.45
 ````
 
 Then connect your client:
@@ -112,7 +112,7 @@ docker run -d --name portainer-mcp \
 	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com \
 	-e PORTAINER_MCP_TRUST_PROXY_TLS=1 \
 	-e PORTAINER_MCP_FORWARDED_ALLOW_IPS=172.18.0.0/16 \
-	portainer/portainer-mcp:2.44
+	portainer/portainer-mcp:2.45
 ````
 
 Then connect your client:
@@ -137,7 +137,7 @@ docker run -d --name portainer-mcp -p 17717:17717 \
 	-e PORTAINER_MCP_AUTH_TOKEN="$TOKEN" \
 	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com:17717 \
 	-e PORTAINER_MCP_DANGEROUSLY_ALLOW_PLAINTEXT_HTTP=1 \
-	portainer/portainer-mcp:2.44
+	portainer/portainer-mcp:2.45
 ````
 
 Then connect your client:
@@ -164,7 +164,7 @@ docker run -d --name portainer-mcp \
 	-e PORTAINER_MCP_ALLOWED_HOSTS=mcp.example.com \
 	-e PORTAINER_MCP_TRUST_PROXY_TLS=1 \
 	-e PORTAINER_MCP_FORWARDED_ALLOW_IPS=172.18.0.0/16 \
-	portainer/portainer-mcp:2.44
+	portainer/portainer-mcp:2.45
 ````
 
 No gate token is configured: the request is admitted by proxy attestation (it must arrive from `PORTAINER_MCP_FORWARDED_ALLOW_IPS` — inherited as the trust boundary, `*` refuses to boot) and by the caller's validated Portainer key. If the MCP server terminates TLS itself instead of the proxy, set `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS=<proxy ip/cidr>` in place of the two `TRUST_PROXY_TLS`/`FORWARDED_ALLOW_IPS` lines. See [`docs/configuration.md`](https://github.com/portainer/portainer-mcp/blob/main/docs/configuration.md#auth-posture-identity-aware-proxies) for the full posture rules.
@@ -186,10 +186,10 @@ For restricting or expanding this set of capabilities, see [`docs/profiles.md`](
 
 | Server version | Portainer (CE / EE) |
 | -------------- | ------------------- |
+| `2.45.x`       | `2.45.x`            |
 | `2.44.x`       | `2.44.x`            |
 | `2.43.x`       | `2.43.x`            |
 | `2.42.x`       | `2.42.x`            |
-| `2.41.x`       | `2.41.x`            |
 
 For more information about the versioning policy, see [`docs/versioning.md`](https://github.com/portainer/portainer-mcp/blob/main/docs/versioning.md).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,7 @@ Each operation becomes an MCP tool.
 
 ### Tag filter — `profiles.py`
 
-The spec exposes ~380 operations across 40+ tags — too noisy for a model
+The spec exposes 400+ operations across 40+ tags — too noisy for a model
 to navigate. Profiles are named bundles of tags (e.g. `DOCKER`,
 `KUBERNETES`). `PORTAINER_PROFILES` selects which to enable; the union
 of their tags becomes a `RouteMap` per tag (FastMCP intersects multi-tag

--- a/docs/distribution/claude-desktop.md
+++ b/docs/distribution/claude-desktop.md
@@ -22,7 +22,7 @@ Claude Desktop > Settings > Developer > Edit Config and choose one of the path b
   "mcpServers": {
     "portainer": {
       "command": "uvx",
-      "args": ["--from", "mcp-portainer~=2.44.0", "mcp-portainer"],
+      "args": ["--from", "mcp-portainer~=2.45.0", "mcp-portainer"],
       "env": {
         "PORTAINER_URL": "https://portainer.example.com",
         "PORTAINER_API_KEY": "ptr_xxxxxxxxxxxxxxxx"

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -41,11 +41,11 @@ when you need them, or switch to `ALL`:
 | Count | Tag | Notes |
 |---:|---|---|
 | 18 | `observability` | Container/pod logs, metrics, stats. |
-| 13 | `omni` | Talos Kubernetes cluster management. |
+| 17 | `addons` | Cluster addon management (new in Portainer 2.44). |
+| 14 | `omni` | Talos Kubernetes cluster management. |
 | 11 | `cloud_credentials` | Cloud provider credentials. |
 | 10 | `custom_templates` | User-defined app templates. |
 | 6 | `webhooks` | Webhook management. |
-| 5 | `addons` | Cluster addon management (new in Portainer 2.44). |
 | 4 | `useractivity` | Audit log. |
 | 3 | `support` | Support bundles / diagnostics. |
 | 2 | `allowlist` | URL allow list. |

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -3,14 +3,14 @@
 **Major+minor tracks the Portainer API; patch is the MCP server's to spend.**
 
 - Tag format: `<portainer-major>.<portainer-minor>.<mcp-patch>`.
-- Compatibility statement: **"MCP 2.44.x ↔ Portainer 2.44.x"** — minor
+- Compatibility statement: **"MCP 2.45.x ↔ Portainer 2.45.x"** — minor
   granularity.
 - Spec cadence: regenerate `src/portainer_mcp/data/portainer-patched.yaml` against the
   **latest patch** of the targeted Portainer minor (e.g. `make specs
-  VERSION=2.44.0` when 2.44.0 is current).
+  VERSION=2.45.0` when 2.45.0 is current).
 - MCP-internal iterations (shaping fixes, new profiles, transform changes,
-  dep bumps, doc-only changes) burn the patch slot — e.g. `2.44.1` is an
-  MCP-only release still targeting Portainer 2.44.x.
+  dep bumps, doc-only changes) burn the patch slot — e.g. `2.45.1` is an
+  MCP-only release still targeting Portainer 2.45.x.
 
 ## What does *not* bump the minor
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-portainer"
-version = "2.44.0"
+version = "2.45.0"
 description = "Portainer MCP server — manage Docker, Kubernetes, stacks, and Helm via the Model Context Protocol."
 readme = "README.md"
 license = "MIT"

--- a/skills/portainer-mcp-hygiene/SKILL.md
+++ b/skills/portainer-mcp-hygiene/SKILL.md
@@ -373,4 +373,4 @@ contradicts an explicit claim in this file, is reportable.
 
 ---
 
-Skill version: 2.44.0 (matches the `mcp-portainer` release tag this file shipped with).
+Skill version: 2.45.0 (matches the `mcp-portainer` release tag this file shipped with).

--- a/src/portainer_mcp/data/portainer-patched.yaml
+++ b/src/portainer_mcp/data/portainer-patched.yaml
@@ -34,8 +34,124 @@ info:
     \ repository was created.\n\nExample encoded value:\n\n```\neyJyZWdpc3RyeUlkIjoxfQ==\n\
     ```\n"
   title: PortainerEE API
-  version: 2.44.0
+  version: 2.45.0
 paths:
+  /addon-store/v1/config:
+    get:
+      description: 'Read the configuration the calling addon has stored. The addon
+        is identified
+
+        by its instance token, so no identifier appears in the path. Values are
+
+        returned in full: this is how an addon loads the secrets it runs on.
+
+        **Access policy**: addon instance token'
+      operationId: AddonStoreConfigList
+      responses:
+        '200':
+          description: Stored configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addons.configResponse'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Server error
+      summary: Read the calling addon's stored configuration
+      tags:
+      - addons
+    put:
+      description: 'Replace the full set of configuration entries: entries absent
+        from the
+
+        request are removed. A sensitive entry may omit its value to keep the
+
+        stored one.
+
+        **Access policy**: addon instance token'
+      operationId: AddonStoreConfigUpdate
+      requestBody:
+        $ref: '#/components/requestBodies/addons.configUpdatePayload'
+      responses:
+        '200':
+          description: Stored configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addons.configMutationResponse'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '500':
+          description: Server error
+      summary: Replace the calling addon's stored configuration
+      tags:
+      - addons
+  /addon-store/v1/config/{key}:
+    delete:
+      description: 'Remove one configuration entry.
+
+        **Access policy**: addon instance token'
+      operationId: AddonStoreConfigEntryDelete
+      parameters:
+      - description: Configuration key (e.g. BASE_DOMAIN)
+        in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Stored configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addons.configMutationResponse'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '404':
+          description: No such configuration entry
+        '500':
+          description: Server error
+      summary: Remove one of the calling addon's configuration entries
+      tags:
+      - addons
+    patch:
+      description: 'Set or update one configuration entry, leaving the others untouched.
+
+        A sensitive entry may omit its value to keep the stored one.
+
+        **Access policy**: addon instance token'
+      operationId: AddonStoreConfigEntryUpdate
+      parameters:
+      - description: Configuration key (e.g. BASE_DOMAIN)
+        in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/addons.configEntryUpdatePayload'
+      responses:
+        '200':
+          description: Stored configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addons.configMutationResponse'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '500':
+          description: Server error
+      summary: Set one of the calling addon's configuration entries
+      tags:
+      - addons
   /addons:
     get:
       description: 'List the addons the calling user may open. Administrators receive
@@ -82,23 +198,16 @@ paths:
       - addons
   /addons/{id}:
     delete:
-      description: 'Uninstall an addon''s Helm release from the local Kubernetes
-
-        environment. The addon record is returned in the uninstalling
-
-        state; the uninstall runs in the background and the record is
-
-        removed once it completes. Uninstalling an addon that is not
-
-        installed is a no-op. An in-flight install or upgrade can be
-
-        uninstalled; only an uninstall already in progress is rejected
-
-        with 409 unless force=true is set, which is the recovery path for
-
-        an addon stuck by a restart.
-
-        **Access policy**: administrator'
+      description: "Uninstall an addon's Helm release from the cluster Portainer is\n\
+        running in. The addon record is returned in the uninstalling\nstate; the uninstall\
+        \ runs in the background and the record is\nremoved once it completes. Uninstalling\
+        \ an addon that is not\ninstalled is a no-op. An in-flight install or upgrade\
+        \ can be\nuninstalled; only an uninstall already in progress is rejected\n\
+        with 409 unless force=true is set, which is the recovery path for\nan addon\
+        \ stuck by a restart.\n\nThe addon's stored configuration is retained by default,\
+        \ so\nreinstalling restores its settings \u2014 including any value the addon's\n\
+        own data depends on, such as an encryption key. Set pruneConfig=true\nto discard\
+        \ it as well; that is not reversible.\n**Access policy**: administrator"
       operationId: AddonUninstall
       parameters:
       - description: Addon identifier (e.g. portal-template)
@@ -110,6 +219,11 @@ paths:
       - description: Uninstall even while an operation is in progress (recovery)
         in: query
         name: force
+        schema:
+          type: boolean
+      - description: Also discard the addon's stored configuration (not reversible)
+        in: query
+        name: pruneConfig
         schema:
           type: boolean
       responses:
@@ -175,9 +289,9 @@ paths:
       tags:
       - addons
     post:
-      description: 'Install a catalog addon as a Helm release on the local Kubernetes
+      description: 'Install a catalog addon as a Helm release into the cluster Portainer
 
-        environment, or upgrade it when already installed. The addon record
+        is running in, or upgrade it when already installed. The addon record
 
         is returned immediately in the installing state for a fresh install
 
@@ -267,6 +381,356 @@ paths:
       - ApiKeyAuth: []
         jwt: []
       summary: Update an addon's access configuration
+      tags:
+      - addons
+  /addons/{id}/chart-source:
+    get:
+      description: 'Check whether Portainer can read an addon''s Helm chart, and list
+        the
+
+        versions published there. With no query parameters the addon''s catalog
+
+        chart is checked; registryId and chart together check a chart held in a
+
+        Portainer registry, which is how an install in an air-gapped environment
+
+        is pointed at a mirror.
+
+        An unreachable source is reported as a reason rather than an error, so the
+
+        install form can show it against the chart location field.
+
+        **Access policy**: administrator'
+      operationId: AddonChartSource
+      parameters:
+      - description: Addon identifier (e.g. portal-template)
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: Portainer registry holding the chart. Omit to check the catalog's
+          chart
+        in: query
+        name: registryId
+        schema:
+          type: integer
+      - description: Chart repository path within the registry. Required with registryId
+        in: query
+        name: chart
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addons.chartSourceStatusResponse'
+        '400':
+          description: Invalid request
+        '404':
+          description: Addon not found in the addon catalog
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Check where an addon's chart is pulled from
+      tags:
+      - addons
+  /addons/{id}/config:
+    delete:
+      description: 'Remove every configuration entry stored for an addon. This triggers
+        no
+
+        redeploy.
+
+        **Access policy**: administrator'
+      operationId: AddonConfigDelete
+      parameters:
+      - description: Addon identifier (e.g. portal-template)
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Stored configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addons.configMutationResponse'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Addon not found in the addon catalog
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Remove all of an addon's stored configuration
+      tags:
+      - addons
+    get:
+      description: 'List the configuration entries stored for an addon. Values are
+        returned
+
+        in full, including secrets, since this is how the addon reads its own
+
+        configuration back; sensitive entries are flagged so a client can display
+
+        them carefully. Portainer does not interpret these entries.
+
+        **Access policy**: administrator'
+      operationId: AddonConfigList
+      parameters:
+      - description: Addon identifier (e.g. portal-template)
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Stored configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addons.configResponse'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Addon not found in the addon catalog
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: List an addon's stored configuration
+      tags:
+      - addons
+    put:
+      description: 'Replace the full set of configuration entries: entries absent
+        from the
+
+        request are removed. A sensitive entry may omit its value to keep the
+
+        stored one. Saving only stores; it triggers no redeploy.
+
+        **Access policy**: administrator'
+      operationId: AddonConfigUpdate
+      parameters:
+      - description: Addon identifier (e.g. portal-template)
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/addons.configUpdatePayload'
+      responses:
+        '200':
+          description: Stored configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addons.configMutationResponse'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Addon not found in the addon catalog
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Replace an addon's stored configuration
+      tags:
+      - addons
+  /addons/{id}/config/{key}:
+    delete:
+      description: 'Remove one configuration entry. This triggers no redeploy.
+
+        **Access policy**: administrator'
+      operationId: AddonConfigEntryDelete
+      parameters:
+      - description: Addon identifier (e.g. portal-template)
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: Configuration key (e.g. BASE_DOMAIN)
+        in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Stored configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addons.configMutationResponse'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Addon not found in the addon catalog, or no such configuration
+            entry
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Remove a single addon configuration entry
+      tags:
+      - addons
+    patch:
+      description: 'Set or update one configuration entry, leaving the others untouched.
+
+        A sensitive entry may omit its value to keep the stored one, as on the
+
+        full-set update. Saving only stores; it triggers no redeploy.
+
+        **Access policy**: administrator'
+      operationId: AddonConfigEntryUpdate
+      parameters:
+      - description: Addon identifier (e.g. portal-template)
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: Configuration key (e.g. BASE_DOMAIN)
+        in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/addons.configEntryUpdatePayload'
+      responses:
+        '200':
+          description: Stored configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addons.configMutationResponse'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Addon not found in the addon catalog
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Set a single addon configuration entry
+      tags:
+      - addons
+  /addons/{id}/repair:
+    post:
+      description: 'Mint a fresh credential for an installed addon and republish it
+        to the
+
+        cluster, along with the certificate the addon verifies Portainer''s TLS
+
+        with. The addon''s stored configuration is untouched.
+
+
+        The recovery path for an addon that is running but can no longer
+
+        authenticate: a database restored from before the credential was issued, a
+
+        Secret deleted by hand, or a replaced Portainer certificate. The credential
+
+        is stored hashed, so Portainer cannot tell which side is stale; repairing
+
+        replaces both, needing no diagnosis and no uninstall.
+
+
+        Not a Helm operation: nothing is redeployed. The addon picks the new
+
+        credential up once Kubernetes propagates the Secret to its pod.
+
+        **Access policy**: administrator'
+      operationId: AddonRepair
+      parameters:
+      - description: Addon identifier (e.g. portal-template)
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Credential repaired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addons.addonLifecycleResponse'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '404':
+          description: Addon not found in the addon catalog, or not installed
+        '409':
+          description: An operation for this add-on is already in progress
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Repair an addon's credential
+      tags:
+      - addons
+  /addons/environment:
+    get:
+      description: 'Return the connected environment that points at the cluster
+
+        Portainer runs in, the cluster addons install into. It is verified
+
+        against the cluster''s own identity rather than inferred from its
+
+        type, so it is never a different cluster. environmentId is 0 when
+
+        none could be verified, which does not affect installed addons.
+
+        **Access policy**: administrator'
+      operationId: AddonEnvironment
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addons.addonEnvironmentResponse'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Portainer is not running on Kubernetes, where addons do not
+            exist
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Retrieve the environment addon resources can be read through
       tags:
       - addons
   /allowlist/{id}:
@@ -2128,7 +2592,8 @@ paths:
         '204':
           description: No Content
         '409':
-          description: Edge group is in use by an Edge stack, Edge job or Edge config
+          description: Edge group is in use by an Edge stack, Edge job, Edge config
+            or Workflow
         '500':
           description: Server error
         '503':
@@ -4558,7 +5023,9 @@ paths:
       - endpoints
   /endpoints/{id}/kubernetes/helm:
     get:
-      description: '**Access policy**: authenticated'
+      description: 'List the Helm releases in the namespaces the user can access.
+
+        **Access policy**: authenticated'
       operationId: HelmList
       parameters:
       - description: Environment(Endpoint) identifier
@@ -4595,6 +5062,8 @@ paths:
           description: Invalid environment(endpoint) identifier
         '401':
           description: Unauthorized
+        '403':
+          description: Permission denied
         '404':
           description: Environment(Endpoint) or ServiceAccount not found
         '500':
@@ -4694,6 +5163,14 @@ paths:
     get:
       description: 'Get details of a helm release by release name
 
+        The release is scoped to the namespaces the user can access. Callers
+
+        without the K8sSecretsDetailsR authorization receive the release with its
+
+        manifest, values, config, hooks and notes omitted, because those are
+
+        rendered from the chart and can contain Secret data.
+
         **Access policy**: authenticated'
       operationId: HelmGet
       parameters:
@@ -4754,7 +5231,13 @@ paths:
       - helm
   /endpoints/{id}/kubernetes/helm/{release}/history:
     get:
-      description: 'Get a historical list of releases by release name
+      description: 'Get a historical list of releases by release name.
+
+        The history is scoped to the namespaces the user can access. Callers
+
+        without the K8sSecretsDetailsR authorization receive each revision with
+
+        its rendered notes omitted.
 
         **Access policy**: authenticated'
       operationId: HelmGetHistory
@@ -6098,6 +6581,52 @@ paths:
       summary: Get a GitOps workflow by ID
       tags:
       - gitops
+    put:
+      description: 'Applies a partial, identity-preserving update to a workflow: the
+        underlying
+
+        Stack/EdgeStack of each matched artifact is updated in place (same ID, no
+
+        delete+recreate) and immediately redeployed. Only artifact entries present
+        in
+
+        the request are touched; omitted fields on a touched artifact are left unchanged.
+
+        **Access policy**: administrator'
+      operationId: WorkflowUpdate
+      parameters:
+      - description: Workflow identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/workflows.updatePayload'
+        description: Workflow update
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/workflows.Workflow'
+        '400':
+          description: Invalid request
+        '404':
+          description: Workflow not found
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+      - jwt: []
+      summary: Update a workflow
+      tags:
+      - gitops
   /gitops/workflows/{id}/destroy:
     delete:
       description: 'Tears down each of the workflow''s artifacts then deletes the
@@ -7165,6 +7694,53 @@ paths:
       summary: Get the dashboard summary data
       tags:
       - kubernetes
+  /kubernetes/{id}/deployments:
+    get:
+      description: 'Get the list of Kubernetes deployments across all namespaces the
+        user can access.
+
+        **Access policy**: Authenticated user.'
+      operationId: getAllKubernetesDeployments
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Kubernetes label selector to filter the deployments
+        in: query
+        name: labelSelector
+        schema:
+          type: string
+      - description: Kubernetes field selector to filter the deployments
+        in: query
+        name: fieldSelector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesDeploymentListResponse'
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '500':
+          description: Server error occurred while attempting to retrieve the deployments.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Get Kubernetes deployments
+      tags:
+      - kubernetes
   /kubernetes/{id}/describe:
     get:
       description: 'Get a description of a kubernetes resource.
@@ -7222,6 +7798,46 @@ paths:
       - ApiKeyAuth: []
         jwt: []
       summary: Get a description of a kubernetes resource
+      tags:
+      - kubernetes
+  /kubernetes/{id}/endpoints:
+    get:
+      description: 'Get a list of Kubernetes endpoints within the given environment.
+
+        **Access policy**: Authenticated user.'
+      operationId: GetKubernetesEndpoints
+      parameters:
+      - description: Environment identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/kubernetes.K8sEndpoint'
+                type: array
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '404':
+          description: Unable to find an environment with the specified identifier.
+        '500':
+          description: Server error occurred while attempting to retrieve endpoints.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Get a list of Endpoints
       tags:
       - kubernetes
   /kubernetes/{id}/events:
@@ -7309,6 +7925,48 @@ paths:
       - ApiKeyAuth: []
         jwt: []
       summary: Get GPU visibility information for a Kubernetes cluster.
+      tags:
+      - kubernetes
+  /kubernetes/{id}/ingressclasses:
+    get:
+      description: 'Get the list of Kubernetes ingress classes (cluster-scoped), as
+        read
+
+        models, distinct from the ingress controllers returned by /ingresscontrollers.
+
+        **Access policy**: Authenticated user.'
+      operationId: getKubernetesIngressClasses
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/kubernetes.K8sIngressClass'
+                type: array
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '500':
+          description: Server error occurred while attempting to retrieve the ingress
+            classes.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Get Kubernetes ingress classes
       tags:
       - kubernetes
   /kubernetes/{id}/ingresscontrollers:
@@ -7633,6 +8291,64 @@ paths:
       summary: Delete Jobs
       tags:
       - kubernetes
+  /kubernetes/{id}/manifests/dry_run:
+    post:
+      description: 'Validate Kubernetes manifests against the cluster with a server-side
+        dry-run apply, without persisting anything.
+
+        Each resource is reported on its own, so a rejected resource does not hide
+        the outcome of the others.
+
+        The dry-run runs with the permissions of the requesting user, so it also surfaces
+        missing permissions.
+
+        A resource living in a namespace created by another manifest of the same request
+        is reported as failed, because the dry-run never persists that namespace.
+
+        **Access policy**: authenticated'
+      operationId: DryRunKubernetesManifests
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.manifestDryRunPayload'
+        description: The manifests to validate
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.manifestDryRunResponse'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '404':
+          description: Unable to find an environment with the specified identifier.
+        '500':
+          description: Server error occurred while attempting to validate the manifests.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Validate Kubernetes manifests without applying them
+      tags:
+      - kubernetes
   /kubernetes/{id}/max_resource_limits:
     get:
       description: 'Get max CPU and memory limits (unused resources) of all nodes
@@ -7793,48 +8509,6 @@ paths:
       summary: Get live metrics for a node
       tags:
       - kubernetes
-  /kubernetes/{id}/metrics/pods/{namespace}:
-    get:
-      description: 'Get a list of pods with their live metrics for the specified namespace.
-
-        **Access policy**: Authenticated user.'
-      operationId: GetKubernetesMetricsForAllPods
-      parameters:
-      - description: Environment identifier
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      - description: Namespace
-        in: path
-        name: namespace
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/v1beta1.PodMetricsList'
-        '400':
-          description: Invalid request payload, such as missing required fields or
-            fields not meeting validation criteria.
-        '401':
-          description: Unauthorized access - the user is not authenticated or does
-            not have the necessary permissions. Ensure that you have provided a valid
-            API key or JWT token, and that you have the required permissions.
-        '500':
-          description: Server error occurred while attempting to retrieve the list
-            of pods with their live metrics.
-      security:
-      - ApiKeyAuth: []
-        jwt: []
-      summary: Get a list of pods with their live metrics
-      tags:
-      - kubernetes
   /kubernetes/{id}/metrics/pods/{namespace}/{name}:
     get:
       description: 'Get live metrics for the specified pod.
@@ -7881,6 +8555,52 @@ paths:
       - ApiKeyAuth: []
         jwt: []
       summary: Get live metrics for a pod
+      tags:
+      - kubernetes
+  /kubernetes/{id}/metrics/pods/namespace/{namespace}:
+    get:
+      description: 'Get a list of pods with their live metrics for the specified namespace.
+
+        **Access policy**: Authenticated user.'
+      operationId: GetKubernetesMetricsForAllPods
+      parameters:
+      - description: Environment identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/v1beta1.PodMetricsList'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but is not authorized
+            to access pod metrics in the specified namespace. Check your user roles
+            and permissions.
+        '500':
+          description: Server error occurred while attempting to retrieve the list
+            of pods with their live metrics.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Get a list of pods with their live metrics
       tags:
       - kubernetes
   /kubernetes/{id}/namespaces:
@@ -8241,7 +8961,8 @@ paths:
             have the necessary permissions to access the requested resource or perform
             the specified operation. Check your user roles and permissions.
         '404':
-          description: Unable to find an environment with the specified identifier.
+          description: Unable to find an environment with the specified identifier,
+            or the requested application does not exist in the namespace.
         '500':
           description: Server error occurred while attempting to retrieve the application.
       security:
@@ -8250,7 +8971,107 @@ paths:
       summary: Get an application by name in a specific namespace
       tags:
       - kubernetes
+  /kubernetes/{id}/namespaces/{namespace}/configmaps:
+    post:
+      description: 'Create a ConfigMap in the given namespace. The response carries
+        the
+
+        created ConfigMap''s metadata only, not its data.
+
+        **Access policy**: Authenticated user.'
+      operationId: CreateKubernetesConfigMap
+      parameters:
+      - description: Environment identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: The namespace name where the configmap is created
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/kubernetes.K8sConfigMapWriteRequest'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/models.K8sConfigMap'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '409':
+          description: A configmap with the same name already exists in the namespace.
+        '500':
+          description: Server error occurred while attempting to create the configmap.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Create a ConfigMap
+      tags:
+      - kubernetes
   /kubernetes/{id}/namespaces/{namespace}/configmaps/{configmap}:
+    delete:
+      description: 'Delete a ConfigMap in the given namespace.
+
+        **Access policy**: Authenticated user.'
+      operationId: DeleteKubernetesConfigMap
+      parameters:
+      - description: Environment identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: The namespace name where the configmap is located
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: The configmap name to delete
+        in: path
+        name: configmap
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Success
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '404':
+          description: Unable to find the configmap to delete.
+        '500':
+          description: Server error occurred while attempting to delete the configmap.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Delete a ConfigMap
+      tags:
+      - kubernetes
     get:
       description: 'Get a ConfigMap by name for a given namespace.
 
@@ -8303,6 +9124,539 @@ paths:
       - ApiKeyAuth: []
         jwt: []
       summary: Get a ConfigMap
+      tags:
+      - kubernetes
+    put:
+      description: 'Update a ConfigMap in the given namespace. A nil field leaves
+        the live
+
+        value untouched, so an empty map clears it, and binary data is preserved.
+
+        The response carries the updated ConfigMap''s metadata only.
+
+        **Access policy**: Authenticated user.'
+      operationId: UpdateKubernetesConfigMap
+      parameters:
+      - description: Environment identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: The namespace name where the configmap is located
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: The configmap name to update
+        in: path
+        name: configmap
+        required: true
+        schema:
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/kubernetes.K8sConfigMapWriteRequest'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/models.K8sConfigMap'
+        '400':
+          description: Invalid request payload, such as missing required fields, fields
+            not meeting validation criteria, or a payload name that does not match
+            the route.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '404':
+          description: Unable to find the configmap to update.
+        '500':
+          description: Server error occurred while attempting to update the configmap.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Update a ConfigMap
+      tags:
+      - kubernetes
+  /kubernetes/{id}/namespaces/{namespace}/deployments:
+    get:
+      description: 'Get the list of Kubernetes deployments in the given namespace.
+
+        **Access policy**: Authenticated user.'
+      operationId: getKubernetesDeploymentsForNamespace
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: Kubernetes label selector to filter the deployments
+        in: query
+        name: labelSelector
+        schema:
+          type: string
+      - description: Kubernetes field selector to filter the deployments
+        in: query
+        name: fieldSelector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesDeploymentListResponse'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '500':
+          description: Server error occurred while attempting to retrieve the deployments
+            within the specified namespace.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Get Kubernetes deployments within a namespace
+      tags:
+      - kubernetes
+    post:
+      description: 'Create a deployment in the given namespace. The namespace comes
+        from the
+
+        route, and the payload models the fields the deployment forms drive.
+
+        **Access policy**: Authenticated user.'
+      operationId: CreateKubernetesDeployment
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/kubernetes.K8sDeploymentWriteRequest'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesDeploymentResponse'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '409':
+          description: A deployment with the same name already exists in the namespace.
+        '500':
+          description: Server error occurred while attempting to create the deployment.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Create a Kubernetes deployment
+      tags:
+      - kubernetes
+  /kubernetes/{id}/namespaces/{namespace}/deployments/{name}:
+    delete:
+      description: 'Delete a deployment in the given namespace. The replica sets and
+        pods it
+
+        owns are garbage collected by the cluster.
+
+        **Access policy**: Authenticated user.'
+      operationId: DeleteKubernetesDeployment
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: Deployment name
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Success
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '404':
+          description: Unable to find the deployment to delete.
+        '500':
+          description: Server error occurred while attempting to delete the deployment.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Delete a Kubernetes deployment
+      tags:
+      - kubernetes
+    get:
+      description: 'Get a Kubernetes deployment in the given namespace. The response
+        is
+
+        trimmed of server-managed and heavy fields (managed fields,
+
+        last-applied-config annotation) while preserving the full pod template,
+
+        spec and resourceVersion so an edit form can be reconstructed from the
+
+        live cluster and the workload subsequently updated.
+
+        **Access policy**: Authenticated user.'
+      operationId: getKubernetesDeployment
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: Deployment name
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesDeploymentResponse'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '500':
+          description: Server error occurred while attempting to retrieve the deployment.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Get a Kubernetes deployment
+      tags:
+      - kubernetes
+    patch:
+      description: 'Add or overwrite annotations on a deployment and on the pods it
+        creates.
+
+        Annotations the payload does not name are kept. Changing a pod annotation
+
+        rolls the workload, which is how a rollout restart is triggered.
+
+        **Access policy**: Authenticated user.'
+      operationId: PatchKubernetesDeployment
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: Deployment name
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/kubernetes.K8sDeploymentPatchRequest'
+        description: Annotations to apply
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesDeploymentResponse'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '404':
+          description: Unable to find the deployment to annotate.
+        '500':
+          description: Server error occurred while attempting to annotate the deployment.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Annotate a Kubernetes deployment
+      tags:
+      - kubernetes
+    put:
+      description: 'Update a deployment in the given namespace. The payload is merged
+        onto the
+
+        live deployment: fields it does not model, such as the update strategy or
+
+        the pod affinity rules, are preserved, and a field left out leaves the live
+
+        value untouched. The selector is immutable and is ignored.
+
+        **Access policy**: Authenticated user.'
+      operationId: UpdateKubernetesDeployment
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: Deployment name
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/kubernetes.K8sDeploymentWriteRequest'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesDeploymentResponse'
+        '400':
+          description: Invalid request payload, such as missing required fields, fields
+            not meeting validation criteria, or a payload name that does not match
+            the route.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '404':
+          description: Unable to find the deployment to update.
+        '409':
+          description: The deployment was modified concurrently.
+        '500':
+          description: Server error occurred while attempting to update the deployment.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Update a Kubernetes deployment
+      tags:
+      - kubernetes
+  /kubernetes/{id}/namespaces/{namespace}/deployments/{name}/rollback:
+    post:
+      description: 'Roll a deployment back to an earlier revision by replaying the
+        pod template
+
+        the corresponding replica set recorded. A revision of 0, or an omitted one,
+
+        selects the revision immediately before the current.
+
+        **Access policy**: Authenticated user.'
+      operationId: RollbackKubernetesDeployment
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: Deployment name
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/kubernetes.K8sDeploymentRollbackRequest'
+        description: Revision to roll back to
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesDeploymentResponse'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '404':
+          description: Unable to find the deployment, or the requested revision is
+            not part of its rollout history.
+        '500':
+          description: Server error occurred while attempting to roll the deployment
+            back.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Roll a Kubernetes deployment back
+      tags:
+      - kubernetes
+  /kubernetes/{id}/namespaces/{namespace}/deployments/{name}/scale:
+    put:
+      description: 'Set the desired replica count of a deployment in the given namespace.
+
+        **Access policy**: Authenticated user.'
+      operationId: ScaleKubernetesDeployment
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: Deployment name
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/kubernetes.K8sDeploymentScaleRequest'
+        description: Desired replica count
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesDeploymentResponse'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '404':
+          description: Unable to find the deployment to scale.
+        '500':
+          description: Server error occurred while attempting to scale the deployment.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Scale a Kubernetes deployment
       tags:
       - kubernetes
   /kubernetes/{id}/namespaces/{namespace}/events:
@@ -8694,6 +10048,66 @@ paths:
       summary: Get PersistentVolumeClaims in a namespace
       tags:
       - kubernetes
+    post:
+      description: 'Create a PersistentVolumeClaim in the given namespace. The access
+        mode
+
+        defaults to ReadWriteOnce and an omitted storage class leaves the choice to
+
+        the cluster default.
+
+        **Access policy**: Authenticated user.'
+      operationId: CreateKubernetesPersistentVolumeClaim
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/kubernetes.K8sPersistentVolumeClaimCreateRequest'
+        description: PersistentVolumeClaim definition
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/models.K8sPersistentVolumeClaim'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            a storage size that is not a valid quantity.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '409':
+          description: A persistent volume claim with the same name already exists
+            in the namespace.
+        '500':
+          description: Server error occurred while attempting to create the persistent
+            volume claim.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Create a PersistentVolumeClaim
+      tags:
+      - kubernetes
   /kubernetes/{id}/namespaces/{namespace}/persistent_volume_claims/{name}:
     get:
       description: 'Get a PersistentVolumeClaim by name within a namespace.
@@ -8739,6 +10153,62 @@ paths:
       - ApiKeyAuth: []
         jwt: []
       summary: Get a specific PersistentVolumeClaim
+      tags:
+      - kubernetes
+  /kubernetes/{id}/namespaces/{namespace}/pods:
+    get:
+      description: 'Get the list of Kubernetes pods in the given namespace.
+
+        **Access policy**: Authenticated user.'
+      operationId: getKubernetesPodsForNamespace
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: Kubernetes label selector to filter the pods (e.g. app=nginx)
+        in: query
+        name: labelSelector
+        schema:
+          type: string
+      - description: Kubernetes field selector to filter the pods (e.g. status.phase=Running)
+        in: query
+        name: fieldSelector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesPodListResponse'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '500':
+          description: Server error occurred while attempting to retrieve the pods
+            within the specified namespace.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Get Kubernetes pods within a namespace
       tags:
       - kubernetes
   /kubernetes/{id}/namespaces/{namespace}/pods/{name}:
@@ -8793,6 +10263,95 @@ paths:
       - ApiKeyAuth: []
         jwt: []
       summary: Delete a kubernetes pod
+      tags:
+      - kubernetes
+  /kubernetes/{id}/namespaces/{namespace}/pods/{name}/log:
+    get:
+      description: 'Stream the logs for a pod in the given namespace as text/plain.
+        When
+
+        follow is set the response stays open and emits new log lines until the
+
+        client disconnects. When the pod has more than one container, the
+
+        container query parameter is required.
+
+        **Access policy**: Authenticated user.'
+      operationId: getKubernetesPodLogs
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: Pod name
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      - description: Container name (required when the pod has multiple containers)
+        in: query
+        name: container
+        schema:
+          type: string
+      - description: Number of lines from the end of the logs to return
+        in: query
+        name: tailLines
+        schema:
+          type: integer
+      - description: Only return logs newer than this many seconds
+        in: query
+        name: sinceSeconds
+        schema:
+          type: integer
+      - description: Prefix each log line with an RFC3339 timestamp
+        in: query
+        name: timestamps
+        schema:
+          type: boolean
+      - description: Return the logs of the previous terminated container instance
+        in: query
+        name: previous
+        schema:
+          type: boolean
+      - description: Stream new log lines as they are produced until the client disconnects
+        in: query
+        name: follow
+        schema:
+          type: boolean
+      responses:
+        '200':
+          description: Success
+          content:
+            text/plain:
+              schema:
+                type: string
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '500':
+          description: Server error occurred while attempting to retrieve the pod
+            logs.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Get logs for a Kubernetes pod
       tags:
       - kubernetes
   /kubernetes/{id}/namespaces/{namespace}/pods/{name}/restart:
@@ -8855,7 +10414,224 @@ paths:
       summary: Restart all containers in a Kubernetes pod
       tags:
       - kubernetes
+  /kubernetes/{id}/namespaces/{namespace}/replicasets:
+    get:
+      description: 'Get the list of Kubernetes replica sets in the given namespace,
+        optionally
+
+        restricted to those owned by a given deployment. This backs the deployment
+
+        revisions view. The response uses the Kubernetes list shape ({items: [...]}).
+
+        **Access policy**: Authenticated user.'
+      operationId: getKubernetesReplicaSets
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: Only return replica sets owned by this deployment
+        in: query
+        name: deployment
+        schema:
+          type: string
+      - description: Kubernetes label selector to filter the replica sets
+        in: query
+        name: labelSelector
+        schema:
+          type: string
+      - description: Kubernetes field selector to filter the replica sets
+        in: query
+        name: fieldSelector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesReplicaSetListResponse'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '404':
+          description: Unable to find the deployment given in the deployment query
+            parameter.
+        '500':
+          description: Server error occurred while attempting to retrieve the replica
+            sets within the specified namespace.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Get Kubernetes replica sets within a namespace
+      tags:
+      - kubernetes
+  /kubernetes/{id}/namespaces/{namespace}/resource_quotas:
+    get:
+      description: 'Get the list of Kubernetes resource quotas in the given namespace.
+
+        **Access policy**: Authenticated user.'
+      operationId: getKubernetesResourceQuotas
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesResourceQuotaListResponse'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '500':
+          description: Server error occurred while attempting to retrieve the resource
+            quotas within the specified namespace.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Get Kubernetes resource quotas within a namespace
+      tags:
+      - kubernetes
+  /kubernetes/{id}/namespaces/{namespace}/secrets:
+    post:
+      description: 'Create a Secret in the given namespace. Data values are sent as
+        plain
+
+        strings and encoded server-side. The response carries the created
+
+        Secret''s metadata only, not its data.
+
+        **Access policy**: Authenticated user.'
+      operationId: CreateKubernetesSecret
+      parameters:
+      - description: Environment identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: The namespace name where the secret is created
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/kubernetes.K8sSecretWriteRequest'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/models.K8sSecret'
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '409':
+          description: A secret with the same name already exists in the namespace.
+        '500':
+          description: Server error occurred while attempting to create the secret.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Create a Secret
+      tags:
+      - kubernetes
   /kubernetes/{id}/namespaces/{namespace}/secrets/{secret}:
+    delete:
+      description: 'Delete a Secret in the given namespace.
+
+        **Access policy**: Authenticated user.'
+      operationId: DeleteKubernetesSecret
+      parameters:
+      - description: Environment identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: The namespace name where the secret is located
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: The secret name to delete
+        in: path
+        name: secret
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Success
+        '400':
+          description: Invalid request payload, such as missing required fields or
+            fields not meeting validation criteria.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '404':
+          description: Unable to find the secret to delete.
+        '500':
+          description: Server error occurred while attempting to delete the secret.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Delete a Secret
+      tags:
+      - kubernetes
     get:
       description: 'Get a Secret by name for a given namespace.
 
@@ -8907,6 +10683,66 @@ paths:
       - ApiKeyAuth: []
         jwt: []
       summary: Get a Secret
+      tags:
+      - kubernetes
+    put:
+      description: 'Update a Secret in the given namespace. A nil field leaves the
+        live value
+
+        untouched, so an empty map clears it, and the secret type cannot be
+
+        changed. The response carries the updated Secret''s metadata only.
+
+        **Access policy**: Authenticated user.'
+      operationId: UpdateKubernetesSecret
+      parameters:
+      - description: Environment identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: The namespace name where the secret is located
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: The secret name to update
+        in: path
+        name: secret
+        required: true
+        schema:
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/kubernetes.K8sSecretWriteRequest'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/models.K8sSecret'
+        '400':
+          description: Invalid request payload, such as missing required fields, fields
+            not meeting validation criteria, or a payload name that does not match
+            the route.
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '404':
+          description: Unable to find the secret to update.
+        '500':
+          description: Server error occurred while attempting to update the secret.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Update a Secret
       tags:
       - kubernetes
   /kubernetes/{id}/namespaces/{namespace}/service_accounts/{name}:
@@ -9359,6 +11195,13 @@ paths:
         required: true
         schema:
           type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.drainNodePayload'
+        description: Drain options, matching kubectl drain flags. Defaults are applied
+          to any omitted field.
       responses:
         '204':
           description: Success
@@ -9683,6 +11526,53 @@ paths:
       - ApiKeyAuth: []
         jwt: []
       summary: Update reclaim policy of a PersistentVolume
+      tags:
+      - kubernetes
+  /kubernetes/{id}/pods:
+    get:
+      description: 'Get the list of Kubernetes pods across all namespaces the user
+        can access.
+
+        **Access policy**: Authenticated user.'
+      operationId: getAllKubernetesPods
+      parameters:
+      - description: Environment(Endpoint) identifier
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Kubernetes label selector to filter the pods (e.g. app=nginx)
+        in: query
+        name: labelSelector
+        schema:
+          type: string
+      - description: Kubernetes field selector to filter the pods (e.g. status.phase=Running)
+        in: query
+        name: fieldSelector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesPodListResponse'
+        '401':
+          description: Unauthorized access - the user is not authenticated or does
+            not have the necessary permissions. Ensure that you have provided a valid
+            API key or JWT token, and that you have the required permissions.
+        '403':
+          description: Permission denied - the user is authenticated but does not
+            have the necessary permissions to access the requested resource or perform
+            the specified operation. Check your user roles and permissions.
+        '500':
+          description: Server error occurred while attempting to retrieve the pods.
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Get Kubernetes pods
       tags:
       - kubernetes
   /kubernetes/{id}/rbac_enabled:
@@ -11815,6 +13705,42 @@ paths:
       summary: Delete an Omni cluster
       tags:
       - omni
+  /omni/{credentialID}/cluster/provision/cancel:
+    post:
+      description: 'Stop the provisioning of an Omni environment and mark it as errored,
+        optionally deleting the partially created cluster in Omni.
+
+        **Access policy**: administrator'
+      operationId: OmniCancelProvisioning
+      parameters:
+      - description: Cloud credential identifier
+        in: path
+        name: credentialID
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/omni.cancelProvisioningPayload'
+        description: Provisioning cancellation request
+        required: true
+      responses:
+        '204':
+          description: Success
+        '400':
+          description: Invalid request
+        '404':
+          description: Environment not found
+        '500':
+          description: Server error
+      security:
+      - ApiKeyAuth: []
+        jwt: []
+      summary: Cancel an Omni cluster provisioning
+      tags:
+      - omni
   /omni/{credentialID}/cluster/update:
     put:
       description: 'Update a cluster''s Kubernetes version, Talos version, or node
@@ -12943,7 +14869,7 @@ paths:
     get:
       description: 'List all roles available for use
 
-        **Access policy**: authenticated'
+        **Access policy**: administrator'
       operationId: RoleList
       responses:
         '200':
@@ -14744,10 +16670,10 @@ paths:
       - team_memberships
   /teams:
     get:
-      description: 'List teams. All authenticated users can list all teams (teams
-        only expose ID and Name).
+      description: 'List teams. For non-administrator users, will only list the teams
+        they are member of.
 
-        **Access policy**: authenticated'
+        **Access policy**: restricted'
       operationId: TeamList
       parameters:
       - description: Only list teams that the user is leader of
@@ -15389,11 +17315,18 @@ paths:
     get:
       description: 'List Portainer users.
 
-        Non-administrator users only receive non-administrator accounts.
+        Administrators can list every user account, and team leaders can list the
+        users of the teams they lead.
 
-        Passwords are never included in any response.
+        When `environmentId` is provided, environment (endpoint) administrators and
+        edge administrators can additionally list the non-administrator users with
+        access to that environment.
 
-        **Access policy**: authenticated'
+        All other authenticated users only receive their own user account.
+
+        User passwords are filtered out, and should never be accessible.
+
+        **Access policy**: restricted'
       operationId: UserList
       parameters:
       - description: Identifier of the environment(endpoint) that will be used to
@@ -16533,6 +18466,13 @@ components:
             $ref: '#/components/schemas/models.K8sServiceInfo'
       description: Service definition
       required: true
+    addons.configEntryUpdatePayload:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/addons.configEntryUpdatePayload'
+      description: Configuration value
+      required: true
     models.K8sIngressControllerArray:
       content:
         application/json:
@@ -16541,6 +18481,13 @@ components:
               $ref: '#/components/schemas/models.K8sIngressController'
             type: array
       description: Ingress controllers
+      required: true
+    kubernetes.K8sDeploymentWriteRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/kubernetes.K8sDeploymentWriteRequest'
+      description: Deployment definition
       required: true
     Create:
       content:
@@ -16570,6 +18517,13 @@ components:
             $ref: '#/components/schemas/models.K8sNamespaceDetails'
       description: Namespace details
       required: true
+    addons.configUpdatePayload:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/addons.configUpdatePayload'
+      description: Configuration entries
+      required: true
     endpoints.endpointDeleteBatchPayload:
       content:
         application/json:
@@ -16578,12 +18532,26 @@ components:
       description: List of environments to delete, with optional deleteCluster flag
         to clean-up associated resources (cloud environments only)
       required: true
+    kubernetes.K8sConfigMapWriteRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/kubernetes.K8sConfigMapWriteRequest'
+      description: ConfigMap definition
+      required: true
     models.K8sIngressInfo:
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/models.K8sIngressInfo'
       description: Ingress details
+      required: true
+    kubernetes.K8sSecretWriteRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/kubernetes.K8sSecretWriteRequest'
+      description: Secret definition
       required: true
   securitySchemes:
     ApiKeyAuth:
@@ -16600,11 +18568,13 @@ components:
       - unknown
       - healthy
       - unhealthy
+      - credential-invalid
       type: string
       x-enum-varnames:
       - AddonHealthUnknown
       - AddonHealthHealthy
       - AddonHealthUnhealthy
+      - AddonHealthCredentialInvalid
     addon.LifecycleStatus:
       enum:
       - installing
@@ -16653,6 +18623,16 @@ components:
             policies
 
             unchanged, send an empty object to revoke all user grants'
+      type: object
+    addons.addonEnvironmentResponse:
+      properties:
+        environmentId:
+          description: 'EnvironmentID is the environment verified to point at Portainer''s
+            own
+
+            cluster. Zero when none could be: the addon runs, it just cannot be read
+            back.'
+          type: integer
       type: object
     addons.addonLifecycleResponse:
       properties:
@@ -16757,6 +18737,14 @@ components:
           items:
             $ref: '#/components/schemas/addons.addonListItem'
           type: array
+        catalogError:
+          description: 'CatalogError explains why the addon catalog could not be refreshed.
+            With
+
+            addons present the list is a cached copy; with none, nothing could be
+
+            loaded. Admin-only, and never set on the switcher view.'
+          type: string
       type: object
     addons.addonRecord:
       properties:
@@ -16771,6 +18759,12 @@ components:
           items:
             type: string
           type: array
+        chartPath:
+          description: 'ChartPath is the chart''s repository path within RegistryID.
+            Empty when
+
+            RegistryID is 0.'
+          type: string
         chartVersion:
           description: 'ChartVersion is the currently installed chart version, from
             the persisted
@@ -16778,14 +18772,29 @@ components:
             record (kept current by the install/upgrade lifecycle).'
           type: string
         helmChartRepository:
-          description: 'HelmChartRepository is the catalog''s OCI chart reference.
-            The install
+          description: 'HelmChartRepository is the catalog''s public OCI chart reference:
+            the default
 
-            wizard shows it as the chart source and uses it to fetch the chart''s
+            chart source, offered by the install wizard when the addon is not pinned
+            to
 
-            default values through the generic Helm API (GET /templates/helm/values).'
+            a Portainer registry.'
           example: oci://ghcr.io/portainer/charts/portal-template
           type: string
+        imageRegistryId:
+          description: 'ImageRegistryID is the Portainer registry whose credentials
+            the addon''s pods
+
+            pull their container image with, or 0 when the image needs none.'
+          type: integer
+        registryId:
+          description: 'RegistryID is the Portainer registry the addon''s chart is
+            pulled from, or 0
+
+            when it comes from HelmChartRepository. Recorded at install time and fixed
+
+            for the life of the release.'
+          type: integer
         teamAccessPolicies:
           $ref: '#/components/schemas/portainer.TeamAccessPolicies'
         upgradeAvailable:
@@ -16806,8 +18815,144 @@ components:
             disabled) is surfaced rather than silently reported as "no upgrade".'
           type: string
       type: object
+    addons.chartSourceStatusResponse:
+      properties:
+        reachable:
+          description: 'Reachable reports whether the registry answered. A registry
+            that answered
+
+            but holds no such chart is reachable, with no versions.'
+          type: boolean
+        reason:
+          description: Reason explains an unreachable source. Empty when Reachable.
+          example: 'The registry''s TLS certificate could not be verified: x509: certificate
+            signed by unknown authority'
+          type: string
+        tlsVerify:
+          description: "TLSVerify reports whether the certificate the registry served\
+            \ verified\nagainst the trust store. It is false only where a certificate\
+            \ did not\nverify and the source allows that, so the chart was accepted\
+            \ from whoever\nanswered \u2014 not merely because verification was allowed\
+            \ to be skipped."
+          type: boolean
+        versions:
+          description: Versions are the chart's published stable versions, ordered
+            latest-first.
+          items:
+            type: string
+          type: array
+      type: object
+    addons.configEntryPayload:
+      properties:
+        key:
+          example: BASE_DOMAIN
+          type: string
+        sensitive:
+          description: Sensitive marks the value as secret so a client displays it
+            carefully.
+          example: false
+          type: boolean
+        value:
+          description: 'Omit for a sensitive entry to keep the stored value; omitting
+            for a
+
+            non-sensitive one is an error. Null means the same but generated clients
+
+            cannot send it (the schema types this as a plain string).'
+          example: apps.example.com
+          type: string
+      type: object
+    addons.configEntryResponse:
+      properties:
+        key:
+          example: BASE_DOMAIN
+          type: string
+        sensitive:
+          description: Sensitive marks the value as secret so a client displays it
+            carefully.
+          example: false
+          type: boolean
+        value:
+          description: 'Returned in full, secrets included: these endpoints are admin-only
+            and the addon
+
+            reads its settings back through them. A plain string, not a pointer, because
+
+            Swagger 2.0 has no nullable string and a null fails validating clients.'
+          example: apps.example.com
+          type: string
+      type: object
+    addons.configEntryUpdatePayload:
+      properties:
+        sensitive:
+          description: Sensitive marks the value as secret so a client displays it
+            carefully.
+          example: false
+          type: boolean
+        value:
+          description: 'Omit for a sensitive entry to keep the stored value; omitting
+            for a
+
+            non-sensitive one is an error. Same rules as configEntryPayload.Value,
+            so
+
+            the two write paths agree on what an omitted value means.'
+          example: apps.example.com
+          type: string
+      type: object
+    addons.configMutationResponse:
+      properties:
+        entries:
+          items:
+            $ref: '#/components/schemas/addons.configEntryResponse'
+          type: array
+      type: object
+    addons.configResponse:
+      properties:
+        entries:
+          items:
+            $ref: '#/components/schemas/addons.configEntryResponse'
+          type: array
+      type: object
+    addons.configUpdatePayload:
+      properties:
+        entries:
+          items:
+            $ref: '#/components/schemas/addons.configEntryPayload'
+          type: array
+      type: object
     addons.installPayload:
       properties:
+        chart:
+          description: 'Chart is the chart''s repository path within RegistryID (e.g.
+
+            "portainer/charts/portainer-run"). Required with RegistryID.'
+          example: portainer/charts/portainer-run
+          type: string
+        imageRegistryId:
+          description: 'ImageRegistryID is the Portainer registry whose credentials
+            the addon''s pods
+
+            use to pull their container image. Send 0 for an image that needs none.
+
+            Unlike RegistryID it may be changed on upgrade, since the image reference
+            is
+
+            an editable chart value; omitting it keeps the registry the addon is
+
+            currently installed with.'
+          example: 3
+          type: integer
+        registryId:
+          description: 'RegistryID is the Portainer registry to pull the chart from.
+            Omit to use the
+
+            catalog''s public chart reference. Only honoured on a first-time install:
+            an
+
+            installed addon keeps the source it was installed from.'
+          example: 3
+          type: integer
         values:
           additionalProperties: {}
           description: Helm value overrides merged over the server-side per-addon
@@ -19736,6 +21881,97 @@ components:
 
             +optional'
       type: object
+    github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesDeploymentListResponse:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object.
+
+            Servers should convert recognized schemas to the latest internal value,
+            and
+
+            may reject unrecognized values.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+            +optional'
+          type: string
+        items:
+          description: Items is the list of Deployments.
+          items:
+            $ref: '#/components/schemas/v1.Deployment'
+          type: array
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents.
+
+            Servers may infer this from the endpoint the client submits requests to.
+
+            Cannot be updated.
+
+            In CamelCase.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+            +optional'
+          type: string
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/v1.ListMeta'
+          description: 'Standard list metadata.
+
+            +optional'
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesDeploymentResponse:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object.
+
+            Servers should convert recognized schemas to the latest internal value,
+            and
+
+            may reject unrecognized values.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+            +optional'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents.
+
+            Servers may infer this from the endpoint the client submits requests to.
+
+            Cannot be updated.
+
+            In CamelCase.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+            +optional'
+          type: string
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/v1.ObjectMeta'
+          description: 'Standard object''s metadata.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+            +optional'
+        spec:
+          allOf:
+          - $ref: '#/components/schemas/v1.DeploymentSpec'
+          description: 'Specification of the desired behavior of the Deployment.
+
+            +optional'
+        status:
+          allOf:
+          - $ref: '#/components/schemas/v1.DeploymentStatus'
+          description: 'Most recently observed status of the Deployment.
+
+            +optional'
+      type: object
     github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesNodeResponse:
       properties:
         apiVersion:
@@ -19794,10 +22030,177 @@ components:
 
             +optional'
       type: object
+    github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesPodListResponse:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object.
+
+            Servers should convert recognized schemas to the latest internal value,
+            and
+
+            may reject unrecognized values.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+            +optional'
+          type: string
+        items:
+          description: 'List of pods.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md'
+          items:
+            $ref: '#/components/schemas/v1.Pod'
+          type: array
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents.
+
+            Servers may infer this from the endpoint the client submits requests to.
+
+            Cannot be updated.
+
+            In CamelCase.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+            +optional'
+          type: string
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/v1.ListMeta'
+          description: 'Standard list metadata.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+            +optional'
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesReplicaSetListResponse:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object.
+
+            Servers should convert recognized schemas to the latest internal value,
+            and
+
+            may reject unrecognized values.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+            +optional'
+          type: string
+        items:
+          description: 'List of ReplicaSets.
+
+            More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset'
+          items:
+            $ref: '#/components/schemas/v1.ReplicaSet'
+          type: array
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents.
+
+            Servers may infer this from the endpoint the client submits requests to.
+
+            Cannot be updated.
+
+            In CamelCase.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+            +optional'
+          type: string
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/v1.ListMeta'
+          description: 'Standard list metadata.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+            +optional'
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_kubernetes.KubernetesResourceQuotaListResponse:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object.
+
+            Servers should convert recognized schemas to the latest internal value,
+            and
+
+            may reject unrecognized values.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+            +optional'
+          type: string
+        items:
+          description: 'Items is a list of ResourceQuota objects.
+
+            More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+          items:
+            $ref: '#/components/schemas/v1.ResourceQuota'
+          type: array
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents.
+
+            Servers may infer this from the endpoint the client submits requests to.
+
+            Cannot be updated.
+
+            In CamelCase.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+            +optional'
+          type: string
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/v1.ListMeta'
+          description: 'Standard list metadata.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+            +optional'
+      type: object
     github_com_portainer_portainer-ee_api_http_handler_kubernetes.describeResourceResponse:
       properties:
         describe:
           type: string
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_kubernetes.drainNodePayload:
+      properties:
+        DeleteEmptyDirData:
+          description: DeleteEmptyDirData allows eviction of pods using emptyDir volumes,
+            whose data is lost once the pod is deleted.
+          example: true
+          type: boolean
+        DisableEviction:
+          description: DisableEviction forces the use of direct pod deletion instead
+            of the eviction API, ignoring any configured PodDisruptionBudgets.
+          example: false
+          type: boolean
+        Force:
+          description: Force allows deletion of standalone pods not managed by a controller.
+          example: false
+          type: boolean
+        GracePeriodSeconds:
+          description: GracePeriodSeconds overrides each pod's termination grace period.
+            -1 uses the pod's own grace period.
+          example: -1
+          type: integer
+        IgnoreDaemonSets:
+          description: IgnoreDaemonSets skips DaemonSet-managed pods, which would
+            otherwise block the drain.
+          example: true
+          type: boolean
+        TimeoutSeconds:
+          description: TimeoutSeconds is the overall time to wait for the drain to
+            complete. Defaults to 60 when omitted.
+          example: 60
+          type: integer
       type: object
     github_com_portainer_portainer-ee_api_http_handler_kubernetes.kubernetesVersionResponse:
       properties:
@@ -19842,6 +22245,55 @@ components:
             signal for whether Portainer can call the pod-restart endpoint, and\n\
             is preferred over a raw Kubernetes-version comparison."
           type: boolean
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_kubernetes.manifestDryRunPayload:
+      properties:
+        manifests:
+          description: The manifests to validate. Each entry may hold several YAML
+            documents separated by "---".
+          example:
+          - "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: app-config"
+          items:
+            type: string
+          type: array
+        namespace:
+          description: The namespace applied to namespaced resources that do not declare
+            one. A resource declaring a different namespace is rejected.
+          example: default
+          type: string
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_kubernetes.manifestDryRunResponse:
+      properties:
+        results:
+          items:
+            $ref: '#/components/schemas/github_com_portainer_portainer-ee_api_http_handler_kubernetes.manifestDryRunResult'
+          type: array
+      type: object
+    github_com_portainer_portainer-ee_api_http_handler_kubernetes.manifestDryRunResult:
+      properties:
+        documentIndex:
+          description: The zero-based position of the document among the non-empty
+            documents of all manifests. It identifies a document rejected before its
+            resource could be named, such as malformed YAML.
+          example: 0
+          type: integer
+        kind:
+          example: ConfigMap
+          type: string
+        message:
+          description: The reason the resource was rejected. Empty when the resource
+            passed.
+          type: string
+        name:
+          example: app-config
+          type: string
+        namespace:
+          example: default
+          type: string
+        status:
+          description: Either "pass" or "fail".
+          example: pass
+          type: string
       type: object
     github_com_portainer_portainer-ee_api_http_handler_kubernetes.namespacesToggleSystemPayload:
       properties:
@@ -20372,6 +22824,73 @@ components:
       x-enum-varnames:
       - Int
       - String
+    k8s_io_api_apps_v1.DeploymentCondition:
+      properties:
+        lastTransitionTime:
+          description: Last time the condition transitioned from one status to another.
+          type: string
+        lastUpdateTime:
+          description: The last time this condition was updated.
+          type: string
+        message:
+          description: A human readable message indicating details about the transition.
+          type: string
+        reason:
+          description: The reason for the condition's last transition.
+          type: string
+        status:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_core_v1.ConditionStatus'
+          description: Status of the condition, one of True, False, Unknown.
+        type:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_apps_v1.DeploymentConditionType'
+          description: Type of deployment condition.
+      type: object
+    k8s_io_api_apps_v1.DeploymentConditionType:
+      enum:
+      - Available
+      - Progressing
+      - ReplicaFailure
+      type: string
+      x-enum-varnames:
+      - DeploymentAvailable
+      - DeploymentProgressing
+      - DeploymentReplicaFailure
+    k8s_io_api_apps_v1.DeploymentStrategy:
+      properties:
+        rollingUpdate:
+          allOf:
+          - $ref: '#/components/schemas/v1.RollingUpdateDeployment'
+          description: 'Rolling update config params. Present only if DeploymentStrategyType
+            =
+
+            RollingUpdate.
+
+            ---
+
+            TODO: Update this to follow our convention for oneOf, whatever we decide
+            it
+
+            to be.
+
+            +optional'
+        type:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_apps_v1.DeploymentStrategyType'
+          description: 'Type of deployment. Can be "Recreate" or "RollingUpdate".
+            Default is RollingUpdate.
+
+            +optional'
+      type: object
+    k8s_io_api_apps_v1.DeploymentStrategyType:
+      enum:
+      - Recreate
+      - RollingUpdate
+      type: string
+      x-enum-varnames:
+      - RecreateDeploymentStrategyType
+      - RollingUpdateDeploymentStrategyType
     k8s_io_api_core_v1.ConditionStatus:
       enum:
       - 'True'
@@ -20698,6 +23217,73 @@ components:
         uid:
           type: string
       type: object
+    kubernetes.K8sConfigMapWriteRequest:
+      properties:
+        Annotations:
+          additionalProperties:
+            type: string
+          type: object
+        Data:
+          additionalProperties:
+            type: string
+          type: object
+        Labels:
+          additionalProperties:
+            type: string
+          type: object
+        Name:
+          type: string
+      type: object
+    kubernetes.K8sContainer:
+      properties:
+        args:
+          items:
+            type: string
+          type: array
+        command:
+          items:
+            type: string
+          type: array
+        env:
+          items:
+            $ref: '#/components/schemas/kubernetes.K8sEnvVar'
+          type: array
+        envFromSecrets:
+          description: 'EnvFromSecrets names secrets whose keys are all exposed as
+            environment
+
+            variables.'
+          items:
+            type: string
+          type: array
+        image:
+          type: string
+        imagePullPolicy:
+          type: string
+        name:
+          type: string
+        ports:
+          items:
+            $ref: '#/components/schemas/kubernetes.K8sContainerPort'
+          type: array
+        resources:
+          $ref: '#/components/schemas/kubernetes.K8sResourceRequirements'
+        volumeMounts:
+          items:
+            $ref: '#/components/schemas/kubernetes.K8sVolumeMount'
+          type: array
+        workingDir:
+          type: string
+      type: object
+    kubernetes.K8sContainerPort:
+      properties:
+        containerPort:
+          type: integer
+        name:
+          type: string
+        protocol:
+          type: string
+      type: object
     kubernetes.K8sCronJob:
       properties:
         Command:
@@ -20726,6 +23312,94 @@ components:
         items:
           type: string
         type: array
+      type: object
+    kubernetes.K8sDeploymentPatchRequest:
+      properties:
+        annotations:
+          additionalProperties:
+            type: string
+          type: object
+        podAnnotations:
+          additionalProperties:
+            type: string
+          type: object
+      type: object
+    kubernetes.K8sDeploymentRollbackRequest:
+      properties:
+        revision:
+          type: integer
+      type: object
+    kubernetes.K8sDeploymentScaleRequest:
+      properties:
+        replicas:
+          type: integer
+      type: object
+    kubernetes.K8sDeploymentWriteRequest:
+      properties:
+        annotations:
+          additionalProperties:
+            type: string
+          type: object
+        labels:
+          additionalProperties:
+            type: string
+          type: object
+        name:
+          type: string
+        pod:
+          $ref: '#/components/schemas/kubernetes.K8sPodTemplate'
+        replicas:
+          type: integer
+        selector:
+          additionalProperties:
+            type: string
+          description: 'Selector matches the pods this deployment owns. It is immutable
+            once the
+
+            deployment exists, so it is only read on create.'
+          type: object
+      type: object
+    kubernetes.K8sEndpoint:
+      properties:
+        addresses:
+          items:
+            $ref: '#/components/schemas/kubernetes.K8sEndpointAddress'
+          type: array
+        name:
+          type: string
+        namespace:
+          type: string
+        ports:
+          items:
+            $ref: '#/components/schemas/kubernetes.K8sEndpointPort'
+          type: array
+        uid:
+          type: string
+      type: object
+    kubernetes.K8sEndpointAddress:
+      properties:
+        ip:
+          type: string
+        nodeName:
+          type: string
+      type: object
+    kubernetes.K8sEndpointPort:
+      properties:
+        name:
+          type: string
+        port:
+          type: integer
+        protocol:
+          type: string
+      type: object
+    kubernetes.K8sEnvVar:
+      properties:
+        name:
+          type: string
+        secretRef:
+          $ref: '#/components/schemas/kubernetes.K8sSecretKeyRef'
+        value:
+          type: string
       type: object
     kubernetes.K8sEvent:
       properties:
@@ -20763,6 +23437,19 @@ components:
         namespace:
           type: string
         uid:
+          type: string
+      type: object
+    kubernetes.K8sIngressClass:
+      properties:
+        Annotations:
+          additionalProperties:
+            type: string
+          type: object
+        Controller:
+          type: string
+        IsDefault:
+          type: boolean
+        Name:
           type: string
       type: object
     kubernetes.K8sJob:
@@ -20882,6 +23569,92 @@ components:
         volumeName:
           type: string
       type: object
+    kubernetes.K8sPersistentVolumeClaimCreateRequest:
+      properties:
+        accessModes:
+          items:
+            $ref: '#/components/schemas/v1.PersistentVolumeAccessMode'
+          type: array
+        annotations:
+          additionalProperties:
+            type: string
+          type: object
+        labels:
+          additionalProperties:
+            type: string
+          type: object
+        name:
+          type: string
+        storage:
+          type: string
+        storageClass:
+          type: string
+        volumeMode:
+          $ref: '#/components/schemas/v1.PersistentVolumeMode'
+      type: object
+    kubernetes.K8sPodTemplate:
+      properties:
+        annotations:
+          additionalProperties:
+            type: string
+          type: object
+        containers:
+          items:
+            $ref: '#/components/schemas/kubernetes.K8sContainer'
+          type: array
+        labels:
+          additionalProperties:
+            type: string
+          type: object
+        volumes:
+          items:
+            $ref: '#/components/schemas/kubernetes.K8sPodVolume'
+          type: array
+      type: object
+    kubernetes.K8sPodVolume:
+      properties:
+        claimName:
+          type: string
+        name:
+          type: string
+      type: object
+    kubernetes.K8sResourceRequirements:
+      properties:
+        limits:
+          additionalProperties:
+            type: string
+          type: object
+        requests:
+          additionalProperties:
+            type: string
+          type: object
+      type: object
+    kubernetes.K8sSecretKeyRef:
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+      type: object
+    kubernetes.K8sSecretWriteRequest:
+      properties:
+        Annotations:
+          additionalProperties:
+            type: string
+          type: object
+        Data:
+          additionalProperties:
+            type: string
+          type: object
+        Labels:
+          additionalProperties:
+            type: string
+          type: object
+        Name:
+          type: string
+        SecretType:
+          type: string
+      type: object
     kubernetes.K8sServiceAccount:
       properties:
         annotations:
@@ -20961,6 +23734,17 @@ components:
           $ref: '#/components/schemas/kubernetes.K8sPersistentVolumeClaim'
         storageClass:
           $ref: '#/components/schemas/kubernetes.K8sStorageClass'
+      type: object
+    kubernetes.K8sVolumeMount:
+      properties:
+        mountPath:
+          type: string
+        name:
+          type: string
+        readOnly:
+          type: boolean
+        subPath:
+          type: string
       type: object
     kubernetes.Metadata:
       properties:
@@ -22406,6 +25190,13 @@ components:
             $ref: '#/components/schemas/observability.logEntry'
           type: array
       type: object
+    omni.cancelProvisioningPayload:
+      properties:
+        deleteCluster:
+          type: boolean
+        endpointId:
+          type: integer
+      type: object
     omni.clusterData:
       properties:
         metadata:
@@ -23262,6 +26053,14 @@ components:
           type: boolean
         Data:
           additionalProperties: {}
+          description: 'Data contains the policy-type-specific configuration. Namespace
+            fields on
+
+            RBAC/Registry/Network Security policies are lowercased automatically and
+
+            must be valid RFC 1123 DNS labels; values still invalid after lowercasing
+
+            are rejected with a 400.'
           type: object
         EnvironmentGroups:
           items:
@@ -27143,6 +29942,13 @@ components:
           allOf:
           - $ref: '#/components/schemas/portaineree.AdditionalFunctionality'
           description: Additional Functionality
+        AddonsCatalogURL:
+          description: 'AddonsCatalogURL is where the add-on catalog is fetched from.
+            Empty means
+
+            the built-in default, so an operator can pin or mirror the catalog.'
+          example: https://raw.githubusercontent.com/portainer/templates/v3/addons/addons-catalog.json
+          type: string
         AgentSecret:
           description: Container environment parameter AGENT_SECRET
           type: string
@@ -28412,6 +31218,11 @@ components:
       type: object
     settings.settingsUpdatePayload:
       properties:
+        AddonsCatalogURL:
+          description: URL to the add-on catalog. Empty string restores the built-in
+            default.
+          example: https://raw.githubusercontent.com/portainer/templates/v3/addons/addons-catalog.json
+          type: string
         AuthenticationMethod:
           description: 'Active authentication method for the Portainer instance. Valid
             values are: 1 for internal, 2 for LDAP, or 3 for oauth'
@@ -30179,6 +32990,74 @@ components:
       - UseCache
       - Username
       type: object
+    v1.AWSElasticBlockStoreVolumeSource:
+      properties:
+        fsType:
+          description: 'fsType is the filesystem type of the volume that you want
+            to mount.
+
+            Tip: Ensure that the filesystem type is supported by the host operating
+            system.
+
+            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+            TODO: how do we prevent errors in the filesystem from compromising the
+            machine
+
+            +optional'
+          type: string
+        partition:
+          description: 'partition is the partition in the volume that you want to
+            mount.
+
+            If omitted, the default is to mount by volume name.
+
+            Examples: For volume /dev/sda1, you specify the partition as "1".
+
+            Similarly, the volume partition for /dev/sda is "0" (or you can leave
+            the property empty).
+
+            +optional'
+          type: integer
+        readOnly:
+          description: 'readOnly value true will force the readOnly setting in VolumeMounts.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+            +optional'
+          type: boolean
+        volumeID:
+          description: 'volumeID is unique ID of the persistent disk resource in AWS
+            (Amazon EBS volume).
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+          type: string
+      type: object
+    v1.Affinity:
+      properties:
+        nodeAffinity:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeAffinity'
+          description: 'Describes node affinity scheduling rules for the pod.
+
+            +optional'
+        podAffinity:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodAffinity'
+          description: 'Describes pod affinity scheduling rules (e.g. co-locate this
+            pod in the same node, zone, etc. as some other pod(s)).
+
+            +optional'
+        podAntiAffinity:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodAntiAffinity'
+          description: 'Describes pod anti-affinity scheduling rules (e.g. avoid putting
+            this pod in the same node, zone, etc. as some other pod(s)).
+
+            +optional'
+      type: object
     v1.AppArmorProfile:
       properties:
         localhostProfile:
@@ -30219,6 +33098,91 @@ components:
           type: string
         name:
           description: Name of the attached volume
+          type: string
+      type: object
+    v1.AzureDataDiskCachingMode:
+      enum:
+      - None
+      - ReadOnly
+      - ReadWrite
+      type: string
+      x-enum-varnames:
+      - AzureDataDiskCachingNone
+      - AzureDataDiskCachingReadOnly
+      - AzureDataDiskCachingReadWrite
+    v1.AzureDataDiskKind:
+      enum:
+      - Shared
+      - Dedicated
+      - Managed
+      type: string
+      x-enum-varnames:
+      - AzureSharedBlobDisk
+      - AzureDedicatedBlobDisk
+      - AzureManagedDisk
+    v1.AzureDiskVolumeSource:
+      properties:
+        cachingMode:
+          allOf:
+          - $ref: '#/components/schemas/v1.AzureDataDiskCachingMode'
+          description: 'cachingMode is the Host Caching mode: None, Read Only, Read
+            Write.
+
+            +optional
+
+            +default=ref(AzureDataDiskCachingReadWrite)'
+        diskName:
+          description: diskName is the Name of the data disk in the blob storage
+          type: string
+        diskURI:
+          description: diskURI is the URI of data disk in the blob storage
+          type: string
+        fsType:
+          description: 'fsType is Filesystem type to mount.
+
+            Must be a filesystem type supported by the host operating system.
+
+            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+            +optional
+
+            +default="ext4"'
+          type: string
+        kind:
+          allOf:
+          - $ref: '#/components/schemas/v1.AzureDataDiskKind'
+          description: 'kind expected values are Shared: multiple blob disks per storage
+            account  Dedicated: single blob disk per storage account  Managed: azure
+            managed data disk (only in managed availability set). defaults to shared
+
+            +default=ref(AzureSharedBlobDisk)'
+        readOnly:
+          description: 'readOnly Defaults to false (read/write). ReadOnly here will
+            force
+
+            the ReadOnly setting in VolumeMounts.
+
+            +optional
+
+            +default=false'
+          type: boolean
+      type: object
+    v1.AzureFileVolumeSource:
+      properties:
+        readOnly:
+          description: 'readOnly defaults to false (read/write). ReadOnly here will
+            force
+
+            the ReadOnly setting in VolumeMounts.
+
+            +optional'
+          type: boolean
+        secretName:
+          description: secretName is the  name of secret that contains Azure Storage
+            Account Name and Key
+          type: string
+        shareName:
+          description: shareName is the azure share Name
           type: string
       type: object
     v1.CSIPersistentVolumeSource:
@@ -30333,6 +33297,56 @@ components:
             \ calls.\nRequired."
           type: string
       type: object
+    v1.CSIVolumeSource:
+      properties:
+        driver:
+          description: 'driver is the name of the CSI driver that handles this volume.
+
+            Consult with your admin for the correct name as registered in the cluster.'
+          type: string
+        fsType:
+          description: 'fsType to mount. Ex. "ext4", "xfs", "ntfs".
+
+            If not provided, the empty value is passed to the associated CSI driver
+
+            which will determine the default filesystem to apply.
+
+            +optional'
+          type: string
+        nodePublishSecretRef:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_core_v1.LocalObjectReference'
+          description: 'nodePublishSecretRef is a reference to the secret object containing
+
+            sensitive information to pass to the CSI driver to complete the CSI
+
+            NodePublishVolume and NodeUnpublishVolume calls.
+
+            This field is optional, and  may be empty if no secret is required. If
+            the
+
+            secret object contains more than one secret, all secret references are
+            passed.
+
+            +optional'
+        readOnly:
+          description: 'readOnly specifies a read-only configuration for the volume.
+
+            Defaults to false (read/write).
+
+            +optional'
+          type: boolean
+        volumeAttributes:
+          additionalProperties:
+            type: string
+          description: 'volumeAttributes stores driver-specific properties that are
+            passed to the CSI
+
+            driver. Consult your driver''s documentation for supported values.
+
+            +optional'
+          type: object
+      type: object
     v1.Capabilities:
       properties:
         add:
@@ -30353,6 +33367,145 @@ components:
           items:
             type: string
           type: array
+      type: object
+    v1.CephFSVolumeSource:
+      properties:
+        monitors:
+          description: 'monitors is Required: Monitors is a collection of Ceph monitors
+
+            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+        path:
+          description: 'path is Optional: Used as the mounted root, rather than the
+            full Ceph tree, default is /
+
+            +optional'
+          type: string
+        readOnly:
+          description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly
+            here will force
+
+            the ReadOnly setting in VolumeMounts.
+
+            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+            +optional'
+          type: boolean
+        secretFile:
+          description: 'secretFile is Optional: SecretFile is the path to key ring
+            for User, default is /etc/ceph/user.secret
+
+            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+            +optional'
+          type: string
+        secretRef:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_core_v1.LocalObjectReference'
+          description: 'secretRef is Optional: SecretRef is reference to the authentication
+            secret for User, default is empty.
+
+            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+            +optional'
+        user:
+          description: 'user is optional: User is the rados user name, default is
+            admin
+
+            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+            +optional'
+          type: string
+      type: object
+    v1.CinderVolumeSource:
+      properties:
+        fsType:
+          description: 'fsType is the filesystem type to mount.
+
+            Must be a filesystem type supported by the host operating system.
+
+            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+            +optional'
+          type: string
+        readOnly:
+          description: 'readOnly defaults to false (read/write). ReadOnly here will
+            force
+
+            the ReadOnly setting in VolumeMounts.
+
+            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+            +optional'
+          type: boolean
+        secretRef:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_core_v1.LocalObjectReference'
+          description: 'secretRef is optional: points to a secret object containing
+            parameters used to connect
+
+            to OpenStack.
+
+            +optional'
+        volumeID:
+          description: 'volumeID used to identify the volume in cinder.
+
+            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+          type: string
+      type: object
+    v1.ClusterTrustBundleProjection:
+      properties:
+        labelSelector:
+          allOf:
+          - $ref: '#/components/schemas/v1.LabelSelector'
+          description: 'Select all ClusterTrustBundles that match this label selector.  Only
+            has
+
+            effect if signerName is set.  Mutually-exclusive with name.  If unset,
+
+            interpreted as "match nothing".  If set but empty, interpreted as "match
+
+            everything".
+
+            +optional'
+        name:
+          description: 'Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+
+            with signerName and labelSelector.
+
+            +optional'
+          type: string
+        optional:
+          description: 'If true, don''t block pod startup if the referenced ClusterTrustBundle(s)
+
+            aren''t available.  If using name, then the named ClusterTrustBundle is
+
+            allowed not to exist.  If using signerName, then the combination of
+
+            signerName and labelSelector is allowed to match zero
+
+            ClusterTrustBundles.
+
+            +optional'
+          type: boolean
+        path:
+          description: Relative path from the volume root to write the bundle.
+          type: string
+        signerName:
+          description: 'Select all ClusterTrustBundles that match this signer name.
+
+            Mutually-exclusive with name.  The contents of all selected
+
+            ClusterTrustBundles will be unified and deduplicated.
+
+            +optional'
+          type: string
       type: object
     v1.ConfigMapEnvSource:
       properties:
@@ -30448,6 +33601,130 @@ components:
 
             +optional'
           type: string
+      type: object
+    v1.ConfigMapProjection:
+      properties:
+        items:
+          description: 'items if unspecified, each key-value pair in the Data field
+            of the referenced
+
+            ConfigMap will be projected into the volume as a file whose name is the
+
+            key and content is the value. If specified, the listed keys will be
+
+            projected into the specified paths, and unlisted keys will not be
+
+            present. If a key is specified which is not present in the ConfigMap,
+
+            the volume setup will error unless it is marked optional. Paths must be
+
+            relative and may not contain the ''..'' path or start with ''..''.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.KeyToPath'
+          type: array
+        name:
+          description: 'Name of the referent.
+
+            This field is effectively required, but due to backwards compatibility
+            is
+
+            allowed to be empty. Instances of this type with an empty value here are
+
+            almost certainly wrong.
+
+            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+            +optional
+
+            +default=""
+
+            +kubebuilder:default=""
+
+            TODO: Drop `kubebuilder:default` when controller-gen doesn''t need it
+            https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
+          type: string
+        optional:
+          description: 'optional specify whether the ConfigMap or its keys must be
+            defined
+
+            +optional'
+          type: boolean
+      type: object
+    v1.ConfigMapVolumeSource:
+      properties:
+        defaultMode:
+          description: 'defaultMode is optional: mode bits used to set permissions
+            on created files by default.
+
+            Must be an octal value between 0000 and 0777 or a decimal value between
+            0 and 511.
+
+            YAML accepts both octal and decimal values, JSON requires decimal values
+            for mode bits.
+
+            Defaults to 0644.
+
+            Directories within the path are not affected by this setting.
+
+            This might be in conflict with other options that affect the file
+
+            mode, like fsGroup, and the result can be other mode bits set.
+
+            +optional'
+          type: integer
+        items:
+          description: 'items if unspecified, each key-value pair in the Data field
+            of the referenced
+
+            ConfigMap will be projected into the volume as a file whose name is the
+
+            key and content is the value. If specified, the listed keys will be
+
+            projected into the specified paths, and unlisted keys will not be
+
+            present. If a key is specified which is not present in the ConfigMap,
+
+            the volume setup will error unless it is marked optional. Paths must be
+
+            relative and may not contain the ''..'' path or start with ''..''.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.KeyToPath'
+          type: array
+        name:
+          description: 'Name of the referent.
+
+            This field is effectively required, but due to backwards compatibility
+            is
+
+            allowed to be empty. Instances of this type with an empty value here are
+
+            almost certainly wrong.
+
+            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+            +optional
+
+            +default=""
+
+            +kubebuilder:default=""
+
+            TODO: Drop `kubebuilder:default` when controller-gen doesn''t need it
+            https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
+          type: string
+        optional:
+          description: 'optional specify whether the ConfigMap or its keys must be
+            defined
+
+            +optional'
+          type: boolean
       type: object
     v1.Container:
       properties:
@@ -30890,6 +34167,20 @@ components:
             +optional'
           type: string
       type: object
+    v1.ContainerExtendedResourceRequest:
+      properties:
+        containerName:
+          description: The name of the container requesting resources.
+          type: string
+        requestName:
+          description: The name of the request in the special ResourceClaim which
+            corresponds to the extended resource.
+          type: string
+        resourceName:
+          description: The name of the extended resource in that container which gets
+            backed by DRA.
+          type: string
+      type: object
     v1.ContainerImage:
       properties:
         names:
@@ -31039,10 +34330,497 @@ components:
       x-enum-varnames:
       - ContainerRestartRuleOnExitCodesOpIn
       - ContainerRestartRuleOnExitCodesOpNotIn
+    v1.ContainerState:
+      properties:
+        running:
+          allOf:
+          - $ref: '#/components/schemas/v1.ContainerStateRunning'
+          description: 'Details about a running container
+
+            +optional'
+        terminated:
+          allOf:
+          - $ref: '#/components/schemas/v1.ContainerStateTerminated'
+          description: 'Details about a terminated container
+
+            +optional'
+        waiting:
+          allOf:
+          - $ref: '#/components/schemas/v1.ContainerStateWaiting'
+          description: 'Details about a waiting container
+
+            +optional'
+      type: object
+    v1.ContainerStateRunning:
+      properties:
+        startedAt:
+          description: 'Time at which the container was last (re-)started
+
+            +optional'
+          type: string
+      type: object
+    v1.ContainerStateTerminated:
+      properties:
+        containerID:
+          description: 'Container''s ID in the format ''<type>://<container_id>''
+
+            +optional'
+          type: string
+        exitCode:
+          description: Exit status from the last termination of the container
+          type: integer
+        finishedAt:
+          description: 'Time at which the container last terminated
+
+            +optional'
+          type: string
+        message:
+          description: 'Message regarding the last termination of the container
+
+            +optional'
+          type: string
+        reason:
+          description: '(brief) reason from the last termination of the container
+
+            +optional'
+          type: string
+        signal:
+          description: 'Signal from the last termination of the container
+
+            +optional'
+          type: integer
+        startedAt:
+          description: 'Time at which previous execution of the container started
+
+            +optional'
+          type: string
+      type: object
+    v1.ContainerStateWaiting:
+      properties:
+        message:
+          description: 'Message regarding why the container is not yet running.
+
+            +optional'
+          type: string
+        reason:
+          description: '(brief) reason the container is not yet running.
+
+            +optional'
+          type: string
+      type: object
+    v1.ContainerStatus:
+      properties:
+        allocatedResources:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceList'
+          description: 'AllocatedResources represents the compute resources allocated
+            for this container by the
+
+            node. Kubelet sets this value to Container.Resources.Requests upon successful
+            pod admission
+
+            and after successfully admitting desired pod resize.
+
+            +featureGate=InPlacePodVerticalScalingAllocatedStatus
+
+            +optional'
+        allocatedResourcesStatus:
+          description: 'AllocatedResourcesStatus represents the status of various
+            resources
+
+            allocated for this Pod.
+
+            +featureGate=ResourceHealthStatus
+
+            +optional
+
+            +patchMergeKey=name
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=name'
+          items:
+            $ref: '#/components/schemas/v1.ResourceStatus'
+          type: array
+        containerID:
+          description: 'ContainerID is the ID of the container in the format ''<type>://<container_id>''.
+
+            Where type is a container runtime identifier, returned from Version call
+            of CRI API
+
+            (for example "containerd").
+
+            +optional'
+          type: string
+        image:
+          description: 'Image is the name of container image that the container is
+            running.
+
+            The container image may not match the image used in the PodSpec,
+
+            as it may have been resolved by the runtime.
+
+            More info: https://kubernetes.io/docs/concepts/containers/images.'
+          type: string
+        imageID:
+          description: 'ImageID is the image ID of the container''s image. The image
+            ID may not
+
+            match the image ID of the image used in the PodSpec, as it may have been
+
+            resolved by the runtime.'
+          type: string
+        lastState:
+          allOf:
+          - $ref: '#/components/schemas/v1.ContainerState'
+          description: 'LastTerminationState holds the last termination state of the
+            container to
+
+            help debug container crashes and restarts. This field is not
+
+            populated if the container is still running and RestartCount is 0.
+
+            +optional'
+        name:
+          description: 'Name is a DNS_LABEL representing the unique name of the container.
+
+            Each container in a pod must have a unique name across all container types.
+
+            Cannot be updated.'
+          type: string
+        ready:
+          description: 'Ready specifies whether the container is currently passing
+            its readiness check.
+
+            The value will change as readiness probes keep executing. If no readiness
+
+            probes are specified, this field defaults to true once the container is
+
+            fully started (see Started field).
+
+
+            The value is typically used to determine whether a container is ready
+            to
+
+            accept traffic.'
+          type: boolean
+        resources:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceRequirements'
+          description: 'Resources represents the compute resource requests and limits
+            that have been successfully
+
+            enacted on the running container after it has been started or has been
+            successfully resized.
+
+            +featureGate=InPlacePodVerticalScaling
+
+            +optional'
+        restartCount:
+          description: 'RestartCount holds the number of times the container has been
+            restarted.
+
+            Kubelet makes an effort to always increment the value, but there
+
+            are cases when the state may be lost due to node restarts and then the
+            value
+
+            may be reset to 0. The value is never negative.'
+          type: integer
+        started:
+          description: 'Started indicates whether the container has finished its postStart
+            lifecycle hook
+
+            and passed its startup probe.
+
+            Initialized as false, becomes true after startupProbe is considered
+
+            successful. Resets to false when the container is restarted, or if kubelet
+
+            loses state temporarily. In both cases, startup probes will run again.
+
+            Is always true when no startupProbe is defined and container is running
+            and
+
+            has passed the postStart lifecycle hook. The null value must be treated
+            the
+
+            same as false.
+
+            +optional'
+          type: boolean
+        state:
+          allOf:
+          - $ref: '#/components/schemas/v1.ContainerState'
+          description: 'State holds details about the container''s current condition.
+
+            +optional'
+        stopSignal:
+          allOf:
+          - $ref: '#/components/schemas/v1.Signal'
+          description: 'StopSignal reports the effective stop signal for this container
+
+            +featureGate=ContainerStopSignals
+
+            +optional'
+        user:
+          allOf:
+          - $ref: '#/components/schemas/v1.ContainerUser'
+          description: 'User represents user identity information initially attached
+            to the first process of the container
+
+            +featureGate=SupplementalGroupsPolicy
+
+            +optional'
+        volumeMounts:
+          description: 'Status of volume mounts.
+
+            +optional
+
+            +patchMergeKey=mountPath
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=mountPath'
+          items:
+            $ref: '#/components/schemas/v1.VolumeMountStatus'
+          type: array
+      type: object
+    v1.ContainerUser:
+      properties:
+        linux:
+          allOf:
+          - $ref: '#/components/schemas/v1.LinuxContainerUser'
+          description: 'Linux holds user identity information initially attached to
+            the first process of the containers in Linux.
+
+            Note that the actual running identity can be changed if the process has
+            enough privilege to do so.
+
+            +optional'
+      type: object
+    v1.DNSPolicy:
+      enum:
+      - ClusterFirstWithHostNet
+      - ClusterFirst
+      - Default
+      - None
+      type: string
+      x-enum-varnames:
+      - DNSClusterFirstWithHostNet
+      - DNSClusterFirst
+      - DNSDefault
+      - DNSNone
     v1.DaemonEndpoint:
       properties:
         Port:
           description: Port number of the given endpoint.
+          type: integer
+      type: object
+    v1.Deployment:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object.
+
+            Servers should convert recognized schemas to the latest internal value,
+            and
+
+            may reject unrecognized values.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+            +optional'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents.
+
+            Servers may infer this from the endpoint the client submits requests to.
+
+            Cannot be updated.
+
+            In CamelCase.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+            +optional'
+          type: string
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/v1.ObjectMeta'
+          description: 'Standard object''s metadata.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+            +optional'
+        spec:
+          allOf:
+          - $ref: '#/components/schemas/v1.DeploymentSpec'
+          description: 'Specification of the desired behavior of the Deployment.
+
+            +optional'
+        status:
+          allOf:
+          - $ref: '#/components/schemas/v1.DeploymentStatus'
+          description: 'Most recently observed status of the Deployment.
+
+            +optional'
+      type: object
+    v1.DeploymentSpec:
+      properties:
+        minReadySeconds:
+          description: 'Minimum number of seconds for which a newly created pod should
+            be ready
+
+            without any of its container crashing, for it to be considered available.
+
+            Defaults to 0 (pod will be considered available as soon as it is ready)
+
+            +optional'
+          type: integer
+        paused:
+          description: 'Indicates that the deployment is paused.
+
+            +optional'
+          type: boolean
+        progressDeadlineSeconds:
+          description: 'The maximum time in seconds for a deployment to make progress
+            before it
+
+            is considered to be failed. The deployment controller will continue to
+
+            process failed deployments and a condition with a ProgressDeadlineExceeded
+
+            reason will be surfaced in the deployment status. Note that progress will
+
+            not be estimated during the time a deployment is paused. Defaults to 600s.'
+          type: integer
+        replicas:
+          description: 'Number of desired pods. This is a pointer to distinguish between
+            explicit
+
+            zero and not specified. Defaults to 1.
+
+            +optional'
+          type: integer
+        revisionHistoryLimit:
+          description: 'The number of old ReplicaSets to retain to allow rollback.
+
+            This is a pointer to distinguish between explicit zero and not specified.
+
+            Defaults to 10.
+
+            +optional'
+          type: integer
+        selector:
+          allOf:
+          - $ref: '#/components/schemas/v1.LabelSelector'
+          description: 'Label selector for pods. Existing ReplicaSets whose pods are
+
+            selected by this will be the ones affected by this deployment.
+
+            It must match the pod template''s labels.'
+        strategy:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_apps_v1.DeploymentStrategy'
+          description: 'The deployment strategy to use to replace existing pods with
+            new ones.
+
+            +optional
+
+            +patchStrategy=retainKeys'
+        template:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodTemplateSpec'
+          description: 'Template describes the pods that will be created.
+
+            The only allowed template.spec.restartPolicy value is "Always".'
+      type: object
+    v1.DeploymentStatus:
+      properties:
+        availableReplicas:
+          description: 'Total number of available non-terminating pods (ready for
+            at least minReadySeconds) targeted by this deployment.
+
+            +optional'
+          type: integer
+        collisionCount:
+          description: 'Count of hash collisions for the Deployment. The Deployment
+            controller uses this
+
+            field as a collision avoidance mechanism when it needs to create the name
+            for the
+
+            newest ReplicaSet.
+
+            +optional'
+          type: integer
+        conditions:
+          description: 'Represents the latest available observations of a deployment''s
+            current state.
+
+            +patchMergeKey=type
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=type'
+          items:
+            $ref: '#/components/schemas/k8s_io_api_apps_v1.DeploymentCondition'
+          type: array
+        observedGeneration:
+          description: 'The generation observed by the deployment controller.
+
+            +optional'
+          type: integer
+        readyReplicas:
+          description: 'Total number of non-terminating pods targeted by this Deployment
+            with a Ready Condition.
+
+            +optional'
+          type: integer
+        replicas:
+          description: 'Total number of non-terminating pods targeted by this deployment
+            (their labels match the selector).
+
+            +optional'
+          type: integer
+        terminatingReplicas:
+          description: 'Total number of terminating pods targeted by this deployment.
+            Terminating pods have a non-null
+
+            .metadata.deletionTimestamp and have not yet reached the Failed or Succeeded
+            .status.phase.
+
+
+            This is a beta field and requires enabling DeploymentReplicaSetTerminatingReplicas
+            feature (enabled by default).
+
+            +optional'
+          type: integer
+        unavailableReplicas:
+          description: 'Total number of unavailable pods targeted by this deployment.
+            This is the total number of
+
+            pods that are still required for the deployment to have 100% available
+            capacity. They may
+
+            either be pods that are running but not yet available or pods that still
+            have not been created.
+
+            +optional'
+          type: integer
+        updatedReplicas:
+          description: 'Total number of non-terminating pods targeted by this deployment
+            that have the desired template spec.
+
+            +optional'
           type: integer
       type: object
     v1.Descriptor:
@@ -31090,6 +34868,129 @@ components:
           items:
             type: string
           type: array
+      type: object
+    v1.DownwardAPIProjection:
+      properties:
+        items:
+          description: 'Items is a list of DownwardAPIVolume file
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.DownwardAPIVolumeFile'
+          type: array
+      type: object
+    v1.DownwardAPIVolumeFile:
+      properties:
+        fieldRef:
+          allOf:
+          - $ref: '#/components/schemas/v1.ObjectFieldSelector'
+          description: 'Required: Selects a field of the pod: only annotations, labels,
+            name, namespace and uid are supported.
+
+            +optional'
+        mode:
+          description: 'Optional: mode bits used to set permissions on this file,
+            must be an octal value
+
+            between 0000 and 0777 or a decimal value between 0 and 511.
+
+            YAML accepts both octal and decimal values, JSON requires decimal values
+            for mode bits.
+
+            If not specified, the volume defaultMode will be used.
+
+            This might be in conflict with other options that affect the file
+
+            mode, like fsGroup, and the result can be other mode bits set.
+
+            +optional'
+          type: integer
+        path:
+          description: 'Required: Path is  the relative path name of the file to be
+            created. Must not be absolute or contain the ''..'' path. Must be utf-8
+            encoded. The first item of the relative path must not start with ''..'''
+          type: string
+        resourceFieldRef:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceFieldSelector'
+          description: 'Selects a resource of the container: only resources limits
+            and requests
+
+            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently
+            supported.
+
+            +optional'
+      type: object
+    v1.DownwardAPIVolumeSource:
+      properties:
+        defaultMode:
+          description: 'Optional: mode bits to use on created files by default. Must
+            be a
+
+            Optional: mode bits used to set permissions on created files by default.
+
+            Must be an octal value between 0000 and 0777 or a decimal value between
+            0 and 511.
+
+            YAML accepts both octal and decimal values, JSON requires decimal values
+            for mode bits.
+
+            Defaults to 0644.
+
+            Directories within the path are not affected by this setting.
+
+            This might be in conflict with other options that affect the file
+
+            mode, like fsGroup, and the result can be other mode bits set.
+
+            +optional'
+          type: integer
+        items:
+          description: 'Items is a list of downward API volume file
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.DownwardAPIVolumeFile'
+          type: array
+      type: object
+    v1.EmptyDirVolumeSource:
+      properties:
+        medium:
+          allOf:
+          - $ref: '#/components/schemas/v1.StorageMedium'
+          description: 'medium represents what type of storage medium should back
+            this directory.
+
+            The default is "" which means to use the node''s default medium.
+
+            Must be an empty string (default) or Memory.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+
+            +optional'
+        sizeLimit:
+          allOf:
+          - $ref: '#/components/schemas/resource.Quantity'
+          description: 'sizeLimit is the total amount of local storage required for
+            this EmptyDir volume.
+
+            The size limit is also applicable for memory medium.
+
+            The maximum usage on memory medium EmptyDir would be the minimum value
+            between
+
+            the SizeLimit specified here and the sum of memory limits of all containers
+            in a pod.
+
+            The default is nil which means that the limit is undefined.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+
+            +optional'
       type: object
     v1.EnvFromSource:
       properties:
@@ -31194,6 +35095,412 @@ components:
 
             +optional'
       type: object
+    v1.EphemeralContainer:
+      properties:
+        args:
+          description: 'Arguments to the entrypoint.
+
+            The image''s CMD is used if this is not provided.
+
+            Variable references $(VAR_NAME) are expanded using the container''s environment.
+            If a variable
+
+            cannot be resolved, the reference in the input string will be unchanged.
+            Double $$ are reduced
+
+            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+            "$$(VAR_NAME)" will
+
+            produce the string literal "$(VAR_NAME)". Escaped references will never
+            be expanded, regardless
+
+            of whether the variable exists or not. Cannot be updated.
+
+            More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+        command:
+          description: 'Entrypoint array. Not executed within a shell.
+
+            The image''s ENTRYPOINT is used if this is not provided.
+
+            Variable references $(VAR_NAME) are expanded using the container''s environment.
+            If a variable
+
+            cannot be resolved, the reference in the input string will be unchanged.
+            Double $$ are reduced
+
+            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+            "$$(VAR_NAME)" will
+
+            produce the string literal "$(VAR_NAME)". Escaped references will never
+            be expanded, regardless
+
+            of whether the variable exists or not. Cannot be updated.
+
+            More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+        env:
+          description: 'List of environment variables to set in the container.
+
+            Cannot be updated.
+
+            +optional
+
+            +patchMergeKey=name
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=name'
+          items:
+            $ref: '#/components/schemas/v1.EnvVar'
+          type: array
+        envFrom:
+          description: 'List of sources to populate environment variables in the container.
+
+            The keys defined within a source may consist of any printable ASCII characters
+            except ''=''.
+
+            When a key exists in multiple
+
+            sources, the value associated with the last source will take precedence.
+
+            Values defined by an Env with a duplicate key will take precedence.
+
+            Cannot be updated.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.EnvFromSource'
+          type: array
+        image:
+          description: 'Container image name.
+
+            More info: https://kubernetes.io/docs/concepts/containers/images'
+          type: string
+        imagePullPolicy:
+          allOf:
+          - $ref: '#/components/schemas/v1.PullPolicy'
+          description: 'Image pull policy.
+
+            One of Always, Never, IfNotPresent.
+
+            Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+
+            Cannot be updated.
+
+            More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+            +optional'
+        lifecycle:
+          allOf:
+          - $ref: '#/components/schemas/v1.Lifecycle'
+          description: 'Lifecycle is not allowed for ephemeral containers.
+
+            +optional'
+        livenessProbe:
+          allOf:
+          - $ref: '#/components/schemas/v1.Probe'
+          description: 'Probes are not allowed for ephemeral containers.
+
+            +optional'
+        name:
+          description: 'Name of the ephemeral container specified as a DNS_LABEL.
+
+            This name must be unique among all containers, init containers and ephemeral
+            containers.'
+          type: string
+        ports:
+          description: 'Ports are not allowed for ephemeral containers.
+
+            +optional
+
+            +patchMergeKey=containerPort
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=containerPort
+
+            +listMapKey=protocol'
+          items:
+            $ref: '#/components/schemas/v1.ContainerPort'
+          type: array
+        readinessProbe:
+          allOf:
+          - $ref: '#/components/schemas/v1.Probe'
+          description: 'Probes are not allowed for ephemeral containers.
+
+            +optional'
+        resizePolicy:
+          description: 'Resources resize policy for the container.
+
+            +featureGate=InPlacePodVerticalScaling
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.ContainerResizePolicy'
+          type: array
+        resources:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceRequirements'
+          description: 'Resources are not allowed for ephemeral containers. Ephemeral
+            containers use spare resources
+
+            already allocated to the pod.
+
+            +optional'
+        restartPolicy:
+          allOf:
+          - $ref: '#/components/schemas/v1.ContainerRestartPolicy'
+          description: 'Restart policy for the container to manage the restart behavior
+            of each
+
+            container within a pod.
+
+            You cannot set this field on ephemeral containers.
+
+            +optional'
+        restartPolicyRules:
+          description: 'Represents a list of rules to be checked to determine if the
+
+            container should be restarted on exit. You cannot set this field on
+
+            ephemeral containers.
+
+            +featureGate=ContainerRestartRules
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.ContainerRestartRule'
+          type: array
+        securityContext:
+          allOf:
+          - $ref: '#/components/schemas/v1.SecurityContext'
+          description: 'Optional: SecurityContext defines the security options the
+            ephemeral container should be run with.
+
+            If set, the fields of SecurityContext override the equivalent fields of
+            PodSecurityContext.
+
+            +optional'
+        startupProbe:
+          allOf:
+          - $ref: '#/components/schemas/v1.Probe'
+          description: 'Probes are not allowed for ephemeral containers.
+
+            +optional'
+        stdin:
+          description: 'Whether this container should allocate a buffer for stdin
+            in the container runtime. If this
+
+            is not set, reads from stdin in the container will always result in EOF.
+
+            Default is false.
+
+            +optional'
+          type: boolean
+        stdinOnce:
+          description: 'Whether the container runtime should close the stdin channel
+            after it has been opened by
+
+            a single attach. When stdin is true the stdin stream will remain open
+            across multiple attach
+
+            sessions. If stdinOnce is set to true, stdin is opened on container start,
+            is empty until the
+
+            first client attaches to stdin, and then remains open and accepts data
+            until the client disconnects,
+
+            at which time stdin is closed and remains closed until the container is
+            restarted. If this
+
+            flag is false, a container processes that reads from stdin will never
+            receive an EOF.
+
+            Default is false
+
+            +optional'
+          type: boolean
+        targetContainerName:
+          description: 'If set, the name of the container from PodSpec that this ephemeral
+            container targets.
+
+            The ephemeral container will be run in the namespaces (IPC, PID, etc)
+            of this container.
+
+            If not set then the ephemeral container uses the namespaces configured
+            in the Pod spec.
+
+
+            The container runtime must implement support for this feature. If the
+            runtime does not
+
+            support namespace targeting then the result of setting this field is undefined.
+
+            +optional'
+          type: string
+        terminationMessagePath:
+          description: 'Optional: Path at which the file to which the container''s
+            termination message
+
+            will be written is mounted into the container''s filesystem.
+
+            Message written is intended to be brief final status, such as an assertion
+            failure message.
+
+            Will be truncated by the node if greater than 4096 bytes. The total message
+            length across
+
+            all containers will be limited to 12kb.
+
+            Defaults to /dev/termination-log.
+
+            Cannot be updated.
+
+            +optional'
+          type: string
+        terminationMessagePolicy:
+          allOf:
+          - $ref: '#/components/schemas/v1.TerminationMessagePolicy'
+          description: 'Indicate how the termination message should be populated.
+            File will use the contents of
+
+            terminationMessagePath to populate the container status message on both
+            success and failure.
+
+            FallbackToLogsOnError will use the last chunk of container log output
+            if the termination
+
+            message file is empty and the container exited with an error.
+
+            The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+
+            Defaults to File.
+
+            Cannot be updated.
+
+            +optional'
+        tty:
+          description: 'Whether this container should allocate a TTY for itself, also
+            requires ''stdin'' to be true.
+
+            Default is false.
+
+            +optional'
+          type: boolean
+        volumeDevices:
+          description: 'volumeDevices is the list of block devices to be used by the
+            container.
+
+            +patchMergeKey=devicePath
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=devicePath
+
+            +optional'
+          items:
+            $ref: '#/components/schemas/v1.VolumeDevice'
+          type: array
+        volumeMounts:
+          description: 'Pod volumes to mount into the container''s filesystem. Subpath
+            mounts are not allowed for ephemeral containers.
+
+            Cannot be updated.
+
+            +optional
+
+            +patchMergeKey=mountPath
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=mountPath'
+          items:
+            $ref: '#/components/schemas/v1.VolumeMount'
+          type: array
+        workingDir:
+          description: 'Container''s working directory.
+
+            If not specified, the container runtime''s default will be used, which
+
+            might be configured in the container image.
+
+            Cannot be updated.
+
+            +optional'
+          type: string
+      type: object
+    v1.EphemeralVolumeSource:
+      properties:
+        volumeClaimTemplate:
+          allOf:
+          - $ref: '#/components/schemas/v1.PersistentVolumeClaimTemplate'
+          description: 'Will be used to create a stand-alone PVC to provision the
+            volume.
+
+            The pod in which this EphemeralVolumeSource is embedded will be the
+
+            owner of the PVC, i.e. the PVC will be deleted together with the
+
+            pod.  The name of the PVC will be `<pod name>-<volume name>` where
+
+            `<volume name>` is the name from the `PodSpec.Volumes` array
+
+            entry. Pod validation will reject the pod if the concatenated name
+
+            is not valid for a PVC (for example, too long).
+
+
+            An existing PVC with that name that is not owned by the pod
+
+            will *not* be used for the pod to avoid using an unrelated
+
+            volume by mistake. Starting the pod is then blocked until
+
+            the unrelated PVC is removed. If such a pre-created PVC is
+
+            meant to be used by the pod, the PVC has to updated with an
+
+            owner reference to the pod once the pod exists. Normally
+
+            this should not be necessary, but it may be useful when
+
+            manually reconstructing a broken cluster.
+
+
+            This field is read-only and no changes will be made by Kubernetes
+
+            to the PVC after it has been created.
+
+
+            Required, must not be nil.'
+      type: object
     v1.ExecAction:
       properties:
         command:
@@ -31209,6 +35516,55 @@ components:
             a shell, you need to explicitly call out to that shell.
 
             Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+      type: object
+    v1.FCVolumeSource:
+      properties:
+        fsType:
+          description: 'fsType is the filesystem type to mount.
+
+            Must be a filesystem type supported by the host operating system.
+
+            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+            TODO: how do we prevent errors in the filesystem from compromising the
+            machine
+
+            +optional'
+          type: string
+        lun:
+          description: 'lun is Optional: FC target lun number
+
+            +optional'
+          type: integer
+        readOnly:
+          description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly
+            here will force
+
+            the ReadOnly setting in VolumeMounts.
+
+            +optional'
+          type: boolean
+        targetWWNs:
+          description: 'targetWWNs is Optional: FC target worldwide names (WWNs)
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+        wwids:
+          description: 'wwids Optional: FC volume world wide identifiers (wwids)
+
+            Either wwids or combination of targetWWNs and lun must be set, but not
+            both simultaneously.
 
             +optional
 
@@ -31271,6 +35627,118 @@ components:
       type: string
       x-enum-varnames:
       - FinalizerKubernetes
+    v1.FlexVolumeSource:
+      properties:
+        driver:
+          description: driver is the name of the driver to use for this volume.
+          type: string
+        fsType:
+          description: 'fsType is the filesystem type to mount.
+
+            Must be a filesystem type supported by the host operating system.
+
+            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume
+            script.
+
+            +optional'
+          type: string
+        options:
+          additionalProperties:
+            type: string
+          description: 'options is Optional: this field holds extra command options
+            if any.
+
+            +optional'
+          type: object
+        readOnly:
+          description: 'readOnly is Optional: defaults to false (read/write). ReadOnly
+            here will force
+
+            the ReadOnly setting in VolumeMounts.
+
+            +optional'
+          type: boolean
+        secretRef:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_core_v1.LocalObjectReference'
+          description: 'secretRef is Optional: secretRef is reference to the secret
+            object containing
+
+            sensitive information to pass to the plugin scripts. This may be
+
+            empty if no secret object is specified. If the secret object
+
+            contains more than one secret, all secrets are passed to the plugin
+
+            scripts.
+
+            +optional'
+      type: object
+    v1.FlockerVolumeSource:
+      properties:
+        datasetName:
+          description: 'datasetName is Name of the dataset stored as metadata -> name
+            on the dataset for Flocker
+
+            should be considered as deprecated
+
+            +optional'
+          type: string
+        datasetUUID:
+          description: 'datasetUUID is the UUID of the dataset. This is unique identifier
+            of a Flocker dataset
+
+            +optional'
+          type: string
+      type: object
+    v1.GCEPersistentDiskVolumeSource:
+      properties:
+        fsType:
+          description: 'fsType is filesystem type of the volume that you want to mount.
+
+            Tip: Ensure that the filesystem type is supported by the host operating
+            system.
+
+            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+            TODO: how do we prevent errors in the filesystem from compromising the
+            machine
+
+            +optional'
+          type: string
+        partition:
+          description: 'partition is the partition in the volume that you want to
+            mount.
+
+            If omitted, the default is to mount by volume name.
+
+            Examples: For volume /dev/sda1, you specify the partition as "1".
+
+            Similarly, the volume partition for /dev/sda is "0" (or you can leave
+            the property empty).
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+            +optional'
+          type: integer
+        pdName:
+          description: 'pdName is unique name of the PD resource in GCE. Used to identify
+            the disk in GCE.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+          type: string
+        readOnly:
+          description: 'readOnly here will force the ReadOnly setting in VolumeMounts.
+
+            Defaults to false.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+            +optional'
+          type: boolean
+      type: object
     v1.GRPCAction:
       properties:
         port:
@@ -31289,6 +35757,51 @@ components:
 
             +default=""'
           type: string
+      type: object
+    v1.GitRepoVolumeSource:
+      properties:
+        directory:
+          description: 'directory is the target directory name.
+
+            Must not contain or start with ''..''.  If ''.'' is supplied, the volume
+            directory will be the
+
+            git repository.  Otherwise, if specified, the volume will contain the
+            git repository in
+
+            the subdirectory with the given name.
+
+            +optional'
+          type: string
+        repository:
+          description: repository is the URL
+          type: string
+        revision:
+          description: 'revision is the commit hash for the specified revision.
+
+            +optional'
+          type: string
+      type: object
+    v1.GlusterfsVolumeSource:
+      properties:
+        endpoints:
+          description: endpoints is the endpoint name that details Glusterfs topology.
+          type: string
+        path:
+          description: 'path is the Glusterfs volume path.
+
+            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+          type: string
+        readOnly:
+          description: 'readOnly here will force the Glusterfs volume to be mounted
+            with read-only permissions.
+
+            Defaults to false.
+
+            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+            +optional'
+          type: boolean
       type: object
     v1.HTTPGetAction:
       properties:
@@ -31331,6 +35844,296 @@ components:
             Defaults to HTTP.
 
             +optional'
+      type: object
+    v1.HostAlias:
+      properties:
+        hostnames:
+          description: 'Hostnames for the above IP address.
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+        ip:
+          description: 'IP address of the host file entry.
+
+            +required'
+          type: string
+      type: object
+    v1.HostIP:
+      properties:
+        ip:
+          description: 'IP is the IP address assigned to the host
+
+            +required'
+          type: string
+      type: object
+    v1.HostPathType:
+      enum:
+      - ''
+      - DirectoryOrCreate
+      - Directory
+      - FileOrCreate
+      - File
+      - Socket
+      - CharDevice
+      - BlockDevice
+      type: string
+      x-enum-varnames:
+      - HostPathUnset
+      - HostPathDirectoryOrCreate
+      - HostPathDirectory
+      - HostPathFileOrCreate
+      - HostPathFile
+      - HostPathSocket
+      - HostPathCharDev
+      - HostPathBlockDev
+    v1.HostPathVolumeSource:
+      properties:
+        path:
+          description: 'path of the directory on the host.
+
+            If the path is a symlink, it will follow the link to the real path.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+          type: string
+        type:
+          allOf:
+          - $ref: '#/components/schemas/v1.HostPathType'
+          description: 'type for HostPath Volume
+
+            Defaults to ""
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+            +optional'
+      type: object
+    v1.ISCSIVolumeSource:
+      properties:
+        chapAuthDiscovery:
+          description: 'chapAuthDiscovery defines whether support iSCSI Discovery
+            CHAP authentication
+
+            +optional'
+          type: boolean
+        chapAuthSession:
+          description: 'chapAuthSession defines whether support iSCSI Session CHAP
+            authentication
+
+            +optional'
+          type: boolean
+        fsType:
+          description: 'fsType is the filesystem type of the volume that you want
+            to mount.
+
+            Tip: Ensure that the filesystem type is supported by the host operating
+            system.
+
+            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+
+            TODO: how do we prevent errors in the filesystem from compromising the
+            machine
+
+            +optional'
+          type: string
+        initiatorName:
+          description: 'initiatorName is the custom iSCSI Initiator Name.
+
+            If initiatorName is specified with iscsiInterface simultaneously, new
+            iSCSI interface
+
+            <target portal>:<volume name> will be created for the connection.
+
+            +optional'
+          type: string
+        iqn:
+          description: iqn is the target iSCSI Qualified Name.
+          type: string
+        iscsiInterface:
+          description: 'iscsiInterface is the interface Name that uses an iSCSI transport.
+
+            Defaults to ''default'' (tcp).
+
+            +optional
+
+            +default="default"'
+          type: string
+        lun:
+          description: lun represents iSCSI Target Lun number.
+          type: integer
+        portals:
+          description: 'portals is the iSCSI Target Portal List. The portal is either
+            an IP or ip_addr:port if the port
+
+            is other than default (typically TCP ports 860 and 3260).
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+        readOnly:
+          description: 'readOnly here will force the ReadOnly setting in VolumeMounts.
+
+            Defaults to false.
+
+            +optional'
+          type: boolean
+        secretRef:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_core_v1.LocalObjectReference'
+          description: 'secretRef is the CHAP Secret for iSCSI target and initiator
+            authentication
+
+            +optional'
+        targetPortal:
+          description: 'targetPortal is iSCSI Target Portal. The Portal is either
+            an IP or ip_addr:port if the port
+
+            is other than default (typically TCP ports 860 and 3260).'
+          type: string
+      type: object
+    v1.ImageVolumeSource:
+      properties:
+        pullPolicy:
+          allOf:
+          - $ref: '#/components/schemas/v1.PullPolicy'
+          description: 'Policy for pulling OCI objects. Possible values are:
+
+            Always: the kubelet always attempts to pull the reference. Container creation
+            will fail If the pull fails.
+
+            Never: the kubelet never pulls the reference and only uses a local image
+            or artifact. Container creation will fail if the reference isn''t present.
+
+            IfNotPresent: the kubelet pulls if the reference isn''t already present
+            on disk. Container creation will fail if the reference isn''t present
+            and the pull fails.
+
+            Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+
+            +optional'
+        reference:
+          description: 'Required: Image or artifact reference to be used.
+
+            Behaves in the same way as pod.spec.containers[*].image.
+
+            Pull secrets will be assembled in the same way as for the container image
+            by looking up node credentials, SA image pull secrets, and pod spec image
+            pull secrets.
+
+            More info: https://kubernetes.io/docs/concepts/containers/images
+
+            This field is optional to allow higher level config management to default
+            or override
+
+            container images in workload controllers like Deployments and StatefulSets.
+
+            +optional'
+          type: string
+      type: object
+    v1.KeyToPath:
+      properties:
+        key:
+          description: key is the key to project.
+          type: string
+        mode:
+          description: 'mode is Optional: mode bits used to set permissions on this
+            file.
+
+            Must be an octal value between 0000 and 0777 or a decimal value between
+            0 and 511.
+
+            YAML accepts both octal and decimal values, JSON requires decimal values
+            for mode bits.
+
+            If not specified, the volume defaultMode will be used.
+
+            This might be in conflict with other options that affect the file
+
+            mode, like fsGroup, and the result can be other mode bits set.
+
+            +optional'
+          type: integer
+        path:
+          description: 'path is the relative path of the file to map the key to.
+
+            May not be an absolute path.
+
+            May not contain the path element ''..''.
+
+            May not start with the string ''..''.'
+          type: string
+      type: object
+    v1.LabelSelector:
+      properties:
+        matchExpressions:
+          description: 'matchExpressions is a list of label selector requirements.
+            The requirements are ANDed.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.LabelSelectorRequirement'
+          type: array
+        matchLabels:
+          additionalProperties:
+            type: string
+          description: 'matchLabels is a map of {key,value} pairs. A single {key,value}
+            in the matchLabels
+
+            map is equivalent to an element of matchExpressions, whose key field is
+            "key", the
+
+            operator is "In", and the values array contains only "value". The requirements
+            are ANDed.
+
+            +optional'
+          type: object
+      type: object
+    v1.LabelSelectorOperator:
+      enum:
+      - In
+      - NotIn
+      - Exists
+      - DoesNotExist
+      type: string
+      x-enum-varnames:
+      - LabelSelectorOpIn
+      - LabelSelectorOpNotIn
+      - LabelSelectorOpExists
+      - LabelSelectorOpDoesNotExist
+    v1.LabelSelectorRequirement:
+      properties:
+        key:
+          description: key is the label key that the selector applies to.
+          type: string
+        operator:
+          allOf:
+          - $ref: '#/components/schemas/v1.LabelSelectorOperator'
+          description: 'operator represents a key''s relationship to a set of values.
+
+            Valid operators are In, NotIn, Exists and DoesNotExist.'
+        values:
+          description: 'values is an array of string values. If the operator is In
+            or NotIn,
+
+            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+
+            the values array must be empty. This array is replaced during a strategic
+
+            merge patch.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
       type: object
     v1.Lifecycle:
       properties:
@@ -31415,6 +36218,27 @@ components:
             lifecycle hooks will fail at runtime when it is specified.
 
             +optional'
+      type: object
+    v1.LinuxContainerUser:
+      properties:
+        gid:
+          description: GID is the primary gid initially attached to the first process
+            in the container
+          type: integer
+        supplementalGroups:
+          description: 'SupplementalGroups are the supplemental groups initially attached
+            to the first process in the container
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: integer
+          type: array
+        uid:
+          description: UID is the primary uid initially attached to the first process
+            in the container
+          type: integer
       type: object
     v1.ListMeta:
       properties:
@@ -31576,6 +36400,29 @@ components:
       - MountPropagationNone
       - MountPropagationHostToContainer
       - MountPropagationBidirectional
+    v1.NFSVolumeSource:
+      properties:
+        path:
+          description: 'path that is exported by the NFS server.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+          type: string
+        readOnly:
+          description: 'readOnly here will force the NFS export to be mounted with
+            read-only permissions.
+
+            Defaults to false.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+            +optional'
+          type: boolean
+        server:
+          description: 'server is the hostname or IP address of the NFS server.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+          type: string
+      type: object
     v1.NamespaceCondition:
       properties:
         lastTransitionTime:
@@ -31691,6 +36538,50 @@ components:
       - NodeExternalIP
       - NodeInternalDNS
       - NodeExternalDNS
+    v1.NodeAffinity:
+      properties:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          description: 'The scheduler will prefer to schedule pods to nodes that satisfy
+
+            the affinity expressions specified by this field, but it may choose
+
+            a node that violates one or more of the expressions. The node that is
+
+            most preferred is the one with the greatest sum of weights, i.e.
+
+            for each node that meets all of the scheduling requirements (resource
+
+            request, requiredDuringScheduling affinity expressions, etc.),
+
+            compute a sum by iterating through the elements of this field and adding
+
+            "weight" to the sum if the node matches the corresponding matchExpressions;
+            the
+
+            node(s) with the highest sum are the most preferred.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.PreferredSchedulingTerm'
+          type: array
+        requiredDuringSchedulingIgnoredDuringExecution:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeSelector'
+          description: 'If the affinity requirements specified by this field are not
+            met at
+
+            scheduling time, the pod will not be scheduled onto the node.
+
+            If the affinity requirements specified by this field cease to be met
+
+            at some point during pod execution (e.g. due to an update), the system
+
+            may or may not try to eventually evict the pod from its node.
+
+            +optional'
+      type: object
     v1.NodeCondition:
       properties:
         lastHeartbeatTime:
@@ -31869,6 +36760,14 @@ components:
             +optional'
           type: boolean
       type: object
+    v1.NodeInclusionPolicy:
+      enum:
+      - Ignore
+      - Honor
+      type: string
+      x-enum-varnames:
+      - NodeInclusionPolicyIgnore
+      - NodeInclusionPolicyHonor
     v1.NodePhase:
       enum:
       - Pending
@@ -31911,6 +36810,82 @@ components:
 
             +optional'
           type: boolean
+      type: object
+    v1.NodeSelector:
+      properties:
+        nodeSelectorTerms:
+          description: 'Required. A list of node selector terms. The terms are ORed.
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.NodeSelectorTerm'
+          type: array
+      type: object
+    v1.NodeSelectorOperator:
+      enum:
+      - In
+      - NotIn
+      - Exists
+      - DoesNotExist
+      - Gt
+      - Lt
+      type: string
+      x-enum-varnames:
+      - NodeSelectorOpIn
+      - NodeSelectorOpNotIn
+      - NodeSelectorOpExists
+      - NodeSelectorOpDoesNotExist
+      - NodeSelectorOpGt
+      - NodeSelectorOpLt
+    v1.NodeSelectorRequirement:
+      properties:
+        key:
+          description: The label key that the selector applies to.
+          type: string
+        operator:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeSelectorOperator'
+          description: 'Represents a key''s relationship to a set of values.
+
+            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.'
+        values:
+          description: 'An array of string values. If the operator is In or NotIn,
+
+            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+
+            the values array must be empty. If the operator is Gt or Lt, the values
+
+            array must have a single element, which will be interpreted as an integer.
+
+            This array is replaced during a strategic merge patch.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+      type: object
+    v1.NodeSelectorTerm:
+      properties:
+        matchExpressions:
+          description: 'A list of node selector requirements by node''s labels.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.NodeSelectorRequirement'
+          type: array
+        matchFields:
+          description: 'A list of node selector requirements by node''s fields.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.NodeSelectorRequirement'
+          type: array
       type: object
     v1.NodeSpec:
       properties:
@@ -32194,6 +37169,14 @@ components:
             https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid'
           type: string
       type: object
+    v1.OSName:
+      enum:
+      - linux
+      - windows
+      type: string
+      x-enum-varnames:
+      - Linux
+      - Windows
     v1.ObjectFieldSelector:
       properties:
         apiVersion:
@@ -32602,6 +37585,191 @@ components:
       - ClaimPending
       - ClaimBound
       - ClaimLost
+    v1.PersistentVolumeClaimSpec:
+      properties:
+        accessModes:
+          description: 'accessModes contains the desired access modes the volume should
+            have.
+
+            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.PersistentVolumeAccessMode'
+          type: array
+        dataSource:
+          allOf:
+          - $ref: '#/components/schemas/v1.TypedLocalObjectReference'
+          description: 'dataSource field can be used to specify either:
+
+            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+
+            * An existing PVC (PersistentVolumeClaim)
+
+            If the provisioner or an external controller can support the specified
+            data source,
+
+            it will create a new volume based on the contents of the specified data
+            source.
+
+            When the AnyVolumeDataSource feature gate is enabled, dataSource contents
+            will be copied to dataSourceRef,
+
+            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace
+            is not specified.
+
+            If the namespace is specified, then dataSourceRef will not be copied to
+            dataSource.
+
+            +optional'
+        dataSourceRef:
+          allOf:
+          - $ref: '#/components/schemas/v1.TypedObjectReference'
+          description: "dataSourceRef specifies the object from which to populate\
+            \ the volume with data, if a non-empty\nvolume is desired. This may be\
+            \ any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim\
+            \ object.\nWhen this field is specified, volume binding will only succeed\
+            \ if the type of\nthe specified object matches some installed volume populator\
+            \ or dynamic\nprovisioner.\nThis field will replace the functionality\
+            \ of the dataSource field and as such\nif both fields are non-empty, they\
+            \ must have the same value. For backwards\ncompatibility, when namespace\
+            \ isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef)\
+            \ will be set to the same\nvalue automatically if one of them is empty\
+            \ and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\n\
+            dataSource isn't set to the same value and must be empty.\nThere are three\
+            \ important differences between dataSource and dataSourceRef:\n* While\
+            \ dataSource only allows two specific types of objects, dataSourceRef\n\
+            \  allows any non-core object, as well as PersistentVolumeClaim objects.\n\
+            * While dataSource ignores disallowed values (dropping them), dataSourceRef\n\
+            \  preserves all values, and generates an error if a disallowed value\
+            \ is\n  specified.\n* While dataSource only allows local objects, dataSourceRef\
+            \ allows objects\n  in any namespaces.\n(Beta) Using this field requires\
+            \ the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the\
+            \ namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource\
+            \ feature gate to be enabled.\n+optional"
+        resources:
+          allOf:
+          - $ref: '#/components/schemas/v1.VolumeResourceRequirements'
+          description: 'resources represents the minimum resources the volume should
+            have.
+
+            Users are allowed to specify resource requirements
+
+            that are lower than previous value but must still be higher than capacity
+            recorded in the
+
+            status field of the claim.
+
+            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+
+            +optional'
+        selector:
+          allOf:
+          - $ref: '#/components/schemas/v1.LabelSelector'
+          description: 'selector is a label query over volumes to consider for binding.
+
+            +optional'
+        storageClassName:
+          description: 'storageClassName is the name of the StorageClass required
+            by the claim.
+
+            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+
+            +optional'
+          type: string
+        volumeAttributesClassName:
+          description: 'volumeAttributesClassName may be used to set the VolumeAttributesClass
+            used by this claim.
+
+            If specified, the CSI driver will create or update the volume with the
+            attributes defined
+
+            in the corresponding VolumeAttributesClass. This has a different purpose
+            than storageClassName,
+
+            it can be changed after the claim is created. An empty string or nil value
+            indicates that no
+
+            VolumeAttributesClass will be applied to the claim. If the claim enters
+            an Infeasible error state,
+
+            this field can be reset to its previous value (including nil) to cancel
+            the modification.
+
+            If the resource referred to by volumeAttributesClass does not exist, this
+            PersistentVolumeClaim will be
+
+            set to a Pending state, as reflected by the modifyVolumeStatus field,
+            until such as a resource
+
+            exists.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+
+            +featureGate=VolumeAttributesClass
+
+            +optional'
+          type: string
+        volumeMode:
+          allOf:
+          - $ref: '#/components/schemas/v1.PersistentVolumeMode'
+          description: 'volumeMode defines what type of volume is required by the
+            claim.
+
+            Value of Filesystem is implied when not included in claim spec.
+
+            +optional'
+        volumeName:
+          description: 'volumeName is the binding reference to the PersistentVolume
+            backing this claim.
+
+            +optional'
+          type: string
+      type: object
+    v1.PersistentVolumeClaimTemplate:
+      properties:
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/v1.ObjectMeta'
+          description: 'May contain labels and annotations that will be copied into
+            the PVC
+
+            when creating it. No other fields are allowed and will be rejected during
+
+            validation.
+
+
+            +optional'
+        spec:
+          allOf:
+          - $ref: '#/components/schemas/v1.PersistentVolumeClaimSpec'
+          description: 'The specification for the PersistentVolumeClaim. The entire
+            content is
+
+            copied unchanged into the PVC that gets created from this
+
+            template. The same fields as in a PersistentVolumeClaim
+
+            are also valid here.'
+      type: object
+    v1.PersistentVolumeClaimVolumeSource:
+      properties:
+        claimName:
+          description: 'claimName is the name of a PersistentVolumeClaim in the same
+            namespace as the pod using this volume.
+
+            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+          type: string
+        readOnly:
+          description: 'readOnly Will force the ReadOnly setting in VolumeMounts.
+
+            Default false.
+
+            +optional'
+          type: boolean
+      type: object
     v1.PersistentVolumeMode:
       enum:
       - Block
@@ -32634,6 +37802,20 @@ components:
       - PersistentVolumeReclaimRecycle
       - PersistentVolumeReclaimDelete
       - PersistentVolumeReclaimRetain
+    v1.PhotonPersistentDiskVolumeSource:
+      properties:
+        fsType:
+          description: 'fsType is the filesystem type to mount.
+
+            Must be a filesystem type supported by the host operating system.
+
+            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.'
+          type: string
+        pdID:
+          description: pdID is the ID that identifies Photon Controller persistent
+            disk
+          type: string
+      type: object
     v1.Platform:
       properties:
         architecture:
@@ -32662,6 +37844,2119 @@ components:
 
             example `v7` to specify ARMv7 when architecture is `arm`.'
           type: string
+      type: object
+    v1.Pod:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object.
+
+            Servers should convert recognized schemas to the latest internal value,
+            and
+
+            may reject unrecognized values.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+            +optional'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents.
+
+            Servers may infer this from the endpoint the client submits requests to.
+
+            Cannot be updated.
+
+            In CamelCase.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+            +optional'
+          type: string
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/v1.ObjectMeta'
+          description: 'Standard object''s metadata.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+            +optional'
+        spec:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodSpec'
+          description: 'Specification of the desired behavior of the pod.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+            +optional'
+        status:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodStatus'
+          description: 'Most recently observed status of the pod.
+
+            This data may not be up to date.
+
+            Populated by the system.
+
+            Read-only.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+            +optional'
+      type: object
+    v1.PodAffinity:
+      properties:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          description: 'The scheduler will prefer to schedule pods to nodes that satisfy
+
+            the affinity expressions specified by this field, but it may choose
+
+            a node that violates one or more of the expressions. The node that is
+
+            most preferred is the one with the greatest sum of weights, i.e.
+
+            for each node that meets all of the scheduling requirements (resource
+
+            request, requiredDuringScheduling affinity expressions, etc.),
+
+            compute a sum by iterating through the elements of this field and adding
+
+            "weight" to the sum if the node has pods which matches the corresponding
+            podAffinityTerm; the
+
+            node(s) with the highest sum are the most preferred.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.WeightedPodAffinityTerm'
+          type: array
+        requiredDuringSchedulingIgnoredDuringExecution:
+          description: 'If the affinity requirements specified by this field are not
+            met at
+
+            scheduling time, the pod will not be scheduled onto the node.
+
+            If the affinity requirements specified by this field cease to be met
+
+            at some point during pod execution (e.g. due to a pod label update), the
+
+            system may or may not try to eventually evict the pod from its node.
+
+            When there are multiple elements, the lists of nodes corresponding to
+            each
+
+            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.PodAffinityTerm'
+          type: array
+      type: object
+    v1.PodAffinityTerm:
+      properties:
+        labelSelector:
+          allOf:
+          - $ref: '#/components/schemas/v1.LabelSelector'
+          description: 'A label query over a set of resources, in this case pods.
+
+            If it''s null, this PodAffinityTerm matches with no Pods.
+
+            +optional'
+        matchLabelKeys:
+          description: 'MatchLabelKeys is a set of pod label keys to select which
+            pods will
+
+            be taken into consideration. The keys are used to lookup values from the
+
+            incoming pod labels, those key-value labels are merged with `labelSelector`
+            as `key in (value)`
+
+            to select the group of existing pods which pods will be taken into consideration
+
+            for the incoming pod''s pod (anti) affinity. Keys that don''t exist in
+            the incoming
+
+            pod labels will be ignored. The default value is empty.
+
+            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+
+            Also, matchLabelKeys cannot be set when labelSelector isn''t set.
+
+
+            +listType=atomic
+
+            +optional'
+          items:
+            type: string
+          type: array
+        mismatchLabelKeys:
+          description: 'MismatchLabelKeys is a set of pod label keys to select which
+            pods will
+
+            be taken into consideration. The keys are used to lookup values from the
+
+            incoming pod labels, those key-value labels are merged with `labelSelector`
+            as `key notin (value)`
+
+            to select the group of existing pods which pods will be taken into consideration
+
+            for the incoming pod''s pod (anti) affinity. Keys that don''t exist in
+            the incoming
+
+            pod labels will be ignored. The default value is empty.
+
+            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+
+            Also, mismatchLabelKeys cannot be set when labelSelector isn''t set.
+
+
+            +listType=atomic
+
+            +optional'
+          items:
+            type: string
+          type: array
+        namespaceSelector:
+          allOf:
+          - $ref: '#/components/schemas/v1.LabelSelector'
+          description: 'A label query over the set of namespaces that the term applies
+            to.
+
+            The term is applied to the union of the namespaces selected by this field
+
+            and the ones listed in the namespaces field.
+
+            null selector and null or empty namespaces list means "this pod''s namespace".
+
+            An empty selector ({}) matches all namespaces.
+
+            +optional'
+        namespaces:
+          description: 'namespaces specifies a static list of namespace names that
+            the term applies to.
+
+            The term is applied to the union of the namespaces listed in this field
+
+            and the ones selected by namespaceSelector.
+
+            null or empty namespaces list and null namespaceSelector means "this pod''s
+            namespace".
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+        topologyKey:
+          description: 'This pod should be co-located (affinity) or not co-located
+            (anti-affinity) with the pods matching
+
+            the labelSelector in the specified namespaces, where co-located is defined
+            as running on a node
+
+            whose value of the label with key topologyKey matches that of any node
+            on which any of the
+
+            selected pods is running.
+
+            Empty topologyKey is not allowed.'
+          type: string
+      type: object
+    v1.PodAntiAffinity:
+      properties:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          description: 'The scheduler will prefer to schedule pods to nodes that satisfy
+
+            the anti-affinity expressions specified by this field, but it may choose
+
+            a node that violates one or more of the expressions. The node that is
+
+            most preferred is the one with the greatest sum of weights, i.e.
+
+            for each node that meets all of the scheduling requirements (resource
+
+            request, requiredDuringScheduling anti-affinity expressions, etc.),
+
+            compute a sum by iterating through the elements of this field and subtracting
+
+            "weight" from the sum if the node has pods which matches the corresponding
+            podAffinityTerm; the
+
+            node(s) with the highest sum are the most preferred.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.WeightedPodAffinityTerm'
+          type: array
+        requiredDuringSchedulingIgnoredDuringExecution:
+          description: 'If the anti-affinity requirements specified by this field
+            are not met at
+
+            scheduling time, the pod will not be scheduled onto the node.
+
+            If the anti-affinity requirements specified by this field cease to be
+            met
+
+            at some point during pod execution (e.g. due to a pod label update), the
+
+            system may or may not try to eventually evict the pod from its node.
+
+            When there are multiple elements, the lists of nodes corresponding to
+            each
+
+            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.PodAffinityTerm'
+          type: array
+      type: object
+    v1.PodCertificateProjection:
+      properties:
+        certificateChainPath:
+          description: 'Write the certificate chain at this path in the projected
+            volume.
+
+
+            Most applications should use credentialBundlePath.  When using keyPath
+
+            and certificateChainPath, your application needs to check that the key
+
+            and leaf certificate are consistent, because it is possible to read the
+
+            files mid-rotation.
+
+
+            +optional'
+          type: string
+        credentialBundlePath:
+          description: 'Write the credential bundle at this path in the projected
+            volume.
+
+
+            The credential bundle is a single file that contains multiple PEM blocks.
+
+            The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+
+            key.
+
+
+            The remaining blocks are CERTIFICATE blocks, containing the issued
+
+            certificate chain from the signer (leaf and any intermediates).
+
+
+            Using credentialBundlePath lets your Pod''s application code make a single
+
+            atomic read that retrieves a consistent key and certificate chain.  If
+            you
+
+            project them to separate files, your application code will need to
+
+            additionally check that the leaf certificate was issued to the key.
+
+
+            +optional'
+          type: string
+        keyPath:
+          description: 'Write the key at this path in the projected volume.
+
+
+            Most applications should use credentialBundlePath.  When using keyPath
+
+            and certificateChainPath, your application needs to check that the key
+
+            and leaf certificate are consistent, because it is possible to read the
+
+            files mid-rotation.
+
+
+            +optional'
+          type: string
+        keyType:
+          description: 'The type of keypair Kubelet will generate for the pod.
+
+
+            Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+
+            "ECDSAP521", and "ED25519".
+
+
+            +required'
+          type: string
+        maxExpirationSeconds:
+          description: 'maxExpirationSeconds is the maximum lifetime permitted for
+            the
+
+            certificate.
+
+
+            Kubelet copies this value verbatim into the PodCertificateRequests it
+
+            generates for this projection.
+
+
+            If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+
+            will reject values shorter than 3600 (1 hour).  The maximum allowable
+
+            value is 7862400 (91 days).
+
+
+            The signer implementation is then free to issue a certificate with any
+
+            lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+
+            seconds (1 hour).  This constraint is enforced by kube-apiserver.
+
+            `kubernetes.io` signers will never issue certificates with a lifetime
+
+            longer than 24 hours.
+
+
+            +optional'
+          type: integer
+        signerName:
+          description: 'Kubelet''s generated CSRs will be addressed to this signer.
+
+
+            +required'
+          type: string
+        userAnnotations:
+          additionalProperties:
+            type: string
+          description: 'userAnnotations allow pod authors to pass additional information
+            to
+
+            the signer implementation.  Kubernetes does not restrict or validate this
+
+            metadata in any way.
+
+
+            These values are copied verbatim into the `spec.unverifiedUserAnnotations`
+            field of
+
+            the PodCertificateRequest objects that Kubelet creates.
+
+
+            Entries are subject to the same validation as object metadata annotations,
+
+            with the addition that all keys must be domain-prefixed. No restrictions
+
+            are placed on values, except an overall size limitation on the entire
+            field.
+
+
+            Signers should document the keys and values they support. Signers should
+
+            deny requests that contain keys they do not recognize.'
+          type: object
+      type: object
+    v1.PodCondition:
+      properties:
+        lastProbeTime:
+          description: 'Last time we probed the condition.
+
+            +optional'
+          type: string
+        lastTransitionTime:
+          description: 'Last time the condition transitioned from one status to another.
+
+            +optional'
+          type: string
+        message:
+          description: 'Human-readable message indicating details about last transition.
+
+            +optional'
+          type: string
+        observedGeneration:
+          description: 'If set, this represents the .metadata.generation that the
+            pod condition was set based upon.
+
+            The PodObservedGenerationTracking feature gate must be enabled to use
+            this field.
+
+            +featureGate=PodObservedGenerationTracking
+
+            +optional'
+          type: integer
+        reason:
+          description: 'Unique, one-word, CamelCase reason for the condition''s last
+            transition.
+
+            +optional'
+          type: string
+        status:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_core_v1.ConditionStatus'
+          description: 'Status is the status of the condition.
+
+            Can be True, False, Unknown.
+
+            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+        type:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodConditionType'
+          description: 'Type is the type of the condition.
+
+            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+      type: object
+    v1.PodConditionType:
+      enum:
+      - ContainersReady
+      - Initialized
+      - Ready
+      - PodScheduled
+      - DisruptionTarget
+      - PodReadyToStartContainers
+      - PodResizePending
+      - PodResizeInProgress
+      - AllContainersRestarting
+      type: string
+      x-enum-varnames:
+      - ContainersReady
+      - PodInitialized
+      - PodReady
+      - PodScheduled
+      - DisruptionTarget
+      - PodReadyToStartContainers
+      - PodResizePending
+      - PodResizeInProgress
+      - AllContainersRestarting
+    v1.PodDNSConfig:
+      properties:
+        nameservers:
+          description: 'A list of DNS name server IP addresses.
+
+            This will be appended to the base nameservers generated from DNSPolicy.
+
+            Duplicated nameservers will be removed.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+        options:
+          description: 'A list of DNS resolver options.
+
+            This will be merged with the base options generated from DNSPolicy.
+
+            Duplicated entries will be removed. Resolution options given in Options
+
+            will override those that appear in the base DNSPolicy.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.PodDNSConfigOption'
+          type: array
+        searches:
+          description: 'A list of DNS search domains for host-name lookup.
+
+            This will be appended to the base search paths generated from DNSPolicy.
+
+            Duplicated search paths will be removed.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+      type: object
+    v1.PodDNSConfigOption:
+      properties:
+        name:
+          description: 'Name is this DNS resolver option''s name.
+
+            Required.'
+          type: string
+        value:
+          description: 'Value is this DNS resolver option''s value.
+
+            +optional'
+          type: string
+      type: object
+    v1.PodExtendedResourceClaimStatus:
+      properties:
+        requestMappings:
+          description: 'RequestMappings identifies the mapping of <container, extended
+            resource backed by DRA> to  device request
+
+            in the generated ResourceClaim.
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.ContainerExtendedResourceRequest'
+          type: array
+        resourceClaimName:
+          description: 'ResourceClaimName is the name of the ResourceClaim that was
+
+            generated for the Pod in the namespace of the Pod.'
+          type: string
+      type: object
+    v1.PodFSGroupChangePolicy:
+      enum:
+      - OnRootMismatch
+      - Always
+      type: string
+      x-enum-varnames:
+      - FSGroupChangeOnRootMismatch
+      - FSGroupChangeAlways
+    v1.PodIP:
+      properties:
+        ip:
+          description: 'IP is the IP address assigned to the pod
+
+            +required'
+          type: string
+      type: object
+    v1.PodOS:
+      properties:
+        name:
+          allOf:
+          - $ref: '#/components/schemas/v1.OSName'
+          description: 'Name is the name of the operating system. The currently supported
+            values are linux and windows.
+
+            Additional value may be defined in future and can be one of:
+
+            https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+
+            Clients should expect to handle additional values and treat unrecognized
+            values in this field as os: null'
+      type: object
+    v1.PodPhase:
+      enum:
+      - Pending
+      - Running
+      - Succeeded
+      - Failed
+      - Unknown
+      type: string
+      x-enum-varnames:
+      - PodPending
+      - PodRunning
+      - PodSucceeded
+      - PodFailed
+      - PodUnknown
+    v1.PodQOSClass:
+      enum:
+      - Guaranteed
+      - Burstable
+      - BestEffort
+      type: string
+      x-enum-varnames:
+      - PodQOSGuaranteed
+      - PodQOSBurstable
+      - PodQOSBestEffort
+    v1.PodReadinessGate:
+      properties:
+        conditionType:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodConditionType'
+          description: ConditionType refers to a condition in the pod's condition
+            list with matching type.
+      type: object
+    v1.PodResizeStatus:
+      enum:
+      - InProgress
+      - Deferred
+      - Infeasible
+      type: string
+      x-enum-varnames:
+      - PodResizeStatusInProgress
+      - PodResizeStatusDeferred
+      - PodResizeStatusInfeasible
+    v1.PodResourceClaim:
+      properties:
+        name:
+          description: 'Name uniquely identifies this resource claim inside the pod.
+
+            This must be a DNS_LABEL.'
+          type: string
+        resourceClaimName:
+          description: 'ResourceClaimName is the name of a ResourceClaim object in
+            the same
+
+            namespace as this pod.
+
+
+            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+
+            be set.'
+          type: string
+        resourceClaimTemplateName:
+          description: 'ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+
+            object in the same namespace as this pod.
+
+
+            The template will be used to create a new ResourceClaim, which will
+
+            be bound to this pod. When this pod is deleted, the ResourceClaim
+
+            will also be deleted. The pod name and resource name, along with a
+
+            generated component, will be used to form a unique name for the
+
+            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+
+            This field is immutable and no changes will be made to the
+
+            corresponding ResourceClaim by the control plane after creating the
+
+            ResourceClaim.
+
+
+            Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+
+            be set.'
+          type: string
+      type: object
+    v1.PodResourceClaimStatus:
+      properties:
+        name:
+          description: 'Name uniquely identifies this resource claim inside the pod.
+
+            This must match the name of an entry in pod.spec.resourceClaims,
+
+            which implies that the string must be a DNS_LABEL.'
+          type: string
+        resourceClaimName:
+          description: 'ResourceClaimName is the name of the ResourceClaim that was
+
+            generated for the Pod in the namespace of the Pod. If this is
+
+            unset, then generating a ResourceClaim was not necessary. The
+
+            pod.spec.resourceClaims entry can be ignored in this case.
+
+
+            +optional'
+          type: string
+      type: object
+    v1.PodSELinuxChangePolicy:
+      enum:
+      - Recursive
+      - MountOption
+      type: string
+      x-enum-varnames:
+      - SELinuxChangePolicyRecursive
+      - SELinuxChangePolicyMountOption
+    v1.PodSchedulingGate:
+      properties:
+        name:
+          description: 'Name of the scheduling gate.
+
+            Each scheduling gate must have a unique name field.'
+          type: string
+      type: object
+    v1.PodSecurityContext:
+      properties:
+        appArmorProfile:
+          allOf:
+          - $ref: '#/components/schemas/v1.AppArmorProfile'
+          description: 'appArmorProfile is the AppArmor options to use by the containers
+            in this pod.
+
+            Note that this field cannot be set when spec.os.name is windows.
+
+            +optional'
+        fsGroup:
+          description: 'A special supplemental group that applies to all containers
+            in a pod.
+
+            Some volume types allow the Kubelet to change the ownership of that volume
+
+            to be owned by the pod:
+
+
+            1. The owning GID will be the FSGroup
+
+            2. The setgid bit is set (new files created in the volume will be owned
+            by FSGroup)
+
+            3. The permission bits are OR''d with rw-rw----
+
+
+            If unset, the Kubelet will not modify the ownership and permissions of
+            any volume.
+
+            Note that this field cannot be set when spec.os.name is windows.
+
+            +optional'
+          type: integer
+        fsGroupChangePolicy:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodFSGroupChangePolicy'
+          description: 'fsGroupChangePolicy defines behavior of changing ownership
+            and permission of the volume
+
+            before being exposed inside Pod. This field will only apply to
+
+            volume types which support fsGroup based ownership(and permissions).
+
+            It will have no effect on ephemeral volume types such as: secret, configmaps
+
+            and emptydir.
+
+            Valid values are "OnRootMismatch" and "Always". If not specified, "Always"
+            is used.
+
+            Note that this field cannot be set when spec.os.name is windows.
+
+            +optional'
+        runAsGroup:
+          description: 'The GID to run the entrypoint of the container process.
+
+            Uses runtime default if unset.
+
+            May also be set in SecurityContext.  If set in both SecurityContext and
+
+            PodSecurityContext, the value specified in SecurityContext takes precedence
+
+            for that container.
+
+            Note that this field cannot be set when spec.os.name is windows.
+
+            +optional'
+          type: integer
+        runAsNonRoot:
+          description: 'Indicates that the container must run as a non-root user.
+
+            If true, the Kubelet will validate the image at runtime to ensure that
+            it
+
+            does not run as UID 0 (root) and fail to start the container if it does.
+
+            If unset or false, no such validation will be performed.
+
+            May also be set in SecurityContext.  If set in both SecurityContext and
+
+            PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+            +optional'
+          type: boolean
+        runAsUser:
+          description: 'The UID to run the entrypoint of the container process.
+
+            Defaults to user specified in image metadata if unspecified.
+
+            May also be set in SecurityContext.  If set in both SecurityContext and
+
+            PodSecurityContext, the value specified in SecurityContext takes precedence
+
+            for that container.
+
+            Note that this field cannot be set when spec.os.name is windows.
+
+            +optional'
+          type: integer
+        seLinuxChangePolicy:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodSELinuxChangePolicy'
+          description: 'seLinuxChangePolicy defines how the container''s SELinux label
+            is applied to all volumes used by the Pod.
+
+            It has no effect on nodes that do not support SELinux or to volumes does
+            not support SELinux.
+
+            Valid values are "MountOption" and "Recursive".
+
+
+            "Recursive" means relabeling of all files on all Pod volumes by the container
+            runtime.
+
+            This may be slow for large volumes, but allows mixing privileged and unprivileged
+            Pods sharing the same volume on the same node.
+
+
+            "MountOption" mounts all eligible Pod volumes with `-o context` mount
+            option.
+
+            This requires all Pods that share the same volume to use the same SELinux
+            label.
+
+            It is not possible to share the same volume among privileged and unprivileged
+            Pods.
+
+            Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI
+            volumes
+
+            whose CSI driver announces SELinux support by setting spec.seLinuxMount:
+            true in their
+
+            CSIDriver instance. Other volumes are always re-labelled recursively.
+
+            "MountOption" value is allowed only when SELinuxMount feature gate is
+            enabled.
+
+
+            If not specified and SELinuxMount feature gate is enabled, "MountOption"
+            is used.
+
+            If not specified and SELinuxMount feature gate is disabled, "MountOption"
+            is used for ReadWriteOncePod volumes
+
+            and "Recursive" for all other volumes.
+
+
+            This field affects only Pods that have SELinux label set, either in PodSecurityContext
+            or in SecurityContext of all containers.
+
+
+            All Pods that use the same volume should use the same seLinuxChangePolicy,
+            otherwise some pods can get stuck in ContainerCreating state.
+
+            Note that this field cannot be set when spec.os.name is windows.
+
+            +featureGate=SELinuxChangePolicy
+
+            +optional'
+        seLinuxOptions:
+          allOf:
+          - $ref: '#/components/schemas/v1.SELinuxOptions'
+          description: 'The SELinux context to be applied to all containers.
+
+            If unspecified, the container runtime will allocate a random SELinux context
+            for each
+
+            container.  May also be set in SecurityContext.  If set in
+
+            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+
+            takes precedence for that container.
+
+            Note that this field cannot be set when spec.os.name is windows.
+
+            +optional'
+        seccompProfile:
+          allOf:
+          - $ref: '#/components/schemas/v1.SeccompProfile'
+          description: 'The seccomp options to use by the containers in this pod.
+
+            Note that this field cannot be set when spec.os.name is windows.
+
+            +optional'
+        supplementalGroups:
+          description: 'A list of groups applied to the first process run in each
+            container, in
+
+            addition to the container''s primary GID and fsGroup (if specified).  If
+
+            the SupplementalGroupsPolicy feature is enabled, the
+
+            supplementalGroupsPolicy field determines whether these are in addition
+
+            to or instead of any group memberships defined in the container image.
+
+            If unspecified, no additional groups are added, though group memberships
+
+            defined in the container image may still be used, depending on the
+
+            supplementalGroupsPolicy field.
+
+            Note that this field cannot be set when spec.os.name is windows.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            type: integer
+          type: array
+        supplementalGroupsPolicy:
+          allOf:
+          - $ref: '#/components/schemas/v1.SupplementalGroupsPolicy'
+          description: 'Defines how supplemental groups of the first container processes
+            are calculated.
+
+            Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+
+            (Alpha) Using the field requires the SupplementalGroupsPolicy feature
+            gate to be enabled
+
+            and the container runtime must implement support for this feature.
+
+            Note that this field cannot be set when spec.os.name is windows.
+
+            TODO: update the default value to "Merge" when spec.os.name is not windows
+            in v1.34
+
+            +featureGate=SupplementalGroupsPolicy
+
+            +optional'
+        sysctls:
+          description: 'Sysctls hold a list of namespaced sysctls used for the pod.
+            Pods with unsupported
+
+            sysctls (by the container runtime) might fail to launch.
+
+            Note that this field cannot be set when spec.os.name is windows.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.Sysctl'
+          type: array
+        windowsOptions:
+          allOf:
+          - $ref: '#/components/schemas/v1.WindowsSecurityContextOptions'
+          description: 'The Windows specific settings applied to all containers.
+
+            If unspecified, the options within a container''s SecurityContext will
+            be used.
+
+            If set in both SecurityContext and PodSecurityContext, the value specified
+            in SecurityContext takes precedence.
+
+            Note that this field cannot be set when spec.os.name is linux.
+
+            +optional'
+      type: object
+    v1.PodSpec:
+      properties:
+        activeDeadlineSeconds:
+          description: 'Optional duration in seconds the pod may be active on the
+            node relative to
+
+            StartTime before the system will actively try to mark it failed and kill
+            associated containers.
+
+            Value must be a positive integer.
+
+            +optional'
+          type: integer
+        affinity:
+          allOf:
+          - $ref: '#/components/schemas/v1.Affinity'
+          description: 'If specified, the pod''s scheduling constraints
+
+            +optional'
+        automountServiceAccountToken:
+          description: 'AutomountServiceAccountToken indicates whether a service account
+            token should be automatically mounted.
+
+            +optional'
+          type: boolean
+        containers:
+          description: 'List of containers belonging to the pod.
+
+            Containers cannot currently be added or removed.
+
+            There must be at least one container in a Pod.
+
+            Cannot be updated.
+
+            +patchMergeKey=name
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=name'
+          items:
+            $ref: '#/components/schemas/v1.Container'
+          type: array
+        dnsConfig:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodDNSConfig'
+          description: 'Specifies the DNS parameters of a pod.
+
+            Parameters specified here will be merged to the generated DNS
+
+            configuration based on DNSPolicy.
+
+            +optional'
+        dnsPolicy:
+          allOf:
+          - $ref: '#/components/schemas/v1.DNSPolicy'
+          description: 'Set DNS policy for the pod.
+
+            Defaults to "ClusterFirst".
+
+            Valid values are ''ClusterFirstWithHostNet'', ''ClusterFirst'', ''Default''
+            or ''None''.
+
+            DNS parameters given in DNSConfig will be merged with the policy selected
+            with DNSPolicy.
+
+            To have DNS options set along with hostNetwork, you have to specify DNS
+            policy
+
+            explicitly to ''ClusterFirstWithHostNet''.
+
+            +optional'
+        enableServiceLinks:
+          description: 'EnableServiceLinks indicates whether information about services
+            should be injected into pod''s
+
+            environment variables, matching the syntax of Docker links.
+
+            Optional: Defaults to true.
+
+            +optional'
+          type: boolean
+        ephemeralContainers:
+          description: 'List of ephemeral containers run in this pod. Ephemeral containers
+            may be run in an existing
+
+            pod to perform user-initiated actions such as debugging. This list cannot
+            be specified when
+
+            creating a pod, and it cannot be modified by updating the pod spec. In
+            order to add an
+
+            ephemeral container to an existing pod, use the pod''s ephemeralcontainers
+            subresource.
+
+            +optional
+
+            +patchMergeKey=name
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=name'
+          items:
+            $ref: '#/components/schemas/v1.EphemeralContainer'
+          type: array
+        hostAliases:
+          description: 'HostAliases is an optional list of hosts and IPs that will
+            be injected into the pod''s hosts
+
+            file if specified.
+
+            +optional
+
+            +patchMergeKey=ip
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=ip'
+          items:
+            $ref: '#/components/schemas/v1.HostAlias'
+          type: array
+        hostIPC:
+          description: 'Use the host''s ipc namespace.
+
+            Optional: Default to false.
+
+            +k8s:conversion-gen=false
+
+            +optional'
+          type: boolean
+        hostNetwork:
+          description: 'Host networking requested for this pod. Use the host''s network
+            namespace.
+
+            When using HostNetwork you should specify ports so the scheduler is aware.
+
+            When `hostNetwork` is true, specified `hostPort` fields in port definitions
+            must match `containerPort`,
+
+            and unspecified `hostPort` fields in port definitions are defaulted to
+            match `containerPort`.
+
+            Default to false.
+
+            +k8s:conversion-gen=false
+
+            +optional'
+          type: boolean
+        hostPID:
+          description: 'Use the host''s pid namespace.
+
+            Optional: Default to false.
+
+            +k8s:conversion-gen=false
+
+            +optional'
+          type: boolean
+        hostUsers:
+          description: 'Use the host''s user namespace.
+
+            Optional: Default to true.
+
+            If set to true or not present, the pod will be run in the host user namespace,
+            useful
+
+            for when the pod needs a feature only available to the host user namespace,
+            such as
+
+            loading a kernel module with CAP_SYS_MODULE.
+
+            When set to false, a new userns is created for the pod. Setting false
+            is useful for
+
+            mitigating container breakout vulnerabilities even allowing users to run
+            their
+
+            containers as root without actually having root privileges on the host.
+
+            This field is alpha-level and is only honored by servers that enable the
+            UserNamespacesSupport feature.
+
+            +k8s:conversion-gen=false
+
+            +optional'
+          type: boolean
+        hostname:
+          description: 'Specifies the hostname of the Pod
+
+            If not specified, the pod''s hostname will be set to a system-defined
+            value.
+
+            +optional'
+          type: string
+        hostnameOverride:
+          description: 'HostnameOverride specifies an explicit override for the pod''s
+            hostname as perceived by the pod.
+
+            This field only specifies the pod''s hostname and does not affect its
+            DNS records.
+
+            When this field is set to a non-empty string:
+
+            - It takes precedence over the values set in `hostname` and `subdomain`.
+
+            - The Pod''s hostname will be set to this value.
+
+            - `setHostnameAsFQDN` must be nil or set to false.
+
+            - `hostNetwork` must be set to false.
+
+
+            This field must be a valid DNS subdomain as defined in RFC 1123 and contain
+            at most 64 characters.
+
+            Requires the HostnameOverride feature gate to be enabled.
+
+
+            +featureGate=HostnameOverride
+
+            +optional'
+          type: string
+        imagePullSecrets:
+          description: 'ImagePullSecrets is an optional list of references to secrets
+            in the same namespace to use for pulling any of the images used by this
+            PodSpec.
+
+            If specified, these secrets will be passed to individual puller implementations
+            for them to use.
+
+            More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+
+            +optional
+
+            +patchMergeKey=name
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=name'
+          items:
+            $ref: '#/components/schemas/k8s_io_api_core_v1.LocalObjectReference'
+          type: array
+        initContainers:
+          description: 'List of initialization containers belonging to the pod.
+
+            Init containers are executed in order prior to containers being started.
+            If any
+
+            init container fails, the pod is considered to have failed and is handled
+            according
+
+            to its restartPolicy. The name for an init container or normal container
+            must be
+
+            unique among all containers.
+
+            Init containers may not have Lifecycle actions, Readiness probes, Liveness
+            probes, or Startup probes.
+
+            The resourceRequirements of an init container are taken into account during
+            scheduling
+
+            by finding the highest request/limit for each resource type, and then
+            using the max of
+
+            that value or the sum of the normal containers. Limits are applied to
+            init containers
+
+            in a similar fashion.
+
+            Init containers cannot currently be added or removed.
+
+            Cannot be updated.
+
+            More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+
+            +patchMergeKey=name
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=name'
+          items:
+            $ref: '#/components/schemas/v1.Container'
+          type: array
+        nodeName:
+          description: 'NodeName indicates in which node this pod is scheduled.
+
+            If empty, this pod is a candidate for scheduling by the scheduler defined
+            in schedulerName.
+
+            Once this field is set, the kubelet for this node becomes responsible
+            for the lifecycle of this pod.
+
+            This field should not be used to express a desire for the pod to be scheduled
+            on a specific node.
+
+            https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
+
+            +optional'
+          type: string
+        nodeSelector:
+          additionalProperties:
+            type: string
+          description: 'NodeSelector is a selector which must be true for the pod
+            to fit on a node.
+
+            Selector which must match a node''s labels for the pod to be scheduled
+            on that node.
+
+            More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+
+            +optional
+
+            +mapType=atomic'
+          type: object
+        os:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodOS'
+          description: 'Specifies the OS of the containers in the pod.
+
+            Some pod and container fields are restricted if this is set.
+
+
+            If the OS field is set to linux, the following fields must be unset:
+
+            -securityContext.windowsOptions
+
+
+            If the OS field is set to windows, following fields must be unset:
+
+            - spec.hostPID
+
+            - spec.hostIPC
+
+            - spec.hostUsers
+
+            - spec.resources
+
+            - spec.securityContext.appArmorProfile
+
+            - spec.securityContext.seLinuxOptions
+
+            - spec.securityContext.seccompProfile
+
+            - spec.securityContext.fsGroup
+
+            - spec.securityContext.fsGroupChangePolicy
+
+            - spec.securityContext.sysctls
+
+            - spec.shareProcessNamespace
+
+            - spec.securityContext.runAsUser
+
+            - spec.securityContext.runAsGroup
+
+            - spec.securityContext.supplementalGroups
+
+            - spec.securityContext.supplementalGroupsPolicy
+
+            - spec.containers[*].securityContext.appArmorProfile
+
+            - spec.containers[*].securityContext.seLinuxOptions
+
+            - spec.containers[*].securityContext.seccompProfile
+
+            - spec.containers[*].securityContext.capabilities
+
+            - spec.containers[*].securityContext.readOnlyRootFilesystem
+
+            - spec.containers[*].securityContext.privileged
+
+            - spec.containers[*].securityContext.allowPrivilegeEscalation
+
+            - spec.containers[*].securityContext.procMount
+
+            - spec.containers[*].securityContext.runAsUser
+
+            - spec.containers[*].securityContext.runAsGroup
+
+            +optional'
+        overhead:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceList'
+          description: 'Overhead represents the resource overhead associated with
+            running a pod for a given RuntimeClass.
+
+            This field will be autopopulated at admission time by the RuntimeClass
+            admission controller. If
+
+            the RuntimeClass admission controller is enabled, overhead must not be
+            set in Pod create requests.
+
+            The RuntimeClass admission controller will reject Pod create requests
+            which have the overhead already
+
+            set. If RuntimeClass is configured and selected in the PodSpec, Overhead
+            will be set to the value
+
+            defined in the corresponding RuntimeClass, otherwise it will remain unset
+            and treated as zero.
+
+            More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+
+            +optional'
+        preemptionPolicy:
+          allOf:
+          - $ref: '#/components/schemas/v1.PreemptionPolicy'
+          description: 'PreemptionPolicy is the Policy for preempting pods with lower
+            priority.
+
+            One of Never, PreemptLowerPriority.
+
+            Defaults to PreemptLowerPriority if unset.
+
+            +optional'
+        priority:
+          description: 'The priority value. Various system components use this field
+            to find the
+
+            priority of the pod. When Priority Admission Controller is enabled, it
+
+            prevents users from setting this field. The admission controller populates
+
+            this field from PriorityClassName.
+
+            The higher the value, the higher the priority.
+
+            +optional'
+          type: integer
+        priorityClassName:
+          description: 'If specified, indicates the pod''s priority. "system-node-critical"
+            and
+
+            "system-cluster-critical" are two special keywords which indicate the
+
+            highest priorities with the former being the highest priority. Any other
+
+            name must be defined by creating a PriorityClass object with that name.
+
+            If not specified, the pod priority will be default or zero if there is
+            no
+
+            default.
+
+            +optional'
+          type: string
+        readinessGates:
+          description: 'If specified, all readiness gates will be evaluated for pod
+            readiness.
+
+            A pod is ready when all its containers are ready AND
+
+            all conditions specified in the readiness gates have status equal to "True"
+
+            More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.PodReadinessGate'
+          type: array
+        resourceClaims:
+          description: 'ResourceClaims defines which ResourceClaims must be allocated
+
+            and reserved before the Pod is allowed to start. The resources
+
+            will be made available to those containers which consume them
+
+            by name.
+
+
+            This is a stable field but requires that the
+
+            DynamicResourceAllocation feature gate is enabled.
+
+
+            This field is immutable.
+
+
+            +patchMergeKey=name
+
+            +patchStrategy=merge,retainKeys
+
+            +listType=map
+
+            +listMapKey=name
+
+            +featureGate=DynamicResourceAllocation
+
+            +optional'
+          items:
+            $ref: '#/components/schemas/v1.PodResourceClaim'
+          type: array
+        resources:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceRequirements'
+          description: 'Resources is the total amount of CPU and Memory resources
+            required by all
+
+            containers in the pod. It supports specifying Requests and Limits for
+
+            "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are
+            not supported.
+
+
+            This field enables fine-grained control over resource allocation for the
+
+            entire pod, allowing resource sharing among containers in a pod.
+
+            TODO: For beta graduation, expand this comment with a detailed explanation.
+
+
+            This is an alpha field and requires enabling the PodLevelResources feature
+
+            gate.
+
+
+            +featureGate=PodLevelResources
+
+            +optional'
+        restartPolicy:
+          allOf:
+          - $ref: '#/components/schemas/v1.RestartPolicy'
+          description: 'Restart policy for all containers within the pod.
+
+            One of Always, OnFailure, Never. In some contexts, only a subset of those
+            values may be permitted.
+
+            Default to Always.
+
+            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+            +optional'
+        runtimeClassName:
+          description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io
+            group, which should be used
+
+            to run this pod.  If no RuntimeClass resource matches the named class,
+            the pod will not be run.
+
+            If unset or empty, the "legacy" RuntimeClass will be used, which is an
+            implicit class with an
+
+            empty definition that uses the default runtime handler.
+
+            More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+
+            +optional'
+          type: string
+        schedulerName:
+          description: 'If specified, the pod will be dispatched by specified scheduler.
+
+            If not specified, the pod will be dispatched by default scheduler.
+
+            +optional'
+          type: string
+        schedulingGates:
+          description: 'SchedulingGates is an opaque list of values that if specified
+            will block scheduling the pod.
+
+            If schedulingGates is not empty, the pod will stay in the SchedulingGated
+            state and the
+
+            scheduler will not attempt to schedule the pod.
+
+
+            SchedulingGates can only be set at pod creation time, and be removed only
+            afterwards.
+
+
+            +patchMergeKey=name
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=name
+
+            +optional'
+          items:
+            $ref: '#/components/schemas/v1.PodSchedulingGate'
+          type: array
+        securityContext:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodSecurityContext'
+          description: 'SecurityContext holds pod-level security attributes and common
+            container settings.
+
+            Optional: Defaults to empty.  See type description for default values
+            of each field.
+
+            +optional'
+        serviceAccount:
+          description: 'DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.
+
+            Deprecated: Use serviceAccountName instead.
+
+            +k8s:conversion-gen=false
+
+            +optional'
+          type: string
+        serviceAccountName:
+          description: 'ServiceAccountName is the name of the ServiceAccount to use
+            to run this pod.
+
+            More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+
+            +optional'
+          type: string
+        setHostnameAsFQDN:
+          description: 'If true the pod''s hostname will be configured as the pod''s
+            FQDN, rather than the leaf name (the default).
+
+            In Linux containers, this means setting the FQDN in the hostname field
+            of the kernel (the nodename field of struct utsname).
+
+            In Windows containers, this means setting the registry value of hostname
+            for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
+            to FQDN.
+
+            If a pod does not have FQDN, this has no effect.
+
+            Default to false.
+
+            +optional'
+          type: boolean
+        shareProcessNamespace:
+          description: 'Share a single process namespace between all of the containers
+            in a pod.
+
+            When this is set containers will be able to view and signal processes
+            from other containers
+
+            in the same pod, and the first process in each container will not be assigned
+            PID 1.
+
+            HostPID and ShareProcessNamespace cannot both be set.
+
+            Optional: Default to false.
+
+            +k8s:conversion-gen=false
+
+            +optional'
+          type: boolean
+        subdomain:
+          description: 'If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod
+            namespace>.svc.<cluster domain>".
+
+            If not specified, the pod will not have a domainname at all.
+
+            +optional'
+          type: string
+        terminationGracePeriodSeconds:
+          description: 'Optional duration in seconds the pod needs to terminate gracefully.
+            May be decreased in delete request.
+
+            Value must be non-negative integer. The value zero indicates stop immediately
+            via
+
+            the kill signal (no opportunity to shut down).
+
+            If this value is nil, the default grace period will be used instead.
+
+            The grace period is the duration in seconds after the processes running
+            in the pod are sent
+
+            a termination signal and the time when the processes are forcibly halted
+            with a kill signal.
+
+            Set this value longer than the expected cleanup time for your process.
+
+            Defaults to 30 seconds.
+
+            +optional'
+          type: integer
+        tolerations:
+          description: 'If specified, the pod''s tolerations.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.Toleration'
+          type: array
+        topologySpreadConstraints:
+          description: 'TopologySpreadConstraints describes how a group of pods ought
+            to spread across topology
+
+            domains. Scheduler will schedule pods in a way which abides by the constraints.
+
+            All topologySpreadConstraints are ANDed.
+
+            +optional
+
+            +patchMergeKey=topologyKey
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=topologyKey
+
+            +listMapKey=whenUnsatisfiable'
+          items:
+            $ref: '#/components/schemas/v1.TopologySpreadConstraint'
+          type: array
+        volumes:
+          description: 'List of volumes that can be mounted by containers belonging
+            to the pod.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes
+
+            +optional
+
+            +patchMergeKey=name
+
+            +patchStrategy=merge,retainKeys
+
+            +listType=map
+
+            +listMapKey=name'
+          items:
+            $ref: '#/components/schemas/v1.Volume'
+          type: array
+        workloadRef:
+          allOf:
+          - $ref: '#/components/schemas/v1.WorkloadReference'
+          description: 'WorkloadRef provides a reference to the Workload object that
+            this Pod belongs to.
+
+            This field is used by the scheduler to identify the PodGroup and apply
+            the
+
+            correct group scheduling policies. The Workload object referenced
+
+            by this field may not exist at the time the Pod is created.
+
+            This field is immutable, but a Workload object with the same name
+
+            may be recreated with different policies. Doing this during pod scheduling
+
+            may result in the placement not conforming to the expected policies.
+
+
+            +featureGate=GenericWorkload
+
+            +optional'
+      type: object
+    v1.PodStatus:
+      properties:
+        allocatedResources:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceList'
+          description: 'AllocatedResources is the total requests allocated for this
+            pod by the node.
+
+            If pod-level requests are not set, this will be the total requests aggregated
+
+            across containers in the pod.
+
+            +featureGate=InPlacePodLevelResourcesVerticalScaling
+
+            +optional'
+        conditions:
+          description: 'Current service state of pod.
+
+            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+
+            +optional
+
+            +patchMergeKey=type
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=type'
+          items:
+            $ref: '#/components/schemas/v1.PodCondition'
+          type: array
+        containerStatuses:
+          description: 'Statuses of containers in this pod.
+
+            Each container in the pod should have at most one status in this list,
+
+            and all statuses should be for containers in the pod.
+
+            However this is not enforced.
+
+            If a status for a non-existent container is present in the list, or the
+            list has duplicate names,
+
+            the behavior of various Kubernetes components is not defined and those
+            statuses might be
+
+            ignored.
+
+            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.ContainerStatus'
+          type: array
+        ephemeralContainerStatuses:
+          description: 'Statuses for any ephemeral containers that have run in this
+            pod.
+
+            Each ephemeral container in the pod should have at most one status in
+            this list,
+
+            and all statuses should be for containers in the pod.
+
+            However this is not enforced.
+
+            If a status for a non-existent container is present in the list, or the
+            list has duplicate names,
+
+            the behavior of various Kubernetes components is not defined and those
+            statuses might be
+
+            ignored.
+
+            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.ContainerStatus'
+          type: array
+        extendedResourceClaimStatus:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodExtendedResourceClaimStatus'
+          description: 'Status of extended resource claim backed by DRA.
+
+            +featureGate=DRAExtendedResource
+
+            +optional'
+        hostIP:
+          description: 'hostIP holds the IP address of the host to which the pod is
+            assigned. Empty if the pod has not started yet.
+
+            A pod can be assigned to a node that has a problem in kubelet which in
+            turns mean that HostIP will
+
+            not be updated even if there is a node is assigned to pod
+
+            +optional'
+          type: string
+        hostIPs:
+          description: 'hostIPs holds the IP addresses allocated to the host. If this
+            field is specified, the first entry must
+
+            match the hostIP field. This list is empty if the pod has not started
+            yet.
+
+            A pod can be assigned to a node that has a problem in kubelet which in
+            turns means that HostIPs will
+
+            not be updated even if there is a node is assigned to this pod.
+
+            +optional
+
+            +patchStrategy=merge
+
+            +patchMergeKey=ip
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.HostIP'
+          type: array
+        initContainerStatuses:
+          description: 'Statuses of init containers in this pod. The most recent successful
+            non-restartable
+
+            init container will have ready = true, the most recently started container
+            will have
+
+            startTime set.
+
+            Each init container in the pod should have at most one status in this
+            list,
+
+            and all statuses should be for containers in the pod.
+
+            However this is not enforced.
+
+            If a status for a non-existent container is present in the list, or the
+            list has duplicate names,
+
+            the behavior of various Kubernetes components is not defined and those
+            statuses might be
+
+            ignored.
+
+            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-and-container-status
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.ContainerStatus'
+          type: array
+        message:
+          description: 'A human readable message indicating details about why the
+            pod is in this condition.
+
+            +optional'
+          type: string
+        nominatedNodeName:
+          description: 'nominatedNodeName is set only when this pod preempts other
+            pods on the node, but it cannot be
+
+            scheduled right away as preemption victims receive their graceful termination
+            periods.
+
+            This field does not guarantee that the pod will be scheduled on this node.
+            Scheduler may decide
+
+            to place the pod elsewhere if other nodes become available sooner. Scheduler
+            may also decide to
+
+            give the resources on this node to a higher priority pod that is created
+            after preemption.
+
+            As a result, this field may be different than PodSpec.nodeName when the
+            pod is
+
+            scheduled.
+
+            +optional'
+          type: string
+        observedGeneration:
+          description: 'If set, this represents the .metadata.generation that the
+            pod status was set based upon.
+
+            The PodObservedGenerationTracking feature gate must be enabled to use
+            this field.
+
+            +featureGate=PodObservedGenerationTracking
+
+            +optional'
+          type: integer
+        phase:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodPhase'
+          description: 'The phase of a Pod is a simple, high-level summary of where
+            the Pod is in its lifecycle.
+
+            The conditions array, the reason and message fields, and the individual
+            container status
+
+            arrays contain more detail about the pod''s status.
+
+            There are five possible phase values:
+
+
+            Pending: The pod has been accepted by the Kubernetes system, but one or
+            more of the
+
+            container images has not been created. This includes time before being
+            scheduled as
+
+            well as time spent downloading images over the network, which could take
+            a while.
+
+            Running: The pod has been bound to a node, and all of the containers have
+            been created.
+
+            At least one container is still running, or is in the process of starting
+            or restarting.
+
+            Succeeded: All containers in the pod have terminated in success, and will
+            not be restarted.
+
+            Failed: All containers in the pod have terminated, and at least one container
+            has
+
+            terminated in failure. The container either exited with non-zero status
+            or was terminated
+
+            by the system.
+
+            Unknown: For some reason the state of the pod could not be obtained, typically
+            due to an
+
+            error in communicating with the host of the pod.
+
+
+            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase
+
+            +optional'
+        podIP:
+          description: 'podIP address allocated to the pod. Routable at least within
+            the cluster.
+
+            Empty if not yet allocated.
+
+            +optional'
+          type: string
+        podIPs:
+          description: 'podIPs holds the IP addresses allocated to the pod. If this
+            field is specified, the 0th entry must
+
+            match the podIP field. Pods may be allocated at most 1 value for each
+            of IPv4 and IPv6. This list
+
+            is empty if no IPs have been allocated yet.
+
+            +optional
+
+            +patchStrategy=merge
+
+            +patchMergeKey=ip
+
+            +listType=map
+
+            +listMapKey=ip'
+          items:
+            $ref: '#/components/schemas/v1.PodIP'
+          type: array
+        qosClass:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodQOSClass'
+          description: 'The Quality of Service (QOS) classification assigned to the
+            pod based on resource requirements
+
+            See PodQOSClass type for available QOS classes
+
+            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#quality-of-service-classes
+
+            +optional'
+        reason:
+          description: 'A brief CamelCase message indicating details about why the
+            pod is in this state.
+
+            e.g. ''Evicted''
+
+            +optional'
+          type: string
+        resize:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodResizeStatus'
+          description: 'Status of resources resize desired for pod''s containers.
+
+            It is empty if no resources resize is pending.
+
+            Any changes to container resources will automatically set this to "Proposed"
+
+            Deprecated: Resize status is moved to two pod conditions PodResizePending
+            and PodResizeInProgress.
+
+            PodResizePending will track states where the spec has been resized, but
+            the Kubelet has not yet allocated the resources.
+
+            PodResizeInProgress will track in-progress resizes, and should be present
+            whenever allocated resources != acknowledged resources.
+
+            +featureGate=InPlacePodVerticalScaling
+
+            +optional'
+        resourceClaimStatuses:
+          description: 'Status of resource claims.
+
+            +patchMergeKey=name
+
+            +patchStrategy=merge,retainKeys
+
+            +listType=map
+
+            +listMapKey=name
+
+            +featureGate=DynamicResourceAllocation
+
+            +optional'
+          items:
+            $ref: '#/components/schemas/v1.PodResourceClaimStatus'
+          type: array
+        resources:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceRequirements'
+          description: 'Resources represents the compute resource requests and limits
+            that have been
+
+            applied at the pod level if pod-level requests or limits are set in
+
+            PodSpec.Resources
+
+            +featureGate=InPlacePodLevelResourcesVerticalScaling
+
+            +optional'
+        startTime:
+          description: 'RFC 3339 date and time at which the object was acknowledged
+            by the Kubelet.
+
+            This is before the Kubelet pulled the container image(s) for the pod.
+
+            +optional'
+          type: string
+      type: object
+    v1.PodTemplateSpec:
+      properties:
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/v1.ObjectMeta'
+          description: 'Standard object''s metadata.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+            +optional'
+        spec:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodSpec'
+          description: 'Specification of the desired behavior of the pod.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+            +optional'
       type: object
     v1.PolicyRule:
       properties:
@@ -32723,6 +40018,46 @@ components:
           items:
             type: string
           type: array
+      type: object
+    v1.PortworxVolumeSource:
+      properties:
+        fsType:
+          description: 'fSType represents the filesystem type to mount
+
+            Must be a filesystem type supported by the host operating system.
+
+            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.'
+          type: string
+        readOnly:
+          description: 'readOnly defaults to false (read/write). ReadOnly here will
+            force
+
+            the ReadOnly setting in VolumeMounts.
+
+            +optional'
+          type: boolean
+        volumeID:
+          description: volumeID uniquely identifies a Portworx volume
+          type: string
+      type: object
+    v1.PreemptionPolicy:
+      enum:
+      - PreemptLowerPriority
+      - Never
+      type: string
+      x-enum-varnames:
+      - PreemptLowerPriority
+      - PreemptNever
+    v1.PreferredSchedulingTerm:
+      properties:
+        preference:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeSelectorTerm'
+          description: A node selector term, associated with the corresponding weight.
+        weight:
+          description: Weight associated with matching the corresponding nodeSelectorTerm,
+            in the range 1-100.
+          type: integer
       type: object
     v1.Probe:
       properties:
@@ -32828,6 +40163,39 @@ components:
       x-enum-varnames:
       - DefaultProcMount
       - UnmaskedProcMount
+    v1.ProjectedVolumeSource:
+      properties:
+        defaultMode:
+          description: 'defaultMode are the mode bits used to set permissions on created
+            files by default.
+
+            Must be an octal value between 0000 and 0777 or a decimal value between
+            0 and 511.
+
+            YAML accepts both octal and decimal values, JSON requires decimal values
+            for mode bits.
+
+            Directories within the path are not affected by this setting.
+
+            This might be in conflict with other options that affect the file
+
+            mode, like fsGroup, and the result can be other mode bits set.
+
+            +optional'
+          type: integer
+        sources:
+          description: 'sources is the list of volume projections. Each entry in this
+            list
+
+            handles one source.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.VolumeProjection'
+          type: array
+      type: object
     v1.Protocol:
       enum:
       - TCP
@@ -32848,6 +40216,140 @@ components:
       - PullAlways
       - PullNever
       - PullIfNotPresent
+    v1.QuobyteVolumeSource:
+      properties:
+        group:
+          description: 'group to map volume access to
+
+            Default is no group
+
+            +optional'
+          type: string
+        readOnly:
+          description: 'readOnly here will force the Quobyte volume to be mounted
+            with read-only permissions.
+
+            Defaults to false.
+
+            +optional'
+          type: boolean
+        registry:
+          description: 'registry represents a single or multiple Quobyte Registry
+            services
+
+            specified as a string as host:port pair (multiple entries are separated
+            with commas)
+
+            which acts as the central registry for volumes'
+          type: string
+        tenant:
+          description: 'tenant owning the given Quobyte volume in the Backend
+
+            Used with dynamically provisioned Quobyte volumes, value is set by the
+            plugin
+
+            +optional'
+          type: string
+        user:
+          description: 'user to map volume access to
+
+            Defaults to serivceaccount user
+
+            +optional'
+          type: string
+        volume:
+          description: volume is a string that references an already created Quobyte
+            volume by name.
+          type: string
+      type: object
+    v1.RBDVolumeSource:
+      properties:
+        fsType:
+          description: 'fsType is the filesystem type of the volume that you want
+            to mount.
+
+            Tip: Ensure that the filesystem type is supported by the host operating
+            system.
+
+            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+
+            TODO: how do we prevent errors in the filesystem from compromising the
+            machine
+
+            +optional'
+          type: string
+        image:
+          description: 'image is the rados image name.
+
+            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+          type: string
+        keyring:
+          description: 'keyring is the path to key ring for RBDUser.
+
+            Default is /etc/ceph/keyring.
+
+            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+            +optional
+
+            +default="/etc/ceph/keyring"'
+          type: string
+        monitors:
+          description: 'monitors is a collection of Ceph monitors.
+
+            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+            +listType=atomic'
+          items:
+            type: string
+          type: array
+        pool:
+          description: 'pool is the rados pool name.
+
+            Default is rbd.
+
+            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+            +optional
+
+            +default="rbd"'
+          type: string
+        readOnly:
+          description: 'readOnly here will force the ReadOnly setting in VolumeMounts.
+
+            Defaults to false.
+
+            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+            +optional'
+          type: boolean
+        secretRef:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_core_v1.LocalObjectReference'
+          description: 'secretRef is name of the authentication secret for RBDUser.
+            If provided
+
+            overrides keyring.
+
+            Default is nil.
+
+            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+            +optional'
+        user:
+          description: 'user is the rados user name.
+
+            Default is admin.
+
+            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+            +optional
+
+            +default="admin"'
+          type: string
+      type: object
     v1.RecursiveReadOnlyMode:
       enum:
       - Disabled
@@ -32858,6 +40360,213 @@ components:
       - RecursiveReadOnlyDisabled
       - RecursiveReadOnlyIfPossible
       - RecursiveReadOnlyEnabled
+    v1.ReplicaSet:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object.
+
+            Servers should convert recognized schemas to the latest internal value,
+            and
+
+            may reject unrecognized values.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+            +optional'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents.
+
+            Servers may infer this from the endpoint the client submits requests to.
+
+            Cannot be updated.
+
+            In CamelCase.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+            +optional'
+          type: string
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/v1.ObjectMeta'
+          description: 'If the Labels of a ReplicaSet are empty, they are defaulted
+            to
+
+            be the same as the Pod(s) that the ReplicaSet manages.
+
+            Standard object''s metadata.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+            +optional'
+        spec:
+          allOf:
+          - $ref: '#/components/schemas/v1.ReplicaSetSpec'
+          description: 'Spec defines the specification of the desired behavior of
+            the ReplicaSet.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+            +optional'
+        status:
+          allOf:
+          - $ref: '#/components/schemas/v1.ReplicaSetStatus'
+          description: 'Status is the most recently observed status of the ReplicaSet.
+
+            This data may be out of date by some window of time.
+
+            Populated by the system.
+
+            Read-only.
+
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+            +optional'
+      type: object
+    v1.ReplicaSetCondition:
+      properties:
+        lastTransitionTime:
+          description: 'The last time the condition transitioned from one status to
+            another.
+
+            +optional'
+          type: string
+        message:
+          description: 'A human readable message indicating details about the transition.
+
+            +optional'
+          type: string
+        reason:
+          description: 'The reason for the condition''s last transition.
+
+            +optional'
+          type: string
+        status:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_core_v1.ConditionStatus'
+          description: Status of the condition, one of True, False, Unknown.
+        type:
+          allOf:
+          - $ref: '#/components/schemas/v1.ReplicaSetConditionType'
+          description: Type of replica set condition.
+      type: object
+    v1.ReplicaSetConditionType:
+      enum:
+      - ReplicaFailure
+      type: string
+      x-enum-varnames:
+      - ReplicaSetReplicaFailure
+    v1.ReplicaSetSpec:
+      properties:
+        minReadySeconds:
+          description: 'Minimum number of seconds for which a newly created pod should
+            be ready
+
+            without any of its container crashing, for it to be considered available.
+
+            Defaults to 0 (pod will be considered available as soon as it is ready)
+
+            +optional'
+          type: integer
+        replicas:
+          description: 'Replicas is the number of desired pods.
+
+            This is a pointer to distinguish between explicit zero and unspecified.
+
+            Defaults to 1.
+
+            More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset
+
+            +optional'
+          type: integer
+        selector:
+          allOf:
+          - $ref: '#/components/schemas/v1.LabelSelector'
+          description: 'Selector is a label query over pods that should match the
+            replica count.
+
+            Label keys and values that must match in order to be controlled by this
+            replica set.
+
+            It must match the pod template''s labels.
+
+            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+        template:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodTemplateSpec'
+          description: 'Template is the object that describes the pod that will be
+            created if
+
+            insufficient replicas are detected.
+
+            More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/#pod-template
+
+            +optional'
+      type: object
+    v1.ReplicaSetStatus:
+      properties:
+        availableReplicas:
+          description: 'The number of available non-terminating pods (ready for at
+            least minReadySeconds) for this replica set.
+
+            +optional'
+          type: integer
+        conditions:
+          description: 'Represents the latest available observations of a replica
+            set''s current state.
+
+            +optional
+
+            +patchMergeKey=type
+
+            +patchStrategy=merge
+
+            +listType=map
+
+            +listMapKey=type'
+          items:
+            $ref: '#/components/schemas/v1.ReplicaSetCondition'
+          type: array
+        fullyLabeledReplicas:
+          description: 'The number of non-terminating pods that have labels matching
+            the labels of the pod template of the replicaset.
+
+            +optional'
+          type: integer
+        observedGeneration:
+          description: 'ObservedGeneration reflects the generation of the most recently
+            observed ReplicaSet.
+
+            +optional'
+          type: integer
+        readyReplicas:
+          description: 'The number of non-terminating pods targeted by this ReplicaSet
+            with a Ready Condition.
+
+            +optional'
+          type: integer
+        replicas:
+          description: 'Replicas is the most recently observed number of non-terminating
+            pods.
+
+            More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset'
+          type: integer
+        terminatingReplicas:
+          description: 'The number of terminating pods for this replica set. Terminating
+            pods have a non-null .metadata.deletionTimestamp
+
+            and have not yet reached the Failed or Succeeded .status.phase.
+
+
+            This is a beta field and requires enabling DeploymentReplicaSetTerminatingReplicas
+            feature (enabled by default).
+
+            +optional'
+          type: integer
+      type: object
     v1.ResourceFieldSelector:
       properties:
         containerName:
@@ -32876,6 +40585,33 @@ components:
           description: 'Required: resource to select'
           type: string
       type: object
+    v1.ResourceHealth:
+      properties:
+        health:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceHealthStatus'
+          description: "Health of the resource.\ncan be one of:\n - Healthy: operates\
+            \ as normal\n - Unhealthy: reported unhealthy. We consider this a temporary\
+            \ health issue\n              since we do not have a mechanism today to\
+            \ distinguish\n              temporary and permanent issues.\n - Unknown:\
+            \ The status cannot be determined.\n            For example, Device Plugin\
+            \ got unregistered and hasn't been re-registered since.\n\nIn future we\
+            \ may want to introduce the PermanentlyUnhealthy Status."
+        resourceID:
+          description: ResourceID is the unique identifier of the resource. See the
+            ResourceID type for more information.
+          type: string
+      type: object
+    v1.ResourceHealthStatus:
+      enum:
+      - Healthy
+      - Unhealthy
+      - Unknown
+      type: string
+      x-enum-varnames:
+      - ResourceHealthStatusHealthy
+      - ResourceHealthStatusUnhealthy
+      - ResourceHealthStatusUnknown
     v1.ResourceList:
       additionalProperties:
         $ref: '#/components/schemas/resource.Quantity'
@@ -33107,6 +40843,50 @@ components:
       x-enum-varnames:
       - NotRequired
       - RestartContainer
+    v1.ResourceStatus:
+      properties:
+        name:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceName'
+          description: 'Name of the resource. Must be unique within the pod and in
+            case of non-DRA resource, match one of the resources from the pod spec.
+
+            For DRA resources, the value must be "claim:<claim_name>/<request>".
+
+            When this status is reported about a container, the "claim_name" and "request"
+            must match one of the claims of this container.
+
+            +required'
+        resources:
+          description: 'List of unique resources health. Each element in the list
+            contains an unique resource ID and its health.
+
+            At a minimum, for the lifetime of a Pod, resource ID must uniquely identify
+            the resource allocated to the Pod on the Node.
+
+            If other Pod on the same Node reports the status with the same resource
+            ID, it must be the same resource they share.
+
+            See ResourceID type definition for a specific format it has in various
+            use cases.
+
+            +listType=map
+
+            +listMapKey=resourceID'
+          items:
+            $ref: '#/components/schemas/v1.ResourceHealth'
+          type: array
+      type: object
+    v1.RestartPolicy:
+      enum:
+      - Always
+      - OnFailure
+      - Never
+      type: string
+      x-enum-varnames:
+      - RestartPolicyAlways
+      - RestartPolicyOnFailure
+      - RestartPolicyNever
     v1.RoleRef:
       properties:
         apiGroup:
@@ -33122,6 +40902,70 @@ components:
 
             +k8s:required'
           type: string
+      type: object
+    v1.RollingUpdateDeployment:
+      properties:
+        maxSurge:
+          allOf:
+          - $ref: '#/components/schemas/intstr.IntOrString'
+          description: 'The maximum number of pods that can be scheduled above the
+            desired number of
+
+            pods.
+
+            Value can be an absolute number (ex: 5) or a percentage of desired pods
+            (ex: 10%).
+
+            This can not be 0 if MaxUnavailable is 0.
+
+            Absolute number is calculated from percentage by rounding up.
+
+            Defaults to 25%.
+
+            Example: when this is set to 30%, the new ReplicaSet can be scaled up
+            immediately when
+
+            the rolling update starts, such that the total number of old and new pods
+            do not exceed
+
+            130% of desired pods. Once old pods have been killed,
+
+            new ReplicaSet can be scaled up further, ensuring that total number of
+            pods running
+
+            at any time during the update is at most 130% of desired pods.
+
+            +optional'
+        maxUnavailable:
+          allOf:
+          - $ref: '#/components/schemas/intstr.IntOrString'
+          description: 'The maximum number of pods that can be unavailable during
+            the update.
+
+            Value can be an absolute number (ex: 5) or a percentage of desired pods
+            (ex: 10%).
+
+            Absolute number is calculated from percentage by rounding down.
+
+            This can not be 0 if MaxSurge is 0.
+
+            Defaults to 25%.
+
+            Example: when this is set to 30%, the old ReplicaSet can be scaled down
+            to 70% of desired pods
+
+            immediately when the rolling update starts. Once new pods are ready, old
+            ReplicaSet
+
+            can be scaled down further, followed by scaling up the new ReplicaSet,
+            ensuring
+
+            that the total number of pods available at all times during the update
+            is at
+
+            least 70% of desired pods.
+
+            +optional'
       type: object
     v1.SELinuxOptions:
       properties:
@@ -33144,6 +40988,76 @@ components:
           description: 'User is a SELinux user label that applies to the container.
 
             +optional'
+          type: string
+      type: object
+    v1.ScaleIOVolumeSource:
+      properties:
+        fsType:
+          description: 'fsType is the filesystem type to mount.
+
+            Must be a filesystem type supported by the host operating system.
+
+            Ex. "ext4", "xfs", "ntfs".
+
+            Default is "xfs".
+
+            +optional
+
+            +default="xfs"'
+          type: string
+        gateway:
+          description: gateway is the host address of the ScaleIO API Gateway.
+          type: string
+        protectionDomain:
+          description: 'protectionDomain is the name of the ScaleIO Protection Domain
+            for the configured storage.
+
+            +optional'
+          type: string
+        readOnly:
+          description: 'readOnly Defaults to false (read/write). ReadOnly here will
+            force
+
+            the ReadOnly setting in VolumeMounts.
+
+            +optional'
+          type: boolean
+        secretRef:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_core_v1.LocalObjectReference'
+          description: 'secretRef references to the secret for ScaleIO user and other
+
+            sensitive information. If this is not provided, Login operation will fail.'
+        sslEnabled:
+          description: 'sslEnabled Flag enable/disable SSL communication with Gateway,
+            default false
+
+            +optional'
+          type: boolean
+        storageMode:
+          description: 'storageMode indicates whether the storage for a volume should
+            be ThickProvisioned or ThinProvisioned.
+
+            Default is ThinProvisioned.
+
+            +optional
+
+            +default="ThinProvisioned"'
+          type: string
+        storagePool:
+          description: 'storagePool is the ScaleIO Storage Pool associated with the
+            protection domain.
+
+            +optional'
+          type: string
+        system:
+          description: system is the name of the storage system as configured in ScaleIO.
+          type: string
+        volumeName:
+          description: 'volumeName is the name of a volume already created in the
+            ScaleIO system
+
+            that is associated with this volume source.'
           type: string
       type: object
     v1.ScopeSelector:
@@ -33301,6 +41215,58 @@ components:
             +optional'
           type: boolean
       type: object
+    v1.SecretProjection:
+      properties:
+        items:
+          description: 'items if unspecified, each key-value pair in the Data field
+            of the referenced
+
+            Secret will be projected into the volume as a file whose name is the
+
+            key and content is the value. If specified, the listed keys will be
+
+            projected into the specified paths, and unlisted keys will not be
+
+            present. If a key is specified which is not present in the Secret,
+
+            the volume setup will error unless it is marked optional. Paths must be
+
+            relative and may not contain the ''..'' path or start with ''..''.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.KeyToPath'
+          type: array
+        name:
+          description: 'Name of the referent.
+
+            This field is effectively required, but due to backwards compatibility
+            is
+
+            allowed to be empty. Instances of this type with an empty value here are
+
+            almost certainly wrong.
+
+            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+            +optional
+
+            +default=""
+
+            +kubebuilder:default=""
+
+            TODO: Drop `kubebuilder:default` when controller-gen doesn''t need it
+            https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
+          type: string
+        optional:
+          description: 'optional field specify whether the Secret or its key must
+            be defined
+
+            +optional'
+          type: boolean
+      type: object
     v1.SecretReference:
       properties:
         name:
@@ -33311,6 +41277,64 @@ components:
         namespace:
           description: 'namespace defines the space within which the secret name must
             be unique.
+
+            +optional'
+          type: string
+      type: object
+    v1.SecretVolumeSource:
+      properties:
+        defaultMode:
+          description: 'defaultMode is Optional: mode bits used to set permissions
+            on created files by default.
+
+            Must be an octal value between 0000 and 0777 or a decimal value between
+            0 and 511.
+
+            YAML accepts both octal and decimal values, JSON requires decimal values
+
+            for mode bits. Defaults to 0644.
+
+            Directories within the path are not affected by this setting.
+
+            This might be in conflict with other options that affect the file
+
+            mode, like fsGroup, and the result can be other mode bits set.
+
+            +optional'
+          type: integer
+        items:
+          description: 'items If unspecified, each key-value pair in the Data field
+            of the referenced
+
+            Secret will be projected into the volume as a file whose name is the
+
+            key and content is the value. If specified, the listed keys will be
+
+            projected into the specified paths, and unlisted keys will not be
+
+            present. If a key is specified which is not present in the Secret,
+
+            the volume setup will error unless it is marked optional. Paths must be
+
+            relative and may not contain the ''..'' path or start with ''..''.
+
+            +optional
+
+            +listType=atomic'
+          items:
+            $ref: '#/components/schemas/v1.KeyToPath'
+          type: array
+        optional:
+          description: 'optional field specify whether the Secret or its keys must
+            be defined
+
+            +optional'
+          type: boolean
+        secretName:
+          description: 'secretName is the name of the secret in the pod''s namespace
+            to use.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
 
             +optional'
           type: string
@@ -33480,6 +41504,47 @@ components:
 
             +optional'
       type: object
+    v1.ServiceAccountTokenProjection:
+      properties:
+        audience:
+          description: 'audience is the intended audience of the token. A recipient
+            of a token
+
+            must identify itself with an identifier specified in the audience of the
+
+            token, and otherwise should reject the token. The audience defaults to
+            the
+
+            identifier of the apiserver.
+
+            +optional'
+          type: string
+        expirationSeconds:
+          description: 'expirationSeconds is the requested duration of validity of
+            the service
+
+            account token. As the token approaches expiration, the kubelet volume
+
+            plugin will proactively rotate the service account token. The kubelet
+            will
+
+            start trying to rotate the token if the token is older than 80 percent
+            of
+
+            its time to live or if the token is older than 24 hours.Defaults to 1
+            hour
+
+            and must be at least 10 minutes.
+
+            +optional'
+          type: integer
+        path:
+          description: 'path is the path relative to the mount point of the file to
+            project the
+
+            token into.'
+          type: string
+      type: object
     v1.Signal:
       enum:
       - SIGABRT
@@ -33620,6 +41685,98 @@ components:
           description: Seconds is the number of seconds to sleep.
           type: integer
       type: object
+    v1.StorageMedium:
+      enum:
+      - ''
+      - Memory
+      - HugePages
+      - HugePages-
+      type: string
+      x-enum-comments:
+        StorageMediumDefault: use whatever the default is for the node, assume anything
+          we don't explicitly handle is this
+        StorageMediumHugePages: use hugepages
+        StorageMediumHugePagesPrefix: prefix for full medium notation HugePages-<size>
+        StorageMediumMemory: use memory (e.g. tmpfs on linux)
+      x-enum-descriptions:
+      - use whatever the default is for the node, assume anything we don't explicitly
+        handle is this
+      - use memory (e.g. tmpfs on linux)
+      - use hugepages
+      - prefix for full medium notation HugePages-<size>
+      x-enum-varnames:
+      - StorageMediumDefault
+      - StorageMediumMemory
+      - StorageMediumHugePages
+      - StorageMediumHugePagesPrefix
+    v1.StorageOSVolumeSource:
+      properties:
+        fsType:
+          description: 'fsType is the filesystem type to mount.
+
+            Must be a filesystem type supported by the host operating system.
+
+            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+            +optional'
+          type: string
+        readOnly:
+          description: 'readOnly defaults to false (read/write). ReadOnly here will
+            force
+
+            the ReadOnly setting in VolumeMounts.
+
+            +optional'
+          type: boolean
+        secretRef:
+          allOf:
+          - $ref: '#/components/schemas/k8s_io_api_core_v1.LocalObjectReference'
+          description: 'secretRef specifies the secret to use for obtaining the StorageOS
+            API
+
+            credentials.  If not specified, default values will be attempted.
+
+            +optional'
+        volumeName:
+          description: 'volumeName is the human-readable name of the StorageOS volume.  Volume
+
+            names are only unique within a namespace.'
+          type: string
+        volumeNamespace:
+          description: 'volumeNamespace specifies the scope of the volume within StorageOS.  If
+            no
+
+            namespace is specified then the Pod''s namespace will be used.  This allows
+            the
+
+            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+
+            Set VolumeName to any name to override the default behaviour.
+
+            Set to "default" if you are not using namespaces within StorageOS.
+
+            Namespaces that do not pre-exist within StorageOS will be created.
+
+            +optional'
+          type: string
+      type: object
+    v1.SupplementalGroupsPolicy:
+      enum:
+      - Merge
+      - Strict
+      type: string
+      x-enum-varnames:
+      - SupplementalGroupsPolicyMerge
+      - SupplementalGroupsPolicyStrict
+    v1.Sysctl:
+      properties:
+        name:
+          description: Name of a property to set
+          type: string
+        value:
+          description: Value of a property to set
+          type: string
+      type: object
     v1.TCPSocketAction:
       properties:
         host:
@@ -33678,6 +41835,349 @@ components:
       x-enum-varnames:
       - TerminationMessageReadFile
       - TerminationMessageFallbackToLogsOnError
+    v1.Toleration:
+      properties:
+        effect:
+          allOf:
+          - $ref: '#/components/schemas/v1.TaintEffect'
+          description: 'Effect indicates the taint effect to match. Empty means match
+            all taint effects.
+
+            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+            +optional'
+        key:
+          description: 'Key is the taint key that the toleration applies to. Empty
+            means match all taint keys.
+
+            If the key is empty, operator must be Exists; this combination means to
+            match all values and all keys.
+
+            +optional'
+          type: string
+        operator:
+          allOf:
+          - $ref: '#/components/schemas/v1.TolerationOperator'
+          description: 'Operator represents a key''s relationship to the value.
+
+            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+
+            Exists is equivalent to wildcard for value, so that a pod can
+
+            tolerate all taints of a particular category.
+
+            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+
+            +optional'
+        tolerationSeconds:
+          description: 'TolerationSeconds represents the period of time the toleration
+            (which must be
+
+            of effect NoExecute, otherwise this field is ignored) tolerates the taint.
+            By default,
+
+            it is not set, which means tolerate the taint forever (do not evict).
+            Zero and
+
+            negative values will be treated as 0 (evict immediately) by the system.
+
+            +optional'
+          type: integer
+        value:
+          description: 'Value is the taint value the toleration matches to.
+
+            If the operator is Exists, the value should be empty, otherwise just a
+            regular string.
+
+            +optional'
+          type: string
+      type: object
+    v1.TolerationOperator:
+      enum:
+      - Exists
+      - Equal
+      - Lt
+      - Gt
+      type: string
+      x-enum-varnames:
+      - TolerationOpExists
+      - TolerationOpEqual
+      - TolerationOpLt
+      - TolerationOpGt
+    v1.TopologySpreadConstraint:
+      properties:
+        labelSelector:
+          allOf:
+          - $ref: '#/components/schemas/v1.LabelSelector'
+          description: 'LabelSelector is used to find matching pods.
+
+            Pods that match this label selector are counted to determine the number
+            of pods
+
+            in their corresponding topology domain.
+
+            +optional'
+        matchLabelKeys:
+          description: 'MatchLabelKeys is a set of pod label keys to select the pods
+            over which
+
+            spreading will be calculated. The keys are used to lookup values from
+            the
+
+            incoming pod labels, those key-value labels are ANDed with labelSelector
+
+            to select the group of existing pods over which spreading will be calculated
+
+            for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys
+            and LabelSelector.
+
+            MatchLabelKeys cannot be set when LabelSelector isn''t set.
+
+            Keys that don''t exist in the incoming pod labels will
+
+            be ignored. A null or empty list means only match against labelSelector.
+
+
+            This is a beta field and requires the MatchLabelKeysInPodTopologySpread
+            feature gate to be enabled (enabled by default).
+
+            +listType=atomic
+
+            +optional'
+          items:
+            type: string
+          type: array
+        maxSkew:
+          description: 'MaxSkew describes the degree to which pods may be unevenly
+            distributed.
+
+            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+
+            between the number of matching pods in the target topology and the global
+            minimum.
+
+            The global minimum is the minimum number of matching pods in an eligible
+            domain
+
+            or zero if the number of eligible domains is less than MinDomains.
+
+            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the
+            same
+
+            labelSelector spread as 2/2/1:
+
+            In this case, the global minimum is 1.
+
+            +-------+-------+-------+
+
+            | zone1 | zone2 | zone3 |
+
+            +-------+-------+-------+
+
+            |  P P  |  P P  |   P   |
+
+            +-------+-------+-------+
+
+            - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become
+            2/2/2;
+
+            scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+
+            violate MaxSkew(1).
+
+            - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+
+            When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+
+            to topologies that satisfy it.
+
+            It''s a required field. Default value is 1 and 0 is not allowed.'
+          type: integer
+        minDomains:
+          description: 'MinDomains indicates a minimum number of eligible domains.
+
+            When the number of eligible domains with matching topology keys is less
+            than minDomains,
+
+            Pod Topology Spread treats "global minimum" as 0, and then the calculation
+            of Skew is performed.
+
+            And when the number of eligible domains with matching topology keys equals
+            or greater than minDomains,
+
+            this value has no effect on scheduling.
+
+            As a result, when the number of eligible domains is less than minDomains,
+
+            scheduler won''t schedule more than maxSkew Pods to those domains.
+
+            If value is nil, the constraint behaves as if MinDomains is equal to 1.
+
+            Valid values are integers greater than 0.
+
+            When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+            For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set
+            to 5 and pods with the same
+
+            labelSelector spread as 2/2/2:
+
+            +-------+-------+-------+
+
+            | zone1 | zone2 | zone3 |
+
+            +-------+-------+-------+
+
+            |  P P  |  P P  |  P P  |
+
+            +-------+-------+-------+
+
+            The number of domains is less than 5(MinDomains), so "global minimum"
+            is treated as 0.
+
+            In this situation, new pod with the same labelSelector cannot be scheduled,
+
+            because computed skew will be 3(3 - 0) if new Pod is scheduled to any
+            of the three zones,
+
+            it will violate MaxSkew.
+
+            +optional'
+          type: integer
+        nodeAffinityPolicy:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeInclusionPolicy'
+          description: 'NodeAffinityPolicy indicates how we will treat Pod''s nodeAffinity/nodeSelector
+
+            when calculating pod topology spread skew. Options are:
+
+            - Honor: only nodes matching nodeAffinity/nodeSelector are included in
+            the calculations.
+
+            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included
+            in the calculations.
+
+
+            If this value is nil, the behavior is equivalent to the Honor policy.
+
+            +optional'
+        nodeTaintsPolicy:
+          allOf:
+          - $ref: '#/components/schemas/v1.NodeInclusionPolicy'
+          description: 'NodeTaintsPolicy indicates how we will treat node taints when
+            calculating
+
+            pod topology spread skew. Options are:
+
+            - Honor: nodes without taints, along with tainted nodes for which the
+            incoming pod
+
+            has a toleration, are included.
+
+            - Ignore: node taints are ignored. All nodes are included.
+
+
+            If this value is nil, the behavior is equivalent to the Ignore policy.
+
+            +optional'
+        topologyKey:
+          description: 'TopologyKey is the key of node labels. Nodes that have a label
+            with this key
+
+            and identical values are considered to be in the same topology.
+
+            We consider each <key, value> as a "bucket", and try to put balanced number
+
+            of pods into each bucket.
+
+            We define a domain as a particular instance of a topology.
+
+            Also, we define an eligible domain as a domain whose nodes meet the requirements
+            of
+
+            nodeAffinityPolicy and nodeTaintsPolicy.
+
+            e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain
+            of that topology.
+
+            And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain
+            of that topology.
+
+            It''s a required field.'
+          type: string
+        whenUnsatisfiable:
+          allOf:
+          - $ref: '#/components/schemas/v1.UnsatisfiableConstraintAction'
+          description: "WhenUnsatisfiable indicates how to deal with a pod if it doesn't\
+            \ satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the\
+            \ scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler\
+            \ to schedule the pod in any location,\n  but giving higher precedence\
+            \ to topologies that would help reduce the\n  skew.\nA constraint is considered\
+            \ \"Unsatisfiable\" for an incoming pod\nif and only if every possible\
+            \ node assignment for that pod would violate\n\"MaxSkew\" on some topology.\n\
+            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the\
+            \ same\nlabelSelector spread as 3/1/1:\n+-------+-------+-------+\n| zone1\
+            \ | zone2 | zone3 |\n+-------+-------+-------+\n| P P P |   P   |   P\
+            \   |\n+-------+-------+-------+\nIf WhenUnsatisfiable is set to DoNotSchedule,\
+            \ incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2)\
+            \ as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words,\
+            \ the cluster can still be imbalanced, but scheduler\nwon't make it *more*\
+            \ imbalanced.\nIt's a required field."
+      type: object
+    v1.TypedLocalObjectReference:
+      properties:
+        apiGroup:
+          description: 'APIGroup is the group for the resource being referenced.
+
+            If APIGroup is not specified, the specified Kind must be in the core API
+            group.
+
+            For any other third-party types, APIGroup is required.
+
+            +optional'
+          type: string
+        kind:
+          description: Kind is the type of resource being referenced
+          type: string
+        name:
+          description: Name is the name of resource being referenced
+          type: string
+      type: object
+    v1.TypedObjectReference:
+      properties:
+        apiGroup:
+          description: 'APIGroup is the group for the resource being referenced.
+
+            If APIGroup is not specified, the specified Kind must be in the core API
+            group.
+
+            For any other third-party types, APIGroup is required.
+
+            +optional'
+          type: string
+        kind:
+          description: Kind is the type of resource being referenced
+          type: string
+        name:
+          description: Name is the name of resource being referenced
+          type: string
+        namespace:
+          description: 'Namespace is the namespace of resource being referenced
+
+            Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
+            object is required in the referent namespace to allow that namespace''s
+            owner to accept the reference. See the ReferenceGrant documentation for
+            details.
+
+            (Alpha) This field requires the CrossNamespaceVolumeDataSource feature
+            gate to be enabled.
+
+            +featureGate=CrossNamespaceVolumeDataSource
+
+            +optional'
+          type: string
+      type: object
     v1.URIScheme:
       enum:
       - HTTP
@@ -33686,6 +42186,390 @@ components:
       x-enum-varnames:
       - URISchemeHTTP
       - URISchemeHTTPS
+    v1.UnsatisfiableConstraintAction:
+      enum:
+      - DoNotSchedule
+      - ScheduleAnyway
+      type: string
+      x-enum-varnames:
+      - DoNotSchedule
+      - ScheduleAnyway
+    v1.Volume:
+      properties:
+        awsElasticBlockStore:
+          allOf:
+          - $ref: '#/components/schemas/v1.AWSElasticBlockStoreVolumeSource'
+          description: 'awsElasticBlockStore represents an AWS Disk resource that
+            is attached to a
+
+            kubelet''s host machine and then exposed to the pod.
+
+            Deprecated: AWSElasticBlockStore is deprecated. All operations for the
+            in-tree
+
+            awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+            +optional'
+        azureDisk:
+          allOf:
+          - $ref: '#/components/schemas/v1.AzureDiskVolumeSource'
+          description: 'azureDisk represents an Azure Data Disk mount on the host
+            and bind mount to the pod.
+
+            Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk
+            type
+
+            are redirected to the disk.csi.azure.com CSI driver.
+
+            +optional'
+        azureFile:
+          allOf:
+          - $ref: '#/components/schemas/v1.AzureFileVolumeSource'
+          description: 'azureFile represents an Azure File Service mount on the host
+            and bind mount to the pod.
+
+            Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile
+            type
+
+            are redirected to the file.csi.azure.com CSI driver.
+
+            +optional'
+        cephfs:
+          allOf:
+          - $ref: '#/components/schemas/v1.CephFSVolumeSource'
+          description: 'cephFS represents a Ceph FS mount on the host that shares
+            a pod''s lifetime.
+
+            Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer
+            supported.
+
+            +optional'
+        cinder:
+          allOf:
+          - $ref: '#/components/schemas/v1.CinderVolumeSource'
+          description: 'cinder represents a cinder volume attached and mounted on
+            kubelets host machine.
+
+            Deprecated: Cinder is deprecated. All operations for the in-tree cinder
+            type
+
+            are redirected to the cinder.csi.openstack.org CSI driver.
+
+            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+            +optional'
+        configMap:
+          allOf:
+          - $ref: '#/components/schemas/v1.ConfigMapVolumeSource'
+          description: 'configMap represents a configMap that should populate this
+            volume
+
+            +optional'
+        csi:
+          allOf:
+          - $ref: '#/components/schemas/v1.CSIVolumeSource'
+          description: 'csi (Container Storage Interface) represents ephemeral storage
+            that is handled by certain external CSI drivers.
+
+            +optional'
+        downwardAPI:
+          allOf:
+          - $ref: '#/components/schemas/v1.DownwardAPIVolumeSource'
+          description: 'downwardAPI represents downward API about the pod that should
+            populate this volume
+
+            +optional'
+        emptyDir:
+          allOf:
+          - $ref: '#/components/schemas/v1.EmptyDirVolumeSource'
+          description: 'emptyDir represents a temporary directory that shares a pod''s
+            lifetime.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+
+            +optional'
+        ephemeral:
+          allOf:
+          - $ref: '#/components/schemas/v1.EphemeralVolumeSource'
+          description: "ephemeral represents a volume that is handled by a cluster\
+            \ storage driver.\nThe volume's lifecycle is tied to the pod that defines\
+            \ it - it will be created before the pod starts,\nand deleted when the\
+            \ pod is removed.\n\nUse this if:\na) the volume is only needed while\
+            \ the pod runs,\nb) features of normal volumes like restoring from snapshot\
+            \ or capacity\n   tracking are needed,\nc) the storage driver is specified\
+            \ through a storage class, and\nd) the storage driver supports dynamic\
+            \ volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource\
+            \ for more\n   information on the connection between this volume type\n\
+            \   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of\
+            \ the vendor-specific\nAPIs for volumes that persist for longer than the\
+            \ lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral\
+            \ volumes if the CSI driver is meant to\nbe used that way - see the documentation\
+            \ of the driver for\nmore information.\n\nA pod can use both types of\
+            \ ephemeral volumes and\npersistent volumes at the same time.\n\n+optional"
+        fc:
+          allOf:
+          - $ref: '#/components/schemas/v1.FCVolumeSource'
+          description: 'fc represents a Fibre Channel resource that is attached to
+            a kubelet''s host machine and then exposed to the pod.
+
+            +optional'
+        flexVolume:
+          allOf:
+          - $ref: '#/components/schemas/v1.FlexVolumeSource'
+          description: 'flexVolume represents a generic volume resource that is
+
+            provisioned/attached using an exec based plugin.
+
+            Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+
+            +optional'
+        flocker:
+          allOf:
+          - $ref: '#/components/schemas/v1.FlockerVolumeSource'
+          description: 'flocker represents a Flocker volume attached to a kubelet''s
+            host machine. This depends on the Flocker control service being running.
+
+            Deprecated: Flocker is deprecated and the in-tree flocker type is no longer
+            supported.
+
+            +optional'
+        gcePersistentDisk:
+          allOf:
+          - $ref: '#/components/schemas/v1.GCEPersistentDiskVolumeSource'
+          description: 'gcePersistentDisk represents a GCE Disk resource that is attached
+            to a
+
+            kubelet''s host machine and then exposed to the pod.
+
+            Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+
+            gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI
+            driver.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+            +optional'
+        gitRepo:
+          allOf:
+          - $ref: '#/components/schemas/v1.GitRepoVolumeSource'
+          description: 'gitRepo represents a git repository at a particular revision.
+
+            Deprecated: GitRepo is deprecated. To provision a container with a git
+            repo, mount an
+
+            EmptyDir into an InitContainer that clones the repo using git, then mount
+            the EmptyDir
+
+            into the Pod''s container.
+
+            +optional'
+        glusterfs:
+          allOf:
+          - $ref: '#/components/schemas/v1.GlusterfsVolumeSource'
+          description: 'glusterfs represents a Glusterfs mount on the host that shares
+            a pod''s lifetime.
+
+            Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is
+            no longer supported.
+
+            +optional'
+        hostPath:
+          allOf:
+          - $ref: '#/components/schemas/v1.HostPathVolumeSource'
+          description: 'hostPath represents a pre-existing file or directory on the
+            host
+
+            machine that is directly exposed to the container. This is generally
+
+            used for system agents or other privileged things that are allowed
+
+            to see the host machine. Most containers will NOT need this.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+            ---
+
+            TODO(jonesdl) We need to restrict who can use host directory mounts and
+            who can/can not
+
+            mount host directories as read/write.
+
+            +optional'
+        image:
+          allOf:
+          - $ref: '#/components/schemas/v1.ImageVolumeSource'
+          description: 'image represents an OCI object (a container image or artifact)
+            pulled and mounted on the kubelet''s host machine.
+
+            The volume is resolved at pod startup depending on which PullPolicy value
+            is provided:
+
+
+            - Always: the kubelet always attempts to pull the reference. Container
+            creation will fail If the pull fails.
+
+            - Never: the kubelet never pulls the reference and only uses a local image
+            or artifact. Container creation will fail if the reference isn''t present.
+
+            - IfNotPresent: the kubelet pulls if the reference isn''t already present
+            on disk. Container creation will fail if the reference isn''t present
+            and the pull fails.
+
+
+            The volume gets re-resolved if the pod gets deleted and recreated, which
+            means that new remote content will become available on pod recreation.
+
+            A failure to resolve or pull the image during pod startup will block containers
+            from starting and may add significant latency. Failures will be retried
+            using normal volume backoff and will be reported on the pod reason and
+            message.
+
+            The types of objects that may be mounted by this volume are defined by
+            the container runtime implementation on a host machine and at minimum
+            must include all valid types supported by the container image field.
+
+            The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath)
+            by merging the manifest layers in the same way as for container images.
+
+            The volume will be mounted read-only (ro) and non-executable files (noexec).
+
+            Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath)
+            before 1.33.
+
+            The field spec.securityContext.fsGroupChangePolicy has no effect on this
+            volume type.
+
+            +featureGate=ImageVolume
+
+            +optional'
+        iscsi:
+          allOf:
+          - $ref: '#/components/schemas/v1.ISCSIVolumeSource'
+          description: 'iscsi represents an ISCSI Disk resource that is attached to
+            a
+
+            kubelet''s host machine and then exposed to the pod.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+
+            +optional'
+        name:
+          description: 'name of the volume.
+
+            Must be a DNS_LABEL and unique within the pod.
+
+            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+          type: string
+        nfs:
+          allOf:
+          - $ref: '#/components/schemas/v1.NFSVolumeSource'
+          description: 'nfs represents an NFS mount on the host that shares a pod''s
+            lifetime
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+            +optional'
+        persistentVolumeClaim:
+          allOf:
+          - $ref: '#/components/schemas/v1.PersistentVolumeClaimVolumeSource'
+          description: 'persistentVolumeClaimVolumeSource represents a reference to
+            a
+
+            PersistentVolumeClaim in the same namespace.
+
+            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+
+            +optional'
+        photonPersistentDisk:
+          allOf:
+          - $ref: '#/components/schemas/v1.PhotonPersistentDiskVolumeSource'
+          description: 'photonPersistentDisk represents a PhotonController persistent
+            disk attached and mounted on kubelets host machine.
+
+            Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk
+            type is no longer supported.'
+        portworxVolume:
+          allOf:
+          - $ref: '#/components/schemas/v1.PortworxVolumeSource'
+          description: 'portworxVolume represents a portworx volume attached and mounted
+            on kubelets host machine.
+
+            Deprecated: PortworxVolume is deprecated. All operations for the in-tree
+            portworxVolume type
+
+            are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx
+            feature-gate
+
+            is on.
+
+            +optional'
+        projected:
+          allOf:
+          - $ref: '#/components/schemas/v1.ProjectedVolumeSource'
+          description: projected items for all in one resources secrets, configmaps,
+            and downward API
+        quobyte:
+          allOf:
+          - $ref: '#/components/schemas/v1.QuobyteVolumeSource'
+          description: 'quobyte represents a Quobyte mount on the host that shares
+            a pod''s lifetime.
+
+            Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer
+            supported.
+
+            +optional'
+        rbd:
+          allOf:
+          - $ref: '#/components/schemas/v1.RBDVolumeSource'
+          description: 'rbd represents a Rados Block Device mount on the host that
+            shares a pod''s lifetime.
+
+            Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+
+            +optional'
+        scaleIO:
+          allOf:
+          - $ref: '#/components/schemas/v1.ScaleIOVolumeSource'
+          description: 'scaleIO represents a ScaleIO persistent volume attached and
+            mounted on Kubernetes nodes.
+
+            Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer
+            supported.
+
+            +optional'
+        secret:
+          allOf:
+          - $ref: '#/components/schemas/v1.SecretVolumeSource'
+          description: 'secret represents a secret that should populate this volume.
+
+            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+
+            +optional'
+        storageos:
+          allOf:
+          - $ref: '#/components/schemas/v1.StorageOSVolumeSource'
+          description: 'storageOS represents a StorageOS volume attached and mounted
+            on Kubernetes nodes.
+
+            Deprecated: StorageOS is deprecated and the in-tree storageos type is
+            no longer supported.
+
+            +optional'
+        vsphereVolume:
+          allOf:
+          - $ref: '#/components/schemas/v1.VsphereVirtualDiskVolumeSource'
+          description: 'vsphereVolume represents a vSphere volume attached and mounted
+            on kubelets host machine.
+
+            Deprecated: VsphereVolume is deprecated. All operations for the in-tree
+            vsphereVolume type
+
+            are redirected to the csi.vsphere.vmware.com CSI driver.
+
+            +optional'
+      type: object
     v1.VolumeDevice:
       properties:
         devicePath:
@@ -33794,6 +42678,227 @@ components:
             +optional'
           type: string
       type: object
+    v1.VolumeMountStatus:
+      properties:
+        mountPath:
+          description: MountPath corresponds to the original VolumeMount.
+          type: string
+        name:
+          description: Name corresponds to the name of the original VolumeMount.
+          type: string
+        readOnly:
+          description: 'ReadOnly corresponds to the original VolumeMount.
+
+            +optional'
+          type: boolean
+        recursiveReadOnly:
+          allOf:
+          - $ref: '#/components/schemas/v1.RecursiveReadOnlyMode'
+          description: 'RecursiveReadOnly must be set to Disabled, Enabled, or unspecified
+            (for non-readonly mounts).
+
+            An IfPossible value in the original VolumeMount must be translated to
+            Disabled or Enabled,
+
+            depending on the mount result.
+
+            +optional'
+      type: object
+    v1.VolumeProjection:
+      properties:
+        clusterTrustBundle:
+          allOf:
+          - $ref: '#/components/schemas/v1.ClusterTrustBundleProjection'
+          description: 'ClusterTrustBundle allows a pod to access the `.spec.trustBundle`
+            field
+
+            of ClusterTrustBundle objects in an auto-updating file.
+
+
+            Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+
+            ClusterTrustBundle objects can either be selected by name, or by the
+
+            combination of signer name and a label selector.
+
+
+            Kubelet performs aggressive normalization of the PEM contents written
+
+            into the pod filesystem.  Esoteric PEM features such as inter-block
+
+            comments and block headers are stripped.  Certificates are deduplicated.
+
+            The ordering of certificates within the file is arbitrary, and Kubelet
+
+            may change the order over time.
+
+
+            +featureGate=ClusterTrustBundleProjection
+
+            +optional'
+        configMap:
+          allOf:
+          - $ref: '#/components/schemas/v1.ConfigMapProjection'
+          description: 'configMap information about the configMap data to project
+
+            +optional'
+        downwardAPI:
+          allOf:
+          - $ref: '#/components/schemas/v1.DownwardAPIProjection'
+          description: 'downwardAPI information about the downwardAPI data to project
+
+            +optional'
+        podCertificate:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodCertificateProjection'
+          description: 'Projects an auto-rotating credential bundle (private key and
+            certificate
+
+            chain) that the pod can use either as a TLS client or server.
+
+
+            Kubelet generates a private key and uses it to send a
+
+            PodCertificateRequest to the named signer.  Once the signer approves the
+
+            request and issues a certificate chain, Kubelet writes the key and
+
+            certificate chain to the pod filesystem.  The pod does not start until
+
+            certificates have been issued for each podCertificate projected volume
+
+            source in its spec.
+
+
+            Kubelet will begin trying to rotate the certificate at the time indicated
+
+            by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+
+            timestamp.
+
+
+            Kubelet can write a single file, indicated by the credentialBundlePath
+
+            field, or separate files, indicated by the keyPath and
+
+            certificateChainPath fields.
+
+
+            The credential bundle is a single file in PEM format.  The first PEM
+
+            entry is the private key (in PKCS#8 format), and the remaining PEM
+
+            entries are the certificate chain issued by the signer (typically,
+
+            signers will return their certificate chain in leaf-to-root order).
+
+
+            Prefer using the credential bundle format, since your application code
+
+            can read it atomically.  If you use keyPath and certificateChainPath,
+
+            your application must make two separate file reads. If these coincide
+
+            with a certificate rotation, it is possible that the private key and leaf
+
+            certificate you read may not correspond to each other.  Your application
+
+            will need to check for this condition, and re-read until they are
+
+            consistent.
+
+
+            The named signer controls chooses the format of the certificate it
+
+            issues; consult the signer implementation''s documentation to learn how
+            to
+
+            use the certificates it issues.
+
+
+            +featureGate=PodCertificateProjection
+
+            +optional'
+        secret:
+          allOf:
+          - $ref: '#/components/schemas/v1.SecretProjection'
+          description: 'secret information about the secret data to project
+
+            +optional'
+        serviceAccountToken:
+          allOf:
+          - $ref: '#/components/schemas/v1.ServiceAccountTokenProjection'
+          description: 'serviceAccountToken is information about the serviceAccountToken
+            data to project
+
+            +optional'
+      type: object
+    v1.VolumeResourceRequirements:
+      properties:
+        limits:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceList'
+          description: 'Limits describes the maximum amount of compute resources allowed.
+
+            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+            +optional'
+        requests:
+          allOf:
+          - $ref: '#/components/schemas/v1.ResourceList'
+          description: 'Requests describes the minimum amount of compute resources
+            required.
+
+            If Requests is omitted for a container, it defaults to Limits if that
+            is explicitly specified,
+
+            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+
+            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+            +optional'
+      type: object
+    v1.VsphereVirtualDiskVolumeSource:
+      properties:
+        fsType:
+          description: 'fsType is filesystem type to mount.
+
+            Must be a filesystem type supported by the host operating system.
+
+            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+            +optional'
+          type: string
+        storagePolicyID:
+          description: 'storagePolicyID is the storage Policy Based Management (SPBM)
+            profile ID associated with the StoragePolicyName.
+
+            +optional'
+          type: string
+        storagePolicyName:
+          description: 'storagePolicyName is the storage Policy Based Management (SPBM)
+            profile name.
+
+            +optional'
+          type: string
+        volumePath:
+          description: volumePath is the path that identifies vSphere volume vmdk
+          type: string
+      type: object
+    v1.WeightedPodAffinityTerm:
+      properties:
+        podAffinityTerm:
+          allOf:
+          - $ref: '#/components/schemas/v1.PodAffinityTerm'
+          description: Required. A pod affinity term, associated with the corresponding
+            weight.
+        weight:
+          description: 'weight associated with matching the corresponding podAffinityTerm,
+
+            in the range 1-100.'
+          type: integer
+      type: object
     v1.WindowsSecurityContextOptions:
       properties:
         gmsaCredentialSpec:
@@ -33836,6 +42941,51 @@ components:
             and
 
             PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+            +optional'
+          type: string
+      type: object
+    v1.WorkloadReference:
+      properties:
+        name:
+          description: 'Name defines the name of the Workload object this Pod belongs
+            to.
+
+            Workload must be in the same namespace as the Pod.
+
+            If it doesn''t match any existing Workload, the Pod will remain unschedulable
+
+            until a Workload object is created and observed by the kube-scheduler.
+
+            It must be a DNS subdomain.
+
+
+            +required'
+          type: string
+        podGroup:
+          description: 'PodGroup is the name of the PodGroup within the Workload that
+            this Pod
+
+            belongs to. If it doesn''t match any existing PodGroup within the Workload,
+
+            the Pod will remain unschedulable until the Workload object is recreated
+
+            and observed by the kube-scheduler. It must be a DNS label.
+
+
+            +required'
+          type: string
+        podGroupReplicaKey:
+          description: 'PodGroupReplicaKey specifies the replica key of the PodGroup
+            to which this
+
+            Pod belongs. It is used to distinguish pods belonging to different replicas
+
+            of the same pod group. The pod group policy is applied separately to each
+            replica.
+
+            When set, it must be a DNS label.
+
 
             +optional'
           type: string
@@ -34317,4 +43467,51 @@ components:
       - path
       - ref
       - sourceId
+      type: object
+    workflows.updateArtifactConfigPayload:
+      properties:
+        envVars:
+          items:
+            $ref: '#/components/schemas/portainer.Pair'
+          type: array
+        parallelConfig:
+          $ref: '#/components/schemas/workflows.createPayloadArtifactParallelConfig'
+        prePullImage:
+          type: boolean
+        registries:
+          items:
+            type: integer
+          type: array
+        retryPeriod:
+          type: integer
+      type: object
+    workflows.updateArtifactPayload:
+      properties:
+        config:
+          $ref: '#/components/schemas/workflows.updateArtifactConfigPayload'
+        deploymentType:
+          type: string
+        files:
+          items:
+            $ref: '#/components/schemas/workflows.createPayloadFile'
+          type: array
+        id:
+          type: integer
+        targets:
+          $ref: '#/components/schemas/workflows.createPayloadArtifactTargets'
+        type:
+          $ref: '#/components/schemas/workflows.Type'
+      required:
+      - id
+      - type
+      type: object
+    workflows.updatePayload:
+      properties:
+        artifacts:
+          items:
+            $ref: '#/components/schemas/workflows.updateArtifactPayload'
+          type: array
+        name:
+          example: my-workflow
+          type: string
       type: object

--- a/uv.lock
+++ b/uv.lock
@@ -684,7 +684,7 @@ wheels = [
 
 [[package]]
 name = "mcp-portainer"
-version = "2.44.0"
+version = "2.45.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Bumps portainer-mcp to `2.45.0` to match today's Portainer 2.45.0 product release.

- Regenerated the embedded spec against upstream `2.45.0.yaml` — 428→466 ops.
  `kubernetes` grows 95→119, the largest delta and the only one landing in the
  default profile; `addons` 5→17, `omni` 13→14, `gitops` 20→21. Default
  `BASE,DOCKER,KUBERNETES,GITOPS` coverage moves 211→236 and the six-profile
  union 350→375.
- Tag inventory is unchanged at 44 — upstream added and removed no tags this
  minor, so `docs/profiles.md`'s orphan table needed only the `addons`/`omni`
  recounts.
- Re-audited every spec-defect mitigation in `spec/patch_spec.py` against raw
  upstream 2.45.0 — all 6 (the `UpdateKubernetesNamespaceDeprecated` exclusion,
  `edge_agent` tag drop, `/websocket` path drop, `policies.PolicyType` +
  `images.Status` duplicate-enum strips, `portaineree.ConditionOperator`
  bare-`=` constructor) are still load-bearing and unchanged from 2.44. No
  `patch_spec.py` change needed this cycle.
- `pyproject.toml`, `uv.lock`, Skill version footer bumped to 2.45.0.
- CHANGELOG consolidated under `[2.45.0] — 2026-08-27`, carrying the mid-cycle
  #97 re-audit entries with a note that their counts refer to 2.44.0.
- Proactively updated every operator-facing version pin that #94 had to catch
  after the fact last release (README compat line/uvx pin/Docker tags/compat
  table, `docs/distribution/claude-desktop.md`, `docs/versioning.md`,
  `Makefile`).

### Review fixes (second commit)

- Corrected the CHANGELOG coverage figures — they understated by three
  operations (233→236 default, 372→375 union).
- Restored the `2.41.x` compat row: the README matrix is cumulative, per the
  release skill and #94.
- CHANGELOG structure brought back in line with prior releases — `Targets
  Portainer 2.45.x.` line added, spec bump moved from `### Added` to the lead
  `### Changed` entry, "all five" corrected to "all six".
- Refreshed the `~380 operations` figure in `CLAUDE.md` and
  `docs/architecture.md`, stale since the 2.44 bump, to the `400+` phrasing
  `docs/profiles.md` already uses.

## Test plan

- [x] `uv run pytest` — 284/284 pass
- [x] `make specs VERSION=2.45.0` reproduces the committed spec **byte-identically**
- [x] Manually re-verified all 6 spec-defect mitigations against raw upstream
      2.45.0 (not just diffed output)
- [x] `build_server()` boots and registers 236 tools, all exposing `select`
- [x] Swept `docs/docker.md`, `.github/workflows/`, tests, and `src/` for other
      hardcoded version pins — none found beyond what's updated here

Ref: PLA-932
