### PR TITLE
Bump pypa/gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -32,6 +32,6 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,4 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
## Summary

The 2.45.0 TestPyPI dry run failed with `InvalidDistribution: '2.5' is not a valid metadata version`. Root cause: `uv build` now produces `Metadata-Version: 2.5` wheels — `hatchling` isn't pinned as a build dependency and picked up a release that stamps 2.5 instead of 2.4 (confirmed by diffing against the published 2.44.0 wheel: the *only* difference is the metadata version label itself, zero content change). The pinned `pypa/gh-action-pypi-publish@v1.14.0` bundles an older Twine that doesn't recognize "2.5" yet — even the `packaging` 25.0 library installed locally only lists up to 2.4 as valid.

`v1.14.2`'s own changelog confirms this exact fix: it bumps Twine to v7, "which will let them upload their sdists and wheels containing core packaging metadata v2.5 to (Test)PyPI."

Not a package bug, not an installer-compatibility risk — purely an outdated CI publish tool. No `CHANGELOG.md` entry, matching the precedent set by `0093025` (an earlier fix to this same pin, for a different underlying issue).

## Test plan

- [x] `uv run pytest` — 290/290 pass (unaffected, this only touches the publish workflows)
- [x] Verified the new pin (`dc37677b2e1c63e2034f94d8a5b11f265b73ba33`) is the actual commit SHA for `v1.14.2` — dereferenced the annotated tag object rather than using its SHA directly, and confirmed the commit matches the PR referenced in v1.14.2's changelog
- [ ] Re-run the TestPyPI dry run (`release-test.yml`) once this merges, to confirm the publish step now succeeds