### PR TITLE
Fix PolicyCreate and PolicyConflicts request-body serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,20 @@ Targets Portainer 2.45.x.
   output schemas of `ServiceImageStatus`, `containerImageStatus` and
   `stackImagesStatus`, so the effect is cosmetic; it left the then-current
   operation count unchanged at 428.
+- **`PolicyCreate` and `PolicyConflicts` were completely broken** — their
+  request-body schemas (`policies.policyCreatePayload`,
+  `policies.policyConflictsPayload`) are undocumented upstream (a bare
+  `{"type": "object"}` with no properties), so FastMCP had nothing to
+  flatten and fell back to a single opaque `body` parameter — then
+  serialized the call *wrapped* under that parameter's own name
+  (`{"body": {...}}`) instead of using it as the literal request body.
+  Portainer never saw the real fields, so every call failed with a generic
+  400 regardless of what was supplied. Fixed by injecting the real property
+  shapes (confirmed by hand against a live server) into both schemas —
+  `PolicyCreate` mirrors `PolicyUpdate`'s already-correct payload shape,
+  `PolicyConflicts` gets the minimal `Type`/`EnvironmentGroups` it actually
+  needs. `PolicyUpdate` itself was never affected — its schema already
+  declares real properties.
 
 ## [2.44.0] — 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,10 +65,17 @@ Targets Portainer 2.45.x.
   Portainer never saw the real fields, so every call failed with a generic
   400 regardless of what was supplied. Fixed by injecting the real property
   shapes (confirmed by hand against a live server) into both schemas —
-  `PolicyCreate` mirrors `PolicyUpdate`'s already-correct payload shape,
-  `PolicyConflicts` gets the minimal `Type`/`EnvironmentGroups` it actually
-  needs. `PolicyUpdate` itself was never affected — its schema already
-  declares real properties.
+  `PolicyCreate` mirrors `PolicyUpdate`'s fields, `PolicyConflicts` uses
+  the server's actual lowercase JSON tags (`policyId`, `type`,
+  `environmentGroups`) rather than the capitalised names that happen to
+  decode anyway. Both `Type`/`type` enums are read from
+  `policies.PolicyType`'s own enum at patch time rather than hand-copied,
+  so they can't silently drift out of sync with the real catalog the way
+  `PolicyUpdate`'s own local enum already has (missing `cleanup-docker`,
+  `network-security-k8s`, `pod-security-standards-k8s` — upstream's
+  pre-existing omission, not fixed here). `PolicyUpdate` itself was never
+  affected by the original defect — its schema already declared real
+  properties.
 
 ## [2.44.0] — 2026-07-30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,18 +228,20 @@ production, not relative paths). To regenerate:
    (`EXCLUDED_OPERATION_IDS`, `EXCLUDED_TAGS`), strips `/websocket/*` paths,
    normalises malformed `enum` blocks (`ENUM_STRIPS`), injects real
    properties into undocumented bare-object request-body schemas
-   (`SCHEMA_PROPERTY_FIXES` — without properties to flatten, FastMCP falls
+   (`_policy_payload_fixes` — without properties to flatten, FastMCP falls
    back to a single opaque `body` parameter and mis-serializes it, so the
-   call can never succeed no matter what's supplied), and rewrites stray
+   call can never succeed no matter what's supplied; its `Type`/`type`
+   enum is read from `policies.PolicyType` before `ENUM_STRIPS` empties it,
+   not hand-copied, so it can't silently drift), and rewrites stray
    tabs. Extend those constants when the upstream spec ships new defects —
    don't hand-edit `portainer-patched.yaml`.
 3. Re-audit the mitigations when the spec moves: upstream fixes its defects
    silently, so entries go stale without failing anything. 2.43 fixed all
    three original `EXCLUDED_OPERATION_IDS` defects and nobody noticed until
    after the 2.44 release. The load-bearing ones as of 2.45 (re-audited,
-   unchanged from 2.44 except the new `SCHEMA_PROPERTY_FIXES` entries): the
-   `=` value-tag constructor (`portaineree.ConditionOperator` still ships a
-   bare `=`, and a pristine `SafeLoader` raises on it), the
+   unchanged from 2.44 except the new policy-payload property injection):
+   the `=` value-tag constructor (`portaineree.ConditionOperator` still
+   ships a bare `=`, and a pristine `SafeLoader` raises on it), the
    `policies.PolicyType` and `images.Status` duplicate-enum strips, the
    `policies.policyCreatePayload`/`policies.policyConflictsPayload`
    property injections, and the websocket/`edge_agent` drops — those last

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,18 +226,24 @@ production, not relative paths). To regenerate:
    `spec/upstream/` (sparse, single-version), then runs `spec/patch_spec.py`.
 2. `patch_spec.py` drops operations that shouldn't reach the tool surface
    (`EXCLUDED_OPERATION_IDS`, `EXCLUDED_TAGS`), strips `/websocket/*` paths,
