### PR TITLE
Make the container healthcheck follow the configured bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ the MCP server.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Container healthcheck follows `PORTAINER_MCP_HTTP_PORT` and
+  `PORTAINER_MCP_HTTP_HOST`** — the image always probed `127.0.0.1:17717`, so
+  overriding the port marked a healthy server unhealthy, and under
+  `--network host` could report whatever else sat on 17717 as healthy. The
+  probe now resolves both variables with the server's own fallback semantics
+  (an empty value behaves like an unset one), and maps a wildcard bind to its
+  loopback. (#98; approach from #99 by @paulcakeface)
+
 ## [2.45.0] — 2026-08-27
 
 Targets Portainer 2.45.x.

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,9 @@ ENV PATH="/app/.venv/bin:$PATH" \
 USER portainer
 EXPOSE 17717
 
+# The probe mirrors server.py's bind resolution (`or` fallbacks, so an empty
+# value behaves like an unset one) and maps a wildcard bind to its loopback.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('127.0.0.1', 17717)); s.close()"
+  CMD python -c "import os, socket; h=os.environ.get('PORTAINER_MCP_HTTP_HOST') or '127.0.0.1'; h={'0.0.0.0': '127.0.0.1', '::': '::1'}.get(h, h); socket.create_connection((h, int(os.environ.get('PORTAINER_MCP_HTTP_PORT') or 17717)), timeout=2).close()"
 
 ENTRYPOINT ["mcp-portainer"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ The server will not start if `PORTAINER_URL` is missing, if `PORTAINER_API_KEY` 
 |---|---|---|
 | `PORTAINER_MCP_TRANSPORT` | `stdio` | `stdio` or `http`. The container image overrides to `http`. |
 | `PORTAINER_MCP_HTTP_HOST` | `127.0.0.1` | Bind address when `transport=http`. Container image overrides to `0.0.0.0` so it's reachable from outside the container. |
-| `PORTAINER_MCP_HTTP_PORT` | `17717` | Bind port when `transport=http`. |
+| `PORTAINER_MCP_HTTP_PORT` | `17717` | Bind port when `transport=http`. The container image's healthcheck follows this and `PORTAINER_MCP_HTTP_HOST`. |
 | `PORTAINER_MCP_AUTH_TOKEN` | _required for http_ | Shared bearer **gate** secret. ≥32 ASCII-printable characters, no whitespace. Generate with `openssl rand -hex 32`. Ignored under stdio. Admits the request; the caller's own Portainer key is then validated and forwarded (see below). The one alternative is the [trust-proxy auth posture](#auth-posture-identity-aware-proxies); setting both refuses to boot. |
 | `PORTAINER_MCP_TRUST_PROXY_AUTH` | `0` | Replace the gate-token compare with per-request **proxy attestation**, for identity-aware proxies that own the `Authorization` header (e.g. Pomerium in MCP server mode). See [Auth posture](#auth-posture-identity-aware-proxies). |
 | `PORTAINER_MCP_TRUSTED_PROXY_AUTH_IPS` | _unset_ | Socket-peer allowlist (IPs/CIDRs) backing `PORTAINER_MCP_TRUST_PROXY_AUTH` when **this server terminates TLS itself**. Behind a TLS-terminating proxy leave it unset — the `PORTAINER_MCP_FORWARDED_ALLOW_IPS` attestation is inherited. `*` refuses to boot. |


### PR DESCRIPTION
Fixes #98. Builds on the approach in #99 by @paulcakeface.

The image always probed `127.0.0.1:17717`, so overriding `PORTAINER_MCP_HTTP_PORT` marked a healthy server unhealthy, and under `--network host` could report whatever else sat on 17717 as healthy.

## What changed

- The healthcheck resolves `PORTAINER_MCP_HTTP_PORT` **and** `PORTAINER_MCP_HTTP_HOST` at runtime.
- It uses the same `or` fallbacks as `server.py`, so an empty value behaves like an unset one. A compose file that templates `PORTAINER_MCP_HTTP_PORT=${MCP_PORT}` with `MCP_PORT` unset keeps the probe and the server on the same port. (`os.environ.get(..., '17717')` would have made the probe crash on `int('')` while the server listened on 17717.)
- Wildcard binds map to their loopback (`0.0.0.0` → `127.0.0.1`, `::` → `::1`); any other host is probed as given. `socket.create_connection` resolves the address family, so an IPv6 bind works.
- Changelog entry under Unreleased; `docs/configuration.md` notes that the healthcheck follows the two variables.

## Validation

- Snippet exercised against real listening sockets: default, overridden port, empty port, empty host, `0.0.0.0`, `::`, `::1`, and two negative cases (probe and server on different ports). All nine behave as expected.
- Image built with `podman build --format docker` and run with `PORTAINER_MCP_HTTP_PORT=17718` and nothing on 17717: `podman healthcheck run` exits 0 and the container reports `healthy` once uvicorn is up.
- `uv run pytest`: 290 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
