### PR TITLE
Accept object bodies and default Content-Type on the proxy tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ the MCP server.
 
 ### Fixed
 
+- **Proxy tools accept a JSON object `body` and default `Content-Type` to
+  `application/json`.** `docker_proxy` / `kubernetes_proxy` declared `body`
+  as string-only, so a model sending the payload as an object was rejected
+  and typically retried by stringifying it again — which Docker then refused
+  with `cannot unmarshal string into Go value`. A body sent without a
+  `Content-Type` was also refused by Docker (`malformed Content-Type header
+  (): mime: no media type`), so any JSON POST needed an explicit header to
+  work at all. Objects and arrays are now serialized server-side, strings are
+  still forwarded verbatim, an explicit `Content-Type` is always preserved,
+  and a body that is a JSON string containing JSON (encoded twice) is
+  rejected at the tool boundary with an `encoded twice` hint instead of
+  reaching the daemon. (#105)
 - **Container healthcheck follows `PORTAINER_MCP_HTTP_PORT` and
   `PORTAINER_MCP_HTTP_HOST`** — the image always probed `127.0.0.1:17717`, so
   overriding the port marked a healthy server unhealthy, and under

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,11 @@ arbitrary paths under `/endpoints/{id}/docker/...` and
 `/endpoints/{id}/kubernetes/...`. These paths aren't enumerated in the
 OpenAPI spec (Portainer forwards them as a subpath to the underlying
 daemon), so they can't be generated. Each tool validates the path (no
-`..`, no `?#`) and blocks auth-bypass headers.
+`..`, no `?#`) and blocks auth-bypass headers. The `body` argument accepts a
+JSON object (serialized server-side) or a raw string (forwarded verbatim); a
+string that is itself JSON-encoded JSON is rejected as a double-encode, and
+`Content-Type` defaults to `application/json` when a body is sent without
+one, because Docker refuses a body with no media type.
 
 ### Tool annotations — `readOnlyHint`
 

--- a/skills/portainer-mcp-hygiene/SKILL.md
+++ b/skills/portainer-mcp-hygiene/SKILL.md
@@ -325,6 +325,17 @@ kubernetes_proxy(environment_id=N, method="PATCH",
 
 Scale to `0`, confirm the pod is gone, then back to the target count. For any workload that must not run two copies at once — anything writing to a single shared volume, such as a game server, a database, or any app with non-shared backing storage — this scale-to-zero-then-up cycle is the *only* safe restart. Never raise replicas above one to "roll" such a workload: two pods writing the same volume can corrupt it.
 
+**JSON bodies on the proxy tools — send the object, don't stringify twice.**
+`docker_proxy` and `kubernetes_proxy` accept `body` as a JSON object directly
+(serialized server-side) or as a raw string forwarded verbatim. When a body is
+sent without a `Content-Type`, the server adds `application/json` — Docker
+otherwise rejects it with `malformed Content-Type header (): mime: no media
+type`. Set `headers` only when the media type is *not* JSON, as in the
+merge-patch example above. If a call fails with `cannot unmarshal string into
+Go value`, the payload was encoded twice (a JSON string containing JSON); the
+server now rejects that shape up front with an `encoded twice` error — resend
+the object itself.
+
 ## Tool selection cheatsheet
 
 - Environment-level summary (counts, status, reachability) → `EndpointList` with snapshot projection, or `EndpointSummaryCounts`/`dockerDashboard` if the question is purely aggregate.

--- a/src/portainer_mcp/proxy.py
+++ b/src/portainer_mcp/proxy.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Annotated
+from typing import Annotated, Any
 
 import httpx
 from fastmcp import FastMCP
@@ -26,6 +26,12 @@ logger = logging.getLogger("portainer_mcp")
 # is the operator's Portainer credential; the others are common bypass /
 # auth-confusion vectors that have no realistic Docker/K8s use case.
 _BLOCKED_HEADERS = frozenset({"x-api-key", "authorization", "cookie", "host"})
+
+BODY_DESCRIPTION = (
+    "Request body for POST/PUT/PATCH: pass the JSON object directly, or a raw "
+    "string forwarded as-is. Content-Type defaults to application/json when a "
+    "body is sent without one; set `headers` to override (e.g. merge-patch)."
+)
 
 
 def _apply_select(text: str, select: str | None) -> str:
@@ -99,6 +105,41 @@ def _coerce_param_map(value: object) -> object:
     }
 
 