-   normalises malformed `enum` blocks (`ENUM_STRIPS`), and rewrites stray
+   normalises malformed `enum` blocks (`ENUM_STRIPS`), injects real
+   properties into undocumented bare-object request-body schemas
+   (`SCHEMA_PROPERTY_FIXES` — without properties to flatten, FastMCP falls
+   back to a single opaque `body` parameter and mis-serializes it, so the
+   call can never succeed no matter what's supplied), and rewrites stray
    tabs. Extend those constants when the upstream spec ships new defects —
    don't hand-edit `portainer-patched.yaml`.
 3. Re-audit the mitigations when the spec moves: upstream fixes its defects
    silently, so entries go stale without failing anything. 2.43 fixed all
    three original `EXCLUDED_OPERATION_IDS` defects and nobody noticed until
    after the 2.44 release. The load-bearing ones as of 2.45 (re-audited,
-   unchanged from 2.44): the `=` value-tag constructor (`portaineree.ConditionOperator`
-   still ships a bare `=`, and a pristine `SafeLoader` raises on it), the
-   `policies.PolicyType` and `images.Status` duplicate-enum strips, and the
-   websocket/`edge_agent` drops — those last two are policy, not defect, so
-   they stay regardless.
+   unchanged from 2.44 except the new `SCHEMA_PROPERTY_FIXES` entries): the
+   `=` value-tag constructor (`portaineree.ConditionOperator` still ships a
+   bare `=`, and a pristine `SafeLoader` raises on it), the
+   `policies.PolicyType` and `images.Status` duplicate-enum strips, the
+   `policies.policyCreatePayload`/`policies.policyConflictsPayload`
+   property injections, and the websocket/`edge_agent` drops — those last
+   two are policy, not defect, so they stay regardless.
 
 ## Versioning
 

--- a/spec/patch_spec.py
+++ b/spec/patch_spec.py
@@ -2,8 +2,10 @@
 
 Drops operations that shouldn't reach the tool surface (deprecated
 duplicates, edge-agent-only callbacks), drops `/websocket/*` paths (protocol
-upgrades, not REST), and strips malformed `enum` blocks that defeat naive
-generators.
+upgrades, not REST), strips malformed `enum` blocks that defeat naive
+generators, and injects real properties into undocumented bare-object
+request-body schemas that would otherwise collapse into a single opaque
+tool parameter FastMCP mis-serializes.
 
 Also normalises stray tab characters in scalar text — swaggo occasionally
 emits a literal tab inside a description string. Current specs keep them
@@ -57,6 +59,59 @@ ENUM_STRIPS = frozenset(
     }
 )
 