+def _coerce_body(value: object) -> str | None:
+    """Normalize the request body into the raw string that goes on the wire.
+
+    A JSON object or array is serialized here so the model can send the
+    payload natively instead of hand-stringifying it. A string is forwarded
+    verbatim — except one shape that is never intended: a JSON *string
+    literal* whose content is itself a JSON object/array, i.e. the payload
+    was stringified twice. Docker rejects that with an opaque "cannot
+    unmarshal string into Go value" (issue #105); name the fix instead.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+    if not isinstance(value, str):
+        raise ValueError(
+            f"expected a string or JSON object, got {type(value).__name__}"
+        )
+    try:
+        inner = json.loads(value)
+    except json.JSONDecodeError:
+        return value
+    if isinstance(inner, str):
+        try:
+            nested = json.loads(inner)
+        except json.JSONDecodeError:
+            return value
+        if isinstance(nested, (dict, list)):
+            raise ValueError(
+                "body is a JSON-encoded string containing JSON (encoded "
+                "twice); send the object itself, or a string encoded once"
+            )
+    return value
+
+
 async def _call(
     client: httpx.AsyncClient,
     *,
@@ -112,6 +153,13 @@ async def _call(
 ) -> str:
     _validate_path(path)
     _validate_headers(headers)
+    headers = dict(headers or {})
+    if body and not any(k.lower() == "content-type" for k in headers):
+        # Docker refuses a body without a media type ("malformed Content-Type
+        # header (): mime: no media type") rather than assuming JSON, and both
+        # upstream APIs speak JSON; a caller sending anything else sets the
+        # header explicitly.
+        headers["Content-Type"] = "application/json"
     url = f"/endpoints/{environment_id}/{kind}{path}"
     response = await client.request(
         method.upper(),
@@ -178,8 +226,9 @@ def register(mcp: FastMCP, client: httpx.AsyncClient, *, read_only: bool) -> Non
             Field(description="Extra request headers"),
         ] = None,
         body: Annotated[
-            str | None,
-            Field(description="Raw request body string (e.g. JSON for POST)"),
+            str | dict[str, Any] | list[Any] | None,
+            BeforeValidator(_coerce_body),
+            Field(description=BODY_DESCRIPTION),
         ] = None,
         select: Annotated[str | None, Field(description=SELECT_DESCRIPTION)] = None,
     ) -> str:
@@ -226,8 +275,9 @@ def register(mcp: FastMCP, client: httpx.AsyncClient, *, read_only: bool) -> Non
             Field(description="Extra request headers"),
         ] = None,
         body: Annotated[
-            str | None,
-            Field(description="Raw request body string (e.g. JSON manifest for POST)"),
+            str | dict[str, Any] | list[Any] | None,
+            BeforeValidator(_coerce_body),
+            Field(description=BODY_DESCRIPTION),
         ] = None,
         select: Annotated[str | None, Field(description=SELECT_DESCRIPTION)] = None,
     ) -> str:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -17,6 +17,7 @@ from fastmcp.exceptions import ToolError
 from portainer_mcp.proxy import (
     _apply_select,
     _call,
+    _coerce_body,
     _coerce_param_map,
     _validate_headers,
     _validate_path,
@@ -202,6 +203,36 @@ def test_coerce_param_map_rejects_non_object(value: str):
         _coerce_param_map(value)
 
 
+# --- _coerce_body -----------------------------------------------------------
+
+
+def test_coerce_body_none_and_plain_strings_pass_through():
+    assert _coerce_body(None) is None
+    assert _coerce_body('{"a": 1}') == '{"a": 1}'
+    assert _coerce_body("not json at all") == "not json at all"
+
+
+def test_coerce_body_serializes_object_and_array():
+    assert json.loads(_coerce_body({"Cmd": ["true"], "Tty": False})) == {
+        "Cmd": ["true"],
+        "Tty": False,
+    }
+    assert _coerce_body([1, 2]) == "[1, 2]"
+
+
+def test_coerce_body_rejects_double_encoded_json():
+    # The #105 signature: the payload stringified twice reaches Docker as a
+    # JSON string literal and fails with an opaque unmarshal error upstream.
+    with pytest.raises(ValueError, match="encoded twice"):
+        _coerce_body(json.dumps('{"AttachStdout": true}'))
+
+
+def test_coerce_body_keeps_json_string_literal_of_non_json():
+    # Only a string *containing JSON* is a double-encode; a quoted plain word
+    # is left alone rather than second-guessed.
+    assert _coerce_body('"hello"') == '"hello"'
+
+
 # --- end-to-end: BeforeValidator survives FastMCP arg validation ------------
 
 
@@ -230,6 +261,33 @@ async def test_proxy_coerces_query_params_end_to_end():
         }
     )
     assert captured["params"] == {"all": "true"}
+
+
+async def test_proxy_object_body_reaches_upstream_as_json():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = request.content
+        captured["content_type"] = request.headers.get("content-type")
+        return httpx.Response(201, json={"Id": "x"})
+
+    client = httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(handler)
+    )
+    mcp = FastMCP("test")
+    register(mcp, client, read_only=False)
+    tool = await mcp.get_tool("docker_proxy")
+
+    await tool.run(
+        {
+            "environment_id": 1,
+            "path": "/containers/abc/exec",
+            "method": "POST",
+            "body": {"AttachStdout": True, "Cmd": ["true"]},
+        }
+    )
+    assert json.loads(captured["body"]) == {"AttachStdout": True, "Cmd": ["true"]}
+    assert captured["content_type"] == "application/json"
 
 
 # --- _call HTTP error handling ----------------------------------------------
@@ -279,3 +337,61 @@ async def test_call_returns_body_on_success():
         body=None,
     )
     assert json.loads(out) == {"ok": True}
+
+
+
+def _client_capturing(captured: dict) -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        captured["body"] = request.content
+        return httpx.Response(200, json={})
+
+    return httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(handler)
+    )
+
+
+async def test_call_defaults_content_type_when_body_present():
+    captured: dict = {}
+    await _call(
+        _client_capturing(captured),
+        kind="docker",
+        environment_id=1,
+        method="POST",
+        path="/containers/abc/exec",
+        query_params=None,
+        headers=None,
+        body='{"Cmd": ["true"]}',
+    )
+    assert captured["headers"]["content-type"] == "application/json"
+    assert captured["body"] == b'{"Cmd": ["true"]}'
+
+
+async def test_call_keeps_explicit_content_type_any_case():
+    captured: dict = {}
+    await _call(
+        _client_capturing(captured),
+        kind="kubernetes",
+        environment_id=1,
+        method="PATCH",
+        path="/apis/apps/v1/namespaces/default/deployments/web",
+        query_params=None,
+        headers={"content-type": "application/merge-patch+json"},
+        body='{"spec": {"replicas": 0}}',
+    )
+    assert captured["headers"]["content-type"] == "application/merge-patch+json"
+
+
+async def test_call_adds_no_content_type_without_body():
+    captured: dict = {}
+    await _call(
+        _client_capturing(captured),
+        kind="docker",
+        environment_id=1,
+        method="GET",
+        path="/containers/json",
+        query_params=None,
+        headers=None,
+        body=None,
+    )
+    assert "content-type" not in captured["headers"]


### PR DESCRIPTION
Fixes #105.

## What

`docker_proxy` / `kubernetes_proxy` `body` handling, applied to both tools:

- `body` accepts a JSON object or array as well as a string. Objects are serialized server-side; strings are forwarded verbatim.
- A string that is itself JSON-encoded JSON (the payload stringified twice) is rejected at the tool boundary with an `encoded twice` hint instead of reaching Docker as a quoted string.
- When a body is sent with no `Content-Type`, the server adds `application/json`. An explicit header of any case is preserved, so merge-patch keeps working.
- Tool descriptions updated to say so; changelog, hygiene skill, and architecture doc updated.

## Why

Reproduced against a live Portainer with a Docker edge agent:

- **Case 2 in the issue is a real gap.** The proxy sent no `Content-Type` when the caller omitted one, and Docker refuses a body with no media type (`malformed Content-Type header (): mime: no media type`).
- **Case 1 does not originate in the server.** A string body with the JSON header reaches the daemon byte for byte and exec creation succeeds. The `cannot unmarshal string into Go value` error appears only when the body is already double-encoded before it reaches the tool, which is what a model tends to do after being told `body` must be a string. Accepting objects removes the trigger; the boundary check names the fix when it still happens.

## Verification

- Full suite: 298 passed (7 new tests in `tests/test_proxy.py`).
- Live through Claude Code against the patched dev server and a Docker edge environment:
  - string body, no headers: `201`, exec Id returned (previously `400 malformed Content-Type`)
  - string body + JSON header: `201`, unchanged
  - double-encoded body: rejected before upstream with the `encoded twice` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