+# `policies.policyCreatePayload` and `policies.policyConflictsPayload` — the
+# request-body schemas for `PolicyCreate` (POST /policies) and
+# `PolicyConflicts` (POST /policies/conflicts) — are undocumented upstream:
+# swaggo emits a bare `{"type": "object"}` with no declared properties. With
+# nothing to flatten, FastMCP falls back to a single opaque `body` tool
+# parameter for the whole payload, but then serializes the call *wrapped*
+# under that parameter's own name (`{"body": {...}}`) instead of using its
+# value as the literal request body — Portainer never sees the real fields,
+# so every call fails with a generic 400 ("Policy name is required and
+# cannot be empty" / "Policy type must be one of the valid types") no
+# matter what's supplied. `PolicyUpdate`'s payload schema *does* declare
+# real properties, so it flattens (and works) correctly — this defect is
+# specific to the two bare-object schemas. The shapes below were confirmed
+# by hand against a live 2.45.0 server: Create mirrors `policyUpdatePayload`
+# (same underlying fields, minus the update-only path context); Conflicts
+# only needs `Type` + `EnvironmentGroups`.
+SCHEMA_PROPERTY_FIXES = {
+    "policies.policyCreatePayload": {
+        "AllowOverride": {"type": "boolean", "example": False},
+        "Data": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": (
+                "Data contains the policy-type-specific configuration. Namespace "
+                "fields on RBAC/Registry/Network Security policies are lowercased "
+                "automatically and must be valid RFC 1123 DNS labels; values still "
+                "invalid after lowercasing are rejected with a 400."
+            ),
+        },
+        "EnvironmentGroups": {"type": "array", "items": {"type": "integer"}},
+        "Name": {"type": "string", "example": "Development Policy"},
+        "Type": {
+            "allOf": [{"$ref": "#/components/schemas/policies.PolicyType"}],
+            "enum": [
+                "rbac-k8s", "rbac-docker", "security-k8s", "security-docker",
+                "setup-k8s", "setup-docker", "registry-k8s", "registry-docker",
+                "change-confirmation", "observability-k8s",
+            ],
+        },
+    },
+    "policies.policyConflictsPayload": {
+        "EnvironmentGroups": {"type": "array", "items": {"type": "integer"}},
+        "Type": {
+            "allOf": [{"$ref": "#/components/schemas/policies.PolicyType"}],
+            "enum": [
+                "rbac-k8s", "rbac-docker", "security-k8s", "security-docker",
+                "setup-k8s", "setup-docker", "registry-k8s", "registry-docker",
+                "change-confirmation", "observability-k8s",
+            ],
+        },
+    },
+}
+
 DEFAULT_OUTPUT = (
     Path(__file__).resolve().parents[1]
     / "src"
@@ -94,6 +149,11 @@ def patch(spec: dict) -> dict:
         node = schemas.get(name)
         if isinstance(node, dict):
             node.pop("enum", None)
+
+    for name, properties in SCHEMA_PROPERTY_FIXES.items():
+        node = schemas.get(name)
+        if isinstance(node, dict) and not node.get("properties"):
+            node["properties"] = properties
     return spec
 
 

--- a/spec/patch_spec.py
+++ b/spec/patch_spec.py
@@ -71,46 +71,75 @@ ENUM_STRIPS = frozenset(
 # cannot be empty" / "Policy type must be one of the valid types") no
 # matter what's supplied. `PolicyUpdate`'s payload schema *does* declare
 # real properties, so it flattens (and works) correctly — this defect is
-# specific to the two bare-object schemas. The shapes below were confirmed
-# by hand against a live 2.45.0 server: Create mirrors `policyUpdatePayload`
-# (same underlying fields, minus the update-only path context); Conflicts
-# only needs `Type` + `EnvironmentGroups`.
-SCHEMA_PROPERTY_FIXES = {
-    "policies.policyCreatePayload": {
-        "AllowOverride": {"type": "boolean", "example": False},
-        "Data": {
-            "type": "object",
-            "additionalProperties": {},
-            "description": (
-                "Data contains the policy-type-specific configuration. Namespace "
-                "fields on RBAC/Registry/Network Security policies are lowercased "
-                "automatically and must be valid RFC 1123 DNS labels; values still "
-                "invalid after lowercasing are rejected with a 400."
-            ),
+# specific to the two bare-object schemas. Field shapes confirmed by hand
+# against a live 2.45.0 server: Create mirrors `policyUpdatePayload`'s
+# fields; Conflicts uses the server's actual lowercase JSON tags
+# (`policyId`, `type`, `environmentGroups`) — capitalised names would still
+# decode (Go's `encoding/json` matches case-insensitively) but would
+# advertise names the API doesn't use. `policyId` lets a conflict check
+# exclude the policy being edited from its own results (the update-preview
+# case); omitting it would silently limit the tool to create-preview only.
+#
+# `Type` is built by `_policy_type_property` as a plain `type: string` +
+# `enum` — never `allOf: [$ref policies.PolicyType]`. That shape is exactly
+# what `ENUM_STRIPS` exists to unwind (an inner enum on the referenced
+# schema contradicting an outer one), and it would only *appear* to work
+# here because `ENUM_STRIPS` happens to run first in `patch()` and empties
+# `policies.PolicyType`'s enum before this runs — nothing pins that
+# ordering. The enum values are read from `policies.PolicyType`'s own enum
+# in `patch()` before `ENUM_STRIPS` empties it (deduplicated, since that's
+# the very defect `ENUM_STRIPS` targets), not hand-copied, so they can't
+# silently drift the way `policyUpdatePayload`'s own local enum already
+# has — it's missing three policy types added in 2.43/2.44
+# (`cleanup-docker`, `network-security-k8s`, `pod-security-standards-k8s`).
+# That's upstream's pre-existing omission on a schema this project doesn't
+# patch (`PolicyUpdate` isn't part of this defect), not fixed here.
+def _policy_type_property(policy_types: list[str]) -> dict:
+    prop: dict = {"type": "string"}
+    if policy_types:
+        prop["enum"] = policy_types
+    return prop
+
+
+def _policy_payload_fixes(policy_types: list[str]) -> dict:
+    type_property = _policy_type_property(policy_types)
+    data_property = {
+        "type": "object",
+        "additionalProperties": {},
+        "description": (
+            "Data contains the policy-type-specific configuration. Namespace "
+            "fields on RBAC/Registry/Network Security policies are lowercased "
+            "automatically and must be valid RFC 1123 DNS labels; values still "
+            "invalid after lowercasing are rejected with a 400."
+        ),
+    }
+    return {
+        "policies.policyCreatePayload": {
+            "properties": {
+                "AllowOverride": {"type": "boolean", "example": False},
+                "Data": data_property,
+                "EnvironmentGroups": {"type": "array", "items": {"type": "integer"}},
+                "Name": {"type": "string", "example": "Development Policy"},
+                "Type": type_property,
+            },
+            "required": ["Name", "Type"],
         },
-        "EnvironmentGroups": {"type": "array", "items": {"type": "integer"}},
-        "Name": {"type": "string", "example": "Development Policy"},
-        "Type": {
-            "allOf": [{"$ref": "#/components/schemas/policies.PolicyType"}],
-            "enum": [
-                "rbac-k8s", "rbac-docker", "security-k8s", "security-docker",
-                "setup-k8s", "setup-docker", "registry-k8s", "registry-docker",
-                "change-confirmation", "observability-k8s",
-            ],
+        "policies.policyConflictsPayload": {
+            "properties": {
+                "environmentGroups": {"type": "array", "items": {"type": "integer"}},
+                "policyId": {
+                    "type": "integer",
+                    "description": (
+                        "The policy being edited, if any — excluded from its own "
+                        "conflicts so an update-preview doesn't flag itself."
+                    ),
+                },
+                "type": type_property,
+            },
+            "required": ["type"],
         },
-    },
-    "policies.policyConflictsPayload": {
-        "EnvironmentGroups": {"type": "array", "items": {"type": "integer"}},
-        "Type": {
-            "allOf": [{"$ref": "#/components/schemas/policies.PolicyType"}],
-            "enum": [
-                "rbac-k8s", "rbac-docker", "security-k8s", "security-docker",
-                "setup-k8s", "setup-docker", "registry-k8s", "registry-docker",
-                "change-confirmation", "observability-k8s",
-            ],
-        },
-    },
-}
+    }
+
 
 DEFAULT_OUTPUT = (
     Path(__file__).resolve().parents[1]
@@ -145,15 +174,24 @@ def patch(spec: dict) -> dict:
             paths.pop(path)
 
     schemas = spec.get("components", {}).get("schemas", {})
+
+    # Read the deduplicated policy-type list before ENUM_STRIPS empties
+    # `policies.PolicyType`'s own (duplicated) enum below — see
+    # `_policy_type_property` for why this must happen first.
+    policy_types = sorted(
+        set((schemas.get("policies.PolicyType") or {}).get("enum") or [])
+    )
+
     for name in ENUM_STRIPS:
         node = schemas.get(name)
         if isinstance(node, dict):
             node.pop("enum", None)
 
-    for name, properties in SCHEMA_PROPERTY_FIXES.items():
+    for name, fix in _policy_payload_fixes(policy_types).items():
         node = schemas.get(name)
         if isinstance(node, dict) and not node.get("properties"):
-            node["properties"] = properties
+            node["properties"] = fix["properties"]
+            node["required"] = fix["required"]
     return spec
 
 

--- a/src/portainer_mcp/data/portainer-patched.yaml
+++ b/src/portainer_mcp/data/portainer-patched.yaml
@@ -26013,6 +26013,25 @@ components:
       type: object
     policies.policyConflictsPayload:
       type: object
+      properties:
+        EnvironmentGroups:
+          type: array
+          items:
+            type: integer
+        Type:
+          allOf:
+          - $ref: '#/components/schemas/policies.PolicyType'
+          enum:
+          - rbac-k8s
+          - rbac-docker
+          - security-k8s
+          - security-docker
+          - setup-k8s
+          - setup-docker
+          - registry-k8s
+          - registry-docker
+          - change-confirmation
+          - observability-k8s
     policies.policyConflictsResponse:
       properties:
         conflicts:
@@ -26032,6 +26051,38 @@ components:
       type: object
     policies.policyCreatePayload:
       type: object
+      properties:
+        AllowOverride:
+          type: boolean
+          example: false
+        Data:
+          type: object
+          additionalProperties: {}
+          description: Data contains the policy-type-specific configuration. Namespace
+            fields on RBAC/Registry/Network Security policies are lowercased automatically
+            and must be valid RFC 1123 DNS labels; values still invalid after lowercasing
+            are rejected with a 400.
+        EnvironmentGroups:
+          type: array
+          items:
+            type: integer
+        Name:
+          type: string
+          example: Development Policy
+        Type:
+          allOf:
+          - $ref: '#/components/schemas/policies.PolicyType'
+          enum:
+          - rbac-k8s
+          - rbac-docker
+          - security-k8s
+          - security-docker
+          - setup-k8s
+          - setup-docker
+          - registry-k8s
+          - registry-docker
+          - change-confirmation
+          - observability-k8s
     policies.policyListResponse:
       properties:
         policies:

--- a/src/portainer_mcp/data/portainer-patched.yaml
+++ b/src/portainer_mcp/data/portainer-patched.yaml
@@ -26014,24 +26014,32 @@ components:
     policies.policyConflictsPayload:
       type: object
       properties:
-        EnvironmentGroups:
+        environmentGroups:
           type: array
           items:
             type: integer
-        Type:
-          allOf:
-          - $ref: '#/components/schemas/policies.PolicyType'
+        policyId:
+          type: integer
+          description: "The policy being edited, if any \u2014 excluded from its own\
+            \ conflicts so an update-preview doesn't flag itself."
+        type: &id001
+          type: string
           enum:
-          - rbac-k8s
-          - rbac-docker
-          - security-k8s
-          - security-docker
-          - setup-k8s
-          - setup-docker
-          - registry-k8s
-          - registry-docker
           - change-confirmation
+          - cleanup-docker
+          - network-security-k8s
           - observability-k8s
+          - pod-security-standards-k8s
+          - rbac-docker
+          - rbac-k8s
+          - registry-docker
+          - registry-k8s
+          - security-docker
+          - security-k8s
+          - setup-docker
+          - setup-k8s
+      required:
+      - type
     policies.policyConflictsResponse:
       properties:
         conflicts:
@@ -26069,20 +26077,10 @@ components:
         Name:
           type: string
           example: Development Policy
-        Type:
-          allOf:
-          - $ref: '#/components/schemas/policies.PolicyType'
-          enum:
-          - rbac-k8s
-          - rbac-docker
-          - security-k8s
-          - security-docker
-          - setup-k8s
-          - setup-docker
-          - registry-k8s
-          - registry-docker
-          - change-confirmation
-          - observability-k8s
+        Type: *id001
+      required:
+      - Name
+      - Type
     policies.policyListResponse:
       properties:
         policies:

--- a/tests/test_patch_spec.py
+++ b/tests/test_patch_spec.py
@@ -162,24 +162,94 @@ def test_enum_strip_missing_schema_is_noop():
     assert spec["components"]["schemas"] == {}
 
 
-# --- SCHEMA_PROPERTY_FIXES ---------------------------------------------------
+# --- policy request-body property injection ---------------------------------
+
+
+_POLICY_TYPES_WITH_DUPES = [
+    # Mirrors the real defect: every value listed twice.
+    "rbac-k8s", "change-confirmation", "cleanup-docker",
+    "rbac-k8s", "change-confirmation", "cleanup-docker",
+]
+_POLICY_TYPES_DEDUPED = ["change-confirmation", "cleanup-docker", "rbac-k8s"]
 
 
 def test_bare_object_payload_gets_properties_injected():
     spec = _spec(
         schemas={
+            "policies.PolicyType": {"enum": _POLICY_TYPES_WITH_DUPES},
             "policies.policyCreatePayload": {"type": "object"},
             "policies.policyConflictsPayload": {"type": "object"},
         }
     )
     patch(spec)
     schemas = spec["components"]["schemas"]
-    assert set(schemas["policies.policyCreatePayload"]["properties"]) == {
+
+    create = schemas["policies.policyCreatePayload"]
+    assert set(create["properties"]) == {
         "AllowOverride", "Data", "EnvironmentGroups", "Name", "Type",
     }
-    assert set(schemas["policies.policyConflictsPayload"]["properties"]) == {
-        "EnvironmentGroups", "Type",
+    assert create["required"] == ["Name", "Type"]
+    assert create["properties"]["Type"] == {
+        "type": "string", "enum": _POLICY_TYPES_DEDUPED,
     }
+
+    conflicts = schemas["policies.policyConflictsPayload"]
+    # Lowercase, matching the server's actual JSON tags — not the create
+    # payload's PascalCase.
+    assert set(conflicts["properties"]) == {"environmentGroups", "policyId", "type"}
+    assert conflicts["required"] == ["type"]
+    assert conflicts["properties"]["type"] == {
+        "type": "string", "enum": _POLICY_TYPES_DEDUPED,
+    }
+
+
+def test_policy_type_enum_is_read_before_enum_strips_empties_it():
+    # `ENUM_STRIPS` empties `policies.PolicyType`'s own enum in the same
+    # `patch()` call — the payload fixes must read it first, not end up
+    # with an empty/absent enum because of ordering.
+    spec = _spec(
+        schemas={
+            "policies.PolicyType": {"enum": _POLICY_TYPES_WITH_DUPES},
+            "policies.policyCreatePayload": {"type": "object"},
+        }
+    )
+    patch(spec)
+    schemas = spec["components"]["schemas"]
+    assert schemas["policies.PolicyType"] == {}  # ENUM_STRIPS still applies
+    assert schemas["policies.policyCreatePayload"]["properties"]["Type"]["enum"] == (
+        _POLICY_TYPES_DEDUPED
+    )
+
+
+def test_policy_type_property_has_no_ref_or_allof():
+    # The `allOf: [$ref policies.PolicyType]` shape is what ENUM_STRIPS
+    # exists to unwind — the injected `Type`/`type` must be a plain
+    # `type: string` + `enum`, never coupled back to that schema.
+    spec = _spec(
+        schemas={
+            "policies.PolicyType": {"enum": _POLICY_TYPES_WITH_DUPES},
+            "policies.policyCreatePayload": {"type": "object"},
+            "policies.policyConflictsPayload": {"type": "object"},
+        }
+    )
+    patch(spec)
+    schemas = spec["components"]["schemas"]
+    for schema_name, field in [
+        ("policies.policyCreatePayload", "Type"),
+        ("policies.policyConflictsPayload", "type"),
+    ]:
+        prop = schemas[schema_name]["properties"][field]
+        assert "$ref" not in prop and "allOf" not in prop
+
+
+def test_policy_type_enum_missing_falls_back_to_plain_string():
+    # If `policies.PolicyType` is ever missing or has no enum, don't inject
+    # an empty (impossible-to-satisfy) enum — fall back to an unconstrained
+    # string, same as ENUM_STRIPS's own fallback.
+    spec = _spec(schemas={"policies.policyCreatePayload": {"type": "object"}})
+    patch(spec)
+    prop = spec["components"]["schemas"]["policies.policyCreatePayload"]["properties"]["Type"]
+    assert prop == {"type": "string"}
 
 
 def test_schema_property_fix_missing_schema_is_noop():

--- a/tests/test_patch_spec.py
+++ b/tests/test_patch_spec.py
@@ -162,6 +162,47 @@ def test_enum_strip_missing_schema_is_noop():
     assert spec["components"]["schemas"] == {}
 
 
+# --- SCHEMA_PROPERTY_FIXES ---------------------------------------------------
+
+
+def test_bare_object_payload_gets_properties_injected():
+    spec = _spec(
+        schemas={
+            "policies.policyCreatePayload": {"type": "object"},
+            "policies.policyConflictsPayload": {"type": "object"},
+        }
+    )
+    patch(spec)
+    schemas = spec["components"]["schemas"]
+    assert set(schemas["policies.policyCreatePayload"]["properties"]) == {
+        "AllowOverride", "Data", "EnvironmentGroups", "Name", "Type",
+    }
+    assert set(schemas["policies.policyConflictsPayload"]["properties"]) == {
+        "EnvironmentGroups", "Type",
+    }
+
+
+def test_schema_property_fix_missing_schema_is_noop():
+    # Future spec versions may drop the schema entirely — patcher must not crash.
+    spec = _spec(schemas={})
+    patch(spec)
+    assert spec["components"]["schemas"] == {}
+
+
+def test_schema_property_fix_does_not_override_real_properties():
+    # If upstream ever documents these payloads for real, don't clobber it.
+    spec = _spec(
+        schemas={
+            "policies.policyCreatePayload": {
+                "type": "object",
+                "properties": {"Upstream": {"type": "string"}},
+            },
+        }
+    )
+    patch(spec)
+    assert set(spec["components"]["schemas"]["policies.policyCreatePayload"]["properties"]) == {"Upstream"}
+
+
 # --- yaml `=` constructor ---------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

`PolicyCreate` and `PolicyConflicts` were completely broken (0% success rate) — found while E2E-testing the 2.45.0 version bump (#100, tracked in [PLA-932](https://linear.app/portainer/issue/PLA-932/verify-portainer-mcp-2450-against-a-live-portainer-2450-deployment)). Pre-existing, not caused by that release.

- Root cause: `policies.policyCreatePayload` and `policies.policyConflictsPayload` are undocumented upstream — swaggo emits a bare `{"type": "object"}` with no properties for both request bodies. With nothing to flatten, FastMCP falls back to a single opaque `body` tool parameter, but then serializes the call *wrapped* under that parameter's own name (`{"body": {...}}`) instead of using it as the literal request body — Portainer never sees the real fields, so every call fails with a generic 400 no matter what's supplied.
- Confirmed via `PORTAINER_MCP_LOG_LEVEL=DEBUG` request tracing and a direct `curl` comparison (identical payload succeeds via curl, fails via the MCP tool).
- `PolicyUpdate` is unaffected — its payload schema already declares real properties, so FastMCP flattens it correctly.
- Fix: a new `SCHEMA_PROPERTY_FIXES` mitigation in `spec/patch_spec.py` injects the real property shapes into both schemas. `PolicyCreate` mirrors `PolicyUpdate`'s already-correct shape (`Name`, `Type`, `Data`, `AllowOverride`, `EnvironmentGroups`); `PolicyConflicts` gets the minimal `Type`/`EnvironmentGroups` it actually needs. Both shapes confirmed by hand against a live 2.45.0 server before writing the fix.

## Test plan

- [x] `uv run pytest` — 287/287 pass (3 new tests for the mitigation)
- [x] `make specs VERSION=2.45.0` regenerated cleanly with the fix applied (51-line diff, scoped to the two payload schemas)
- [x] Live-verified against a real Portainer 2.45.0 deployment: `PolicyCreate` now flattens to real top-level parameters and successfully creates a policy; `PolicyConflicts` now returns real conflict data instead of a 400. Both cleaned up after.

Ref: PLA-932