### PR TITLE
Require endpointId on stack git ops and send {} for empty JSON bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ the MCP server.
 
 ### Fixed
 
+- **`endpointId` is now a required argument on `StackGitRedeploy`,
+  `StackUpdateGit` and `StackMigrate`.** Upstream documents it as an
+  optional fallback for stacks created before Portainer 1.18, but the
+  handlers apply a missing value as environment 0, so every call without it
+  failed with `Object not found inside the database (bucket=endpoints,
+  key=0)` regardless of the stack's age. The patched spec marks it required
+  so the argument is enforced at the tool boundary. (#106)
+- **Write tools with all-optional body fields send `{}` instead of no
+  body.** FastMCP sends no request body when the model supplies no body
+  fields, and Portainer rejects that with `400 Invalid request payload:
+  EOF`, so a bare `StackGitRedeploy` ("pull and re-apply as configured")
+  could never succeed without a decoy field. Routes that declare an
+  `application/json` body now go out as an empty object, and the hygiene
+  guide's `Prune: false` workaround is gone. (#106)
 - **Proxy tools accept a JSON object `body` and default `Content-Type` to
   `application/json`.** `docker_proxy` / `kubernetes_proxy` declared `body`
   as string-only, so a model sending the payload as an object was rejected

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,14 @@ Key things to internalise before changing code:
   OpenAPI responses as `{"result": …}` to fit MCP's structured-content
   schema. `_select_wrapper` unwraps that single-key envelope before
   projecting, so callers write `[].Id` rather than `result[].Id`.
+- **Empty JSON bodies go out as `{}`.** `json_body.install()` swaps every
+  OpenAPI tool's request director for `JsonBodyDirector`, which sends `{}`
+  when a route declares an `application/json` body and the model supplied
+  no body fields. FastMCP would otherwise send no body at all, and
+  Portainer's bare `json.Decoder` answers `400 … EOF` (a no-arg
+  `StackGitRedeploy` could never succeed). It runs right after
+  `from_openapi`, before `SelectArgTransform` wraps the tools; routes
+  without a declared body are untouched.
 - **Env values redacted before projection.** `redaction.redact_envs()`
   walks the parsed response in `_select_wrapper` and in the proxy tools
   *before* JMESPath `select` runs — so `select="Env[0].value"` lands on
@@ -232,20 +240,26 @@ production, not relative paths). To regenerate:
    back to a single opaque `body` parameter and mis-serializes it, so the
    call can never succeed no matter what's supplied; its `Type`/`type`
    enum is read from `policies.PolicyType` before `ENUM_STRIPS` empties it,
-   not hand-copied, so it can't silently drift), and rewrites stray
-   tabs. Extend those constants when the upstream spec ships new defects —
-   don't hand-edit `portainer-patched.yaml`.
+   not hand-copied, so it can't silently drift), marks `endpointId`
+   required on the three stack operations whose handlers fail without it
+   (`REQUIRED_ENDPOINT_ID_OPERATIONS`), and rewrites stray tabs. Extend
+   those constants when the upstream spec ships new defects — don't
+   hand-edit `portainer-patched.yaml`.
 3. Re-audit the mitigations when the spec moves: upstream fixes its defects
    silently, so entries go stale without failing anything. 2.43 fixed all
    three original `EXCLUDED_OPERATION_IDS` defects and nobody noticed until
    after the 2.44 release. The load-bearing ones as of 2.45 (re-audited,
-   unchanged from 2.44 except the new policy-payload property injection):
+   unchanged from 2.44 except the policy-payload property injection and
+   the `endpointId` required-flip):
    the `=` value-tag constructor (`portaineree.ConditionOperator` still
    ships a bare `=`, and a pristine `SafeLoader` raises on it), the
    `policies.PolicyType` and `images.Status` duplicate-enum strips, the
    `policies.policyCreatePayload`/`policies.policyConflictsPayload`
-   property injections, and the websocket/`edge_agent` drops — those last
-   two are policy, not defect, so they stay regardless.
+   property injections, the `endpointId` required-flip on
+   `StackGitRedeploy`/`StackUpdateGit`/`StackMigrate` (the tell that
+   upstream fixed it is the "before version 1.18.0" wording leaving the
+   parameter description), and the websocket/`edge_agent` drops — those
+   last two are policy, not defect, so they stay regardless.
 
 ## Versioning
 

--- a/skills/portainer-mcp-hygiene/SKILL.md
+++ b/skills/portainer-mcp-hygiene/SKILL.md
@@ -276,14 +276,17 @@ endpoint is strong end-to-end evidence; a health check alone is necessary, not
 sufficient. The response is whatever the app returns — often non-JSON, so
 `select` may not apply (see *Non-JSON endpoints*).
 
-**A mutation call with no body fields can be rejected with `400 … EOF`.** If
-every body field of a write tool is optional and you supply none, the server
-receives *no request body at all*, and some Portainer handlers refuse to decode
-that — the signature is `Invalid request payload` with details `EOF`. The
-canonical case is `StackGitRedeploy`, where a bare redeploy ("pull the
-configured ref and re-apply") conceptually needs no arguments: pass one
-harmless body field to make the request well-formed, e.g. `Prune: false`.
-Read that error as "send at least one body field", not as a broken tool.
+**A bare `StackGitRedeploy` is a valid call — and `endpointId` is required.**
+"Pull the configured ref and re-apply" needs no body fields: omitted fields
+keep the stack's stored ref, env and Git credentials, and the server sends an
+empty JSON object on your behalf (Portainer rejects a *missing* body with
+`400 … EOF`, so there is no need for a decoy field such as `Prune: false`).
+What *is* mandatory is the `endpointId` argument, on `StackGitRedeploy`,
+`StackUpdateGit` and `StackMigrate` alike. Upstream documents it as an optional
+fallback for pre-1.18 stacks, but the handler applies a missing value as
+environment 0, so every call without it fails with `Object not found inside
+the database (bucket=endpoints, key=0)` whatever the stack's age. Read it off
+`StackInspect` or `StackList` (`EndpointId`).
 
 **`StackUpdateGit` changes the Git *settings*, not the running deployment —
 and its response looks like it already redeployed.** Repointing a ref or

--- a/spec/patch_spec.py
+++ b/spec/patch_spec.py
@@ -45,6 +45,25 @@ EXCLUDED_TAGS = frozenset({"edge_agent"})
 
 EXCLUDED_PATH_PREFIXES = ("/websocket",)
 
+# `endpointId` on these stack operations is documented as an optional fallback
+# for pre-1.18 stacks that carry no environment id, but the handlers read a
+# missing value as 0 and assign it to the stack *unconditionally* before the
+# environment lookup, so every call without it fails with `Object not found
+# inside the database (bucket=endpoints, key=0)` whatever the stack's age
+# (portainer-mcp #106; CE and EE handlers match as of 2.45.0). The web UI
+# always sends it, which is how it survived. Marking it required makes FastMCP
+# enforce the tool argument instead of relying on the model to read prose.
+# Stale-check: drop an entry once upstream ships it `required: true` or the
+# "before version 1.18.0" wording leaves its description.
+REQUIRED_ENDPOINT_ID_OPERATIONS = frozenset(
+    {"StackGitRedeploy", "StackUpdateGit", "StackMigrate"}
+)
+ENDPOINT_ID_DESCRIPTION = (
+    "Environment (endpoint) identifier of the stack. Required: the server "
+    "rejects the call without it. Read it from StackInspect/StackList "
+    "(EndpointId)."
+)
+
 # Schemas whose `enum` lists every value twice (swaggo emits the varname list
 # a second time). The duplicates parse fine, but FastMCP folds the schema into
 # an `allOf` whose inner enum then contradicts the outer one — visible on
@@ -156,6 +175,13 @@ yaml.SafeLoader.add_constructor(
 )
 
 
+def _require_endpoint_id(op: dict) -> None:
+    for param in op.get("parameters") or ():
+        if param.get("in") == "query" and param.get("name") == "endpointId":
+            param["required"] = True
+            param["description"] = ENDPOINT_ID_DESCRIPTION
+
+
 def patch(spec: dict) -> dict:
     paths = spec.setdefault("paths", {})
     for path in list(paths):
@@ -170,6 +196,9 @@ def patch(spec: dict) -> dict:
                 EXCLUDED_TAGS.intersection(op.get("tags") or ())
             ):
                 paths[path].pop(method)
+                continue
+            if op.get("operationId") in REQUIRED_ENDPOINT_ID_OPERATIONS:
+                _require_endpoint_id(op)
         if not paths[path]:
             paths.pop(path)
 

--- a/src/portainer_mcp/data/portainer-patched.yaml
+++ b/src/portainer_mcp/data/portainer-patched.yaml
@@ -15524,13 +15524,14 @@ paths:
         required: true
         schema:
           type: integer
-      - description: Stacks created before version 1.18.0 might not have an associated
-          environment(endpoint) identifier. Use this optional parameter to set the
-          environment(endpoint) identifier used by the stack.
+      - description: 'Environment (endpoint) identifier of the stack. Required: the
+          server rejects the call without it. Read it from StackInspect/StackList
+          (EndpointId).'
         in: query
         name: endpointId
         schema:
           type: integer
+        required: true
       requestBody:
         content:
           application/json:
@@ -15572,13 +15573,14 @@ paths:
         required: true
         schema:
           type: integer
-      - description: Stacks created before version 1.18.0 might not have an associated
-          environment(endpoint) identifier. Use this optional parameter to set the
-          environment(endpoint) identifier used by the stack.
+      - description: 'Environment (endpoint) identifier of the stack. Required: the
+          server rejects the call without it. Read it from StackInspect/StackList
+          (EndpointId).'
         in: query
         name: endpointId
         schema:
           type: integer
+        required: true
       requestBody:
         content:
           application/json:
@@ -15658,13 +15660,14 @@ paths:
         required: true
         schema:
           type: integer
-      - description: Stacks created before version 1.18.0 might not have an associated
-          environment(endpoint) identifier. Use this optional parameter to set the
-          environment(endpoint) identifier used by the stack.
+      - description: 'Environment (endpoint) identifier of the stack. Required: the
+          server rejects the call without it. Read it from StackInspect/StackList
+          (EndpointId).'
         in: query
         name: endpointId
         schema:
           type: integer
+        required: true
       requestBody:
         content:
           application/json:

--- a/src/portainer_mcp/json_body.py
+++ b/src/portainer_mcp/json_body.py
@@ -1,0 +1,56 @@
+"""Send `{}` instead of no body when a route declares a JSON request body.
+
+FastMCP's `RequestDirector` builds the request body only from body-located
+tool arguments, so a write tool whose body fields are all optional sends *no*
+request body when the model supplies none. Portainer decodes payloads with a
+bare `json.Decoder`, which rejects an empty body with `400 Invalid request
+payload: EOF` — so a "redeploy as configured" `StackGitRedeploy` could never
+succeed without a decoy field. Routes without a declared body are untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.server.providers.openapi import OpenAPITool
+from fastmcp.utilities.openapi.director import RequestDirector
+from fastmcp.utilities.openapi.models import HTTPRoute
+
+
+class JsonBodyDirector(RequestDirector):
+    def _unflatten_arguments(
+        self, route: HTTPRoute, flat_args: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], Any]:
+        path, query, headers, cookies, body = super()._unflatten_arguments(
+            route, flat_args
+        )
+        if body is None and _declares_json_body(route):
+            body = {}
+        return path, query, headers, cookies, body
+
+
+def _declares_json_body(route: HTTPRoute) -> bool:
+    content = route.request_body.content_schema if route.request_body else {}
+    return any(
+        media.split(";")[0].strip().lower() == "application/json"
+        for media in content
+    )
+
+
+async def install(mcp: FastMCP) -> int:
+    """Point every OpenAPI tool at a `JsonBodyDirector`; returns how many.
+
+    FastMCP creates the tools eagerly inside `from_openapi` and hands each one
+    the provider's director at construction, so there is no hook to supply a
+    director up front — swap it on the tools afterwards. Must run before
+    `SelectArgTransform` is added: the transform wraps the tools, and the
+    wrappers are what `list_tools()` returns from then on.
+    """
+    tools = [t for t in await mcp.list_tools() if isinstance(t, OpenAPITool)]
+    if not tools:
+        return 0
+    director = JsonBodyDirector(tools[0]._director._spec)
+    for tool in tools:
+        tool._director = director
+    return len(tools)

--- a/src/portainer_mcp/server.py
+++ b/src/portainer_mcp/server.py
@@ -80,6 +80,7 @@ from portainer_mcp import (
     auth_posture,
     guidance,
     http_security,
+    json_body,
     passthrough,
     profiles,
     proxy,
@@ -419,6 +420,12 @@ def build_server() -> FastMCP:
         auth=auth_provider,
         instructions=INSTRUCTIONS,
     )
+    # Before the proxy tools are registered and before SelectArgTransform wraps
+    # anything: install() only touches OpenAPI tools and needs the originals.
+    patched = asyncio.run(json_body.install(mcp))
+    if not patched:
+        raise RuntimeError("JsonBodyDirector reached no OpenAPI tools")
+    logger.info("empty JSON bodies sent as `{}` on %d tools", patched)
     if no_proxy:
         logger.info("proxy tools skipped (PORTAINER_NO_PROXY=1)")
     else:

--- a/tests/test_json_body.py
+++ b/tests/test_json_body.py
@@ -1,0 +1,86 @@
+"""`JsonBodyDirector`: a declared JSON body goes out as `{}` when no body
+arguments are supplied; routes without a body keep sending nothing."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+from fastmcp import FastMCP
+from fastmcp.server.providers.openapi import MCPType, RouteMap
+
+from portainer_mcp import json_body
+
+_ID = {"name": "id", "in": "path", "required": True, "schema": {"type": "integer"}}
+
+_SPEC = {
+    "openapi": "3.0.0",
+    "info": {"title": "t", "version": "1"},
+    "servers": [{"url": "http://test"}],
+    "paths": {
+        "/stacks/{id}/git/redeploy": {
+            "put": {
+                "operationId": "redeploy",
+                "parameters": [_ID],
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {"Prune": {"type": "boolean"}},
+                            }
+                        }
+                    },
+                },
+                "responses": {"200": {"description": "ok"}},
+            },
+        },
+        "/stacks/{id}/start": {
+            "post": {
+                "operationId": "start",
+                "parameters": [_ID],
+                "responses": {"200": {"description": "ok"}},
+            },
+        },
+    },
+}
+
+
+async def _call(name: str, args: dict) -> httpx.Request:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    client = httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(handler)
+    )
+    mcp = FastMCP.from_openapi(
+        openapi_spec=_SPEC,
+        client=client,
+        route_maps=[RouteMap(methods="*", mcp_type=MCPType.TOOL)],
+        validate_output=False,
+    )
+    assert await json_body.install(mcp) == 2
+    await mcp.call_tool(name, args)
+    (request,) = seen
+    return request
+
+
+async def test_no_body_args_sends_empty_json_object():
+    request = await _call("redeploy", {"id": 1})
+    assert request.content == b"{}"
+    assert request.headers["content-type"] == "application/json"
+
+
+async def test_supplied_body_args_are_sent_unchanged():
+    request = await _call("redeploy", {"id": 1, "Prune": False})
+    assert json.loads(request.content) == {"Prune": False}
+
+
+async def test_route_without_request_body_still_sends_nothing():
+    request = await _call("start", {"id": 1})
+    assert request.content == b""
+    assert "content-type" not in request.headers

--- a/tests/test_patch_spec.py
+++ b/tests/test_patch_spec.py
@@ -6,9 +6,11 @@ Inputs are hand-rolled minimal specs — no live Portainer YAML required.
 
 from __future__ import annotations
 
+import copy
+
 import yaml
 
-from patch_spec import patch
+from patch_spec import ENDPOINT_ID_DESCRIPTION, patch
 
 
 def _spec(paths: dict | None = None, schemas: dict | None = None) -> dict:
@@ -160,6 +162,67 @@ def test_enum_strip_missing_schema_is_noop():
     spec = _spec(schemas={})
     patch(spec)
     assert spec["components"]["schemas"] == {}
+
+
+# --- endpointId required on the stack git/migrate operations ----------------
+
+
+_LEGACY_ENDPOINT_ID_TEXT = (
+    "Stacks created before version 1.18.0 might not have an associated "
+    "environment(endpoint) identifier."
+)
+
+
+def _stack_op(operation_id: str, required: bool | None = None) -> dict:
+    param = {
+        "name": "endpointId",
+        "in": "query",
+        "schema": {"type": "integer"},
+        "description": _LEGACY_ENDPOINT_ID_TEXT,
+    }
+    if required is not None:
+        param["required"] = required
+    return {
+        "operationId": operation_id,
+        "parameters": [
+            {"name": "id", "in": "path", "required": True, "schema": {"type": "integer"}},
+            param,
+        ],
+    }
+
+
+def _endpoint_id(op: dict) -> dict:
+    return next(p for p in op["parameters"] if p["name"] == "endpointId")
+
+
+def test_endpoint_id_becomes_required_on_affected_operations():
+    ops = {
+        ("/stacks/{id}/git/redeploy", "put"): "StackGitRedeploy",
+        ("/stacks/{id}/git", "post"): "StackUpdateGit",
+        ("/stacks/{id}/migrate", "post"): "StackMigrate",
+    }
+    spec = _spec(paths={p: {m: _stack_op(oid)} for (p, m), oid in ops.items()})
+    patch(spec)
+    for (path, method) in ops:
+        param = _endpoint_id(spec["paths"][path][method])
+        assert param["required"] is True
+        assert param["description"] == ENDPOINT_ID_DESCRIPTION
+        # The path param is untouched.
+        assert spec["paths"][path][method]["parameters"][0]["name"] == "id"
+
+
+def test_endpoint_id_untouched_on_other_operations():
+    spec = _spec(
+        paths={
+            # Already required upstream — nothing to fix.
+            "/stacks/{id}": {"delete": _stack_op("StackDelete", required=True)},
+            # Genuinely optional elsewhere; the fix is per-operation, not per-name.
+            "/stacks/{id}/file": {"get": _stack_op("StackFileInspect")},
+        }
+    )
+    before = copy.deepcopy(spec)
+    patch(spec)
+    assert spec == before
 
 
 # --- policy request-body property injection ---------------------------------


### PR DESCRIPTION
## Summary

Two MCP-side fixes surfaced by #106. The reporter's actual failure (a private-repo `StackGitRedeploy` returning `authentication required: Repository not found`) is Portainer 2.39 server behaviour: that version treats the redeploy body as a full replacement, so omitting the auth fields clones anonymously. Portainer 2.44 made the payload a patch, and 2.45.0 LTS is the recommended fix for that part. Two quirks bite on every Portainer version, though, and those are fixed here.

- **`endpointId` is now required on `StackGitRedeploy`, `StackUpdateGit` and `StackMigrate`.** Upstream documents it as an optional fallback for stacks created before 1.18, but the handlers apply a missing value as environment 0 before the lookup, so every call without it fails with `Object not found inside the database (bucket=endpoints, key=0)` regardless of the stack's age. The spec patcher (`REQUIRED_ENDPOINT_ID_OPERATIONS`) marks it required so FastMCP enforces the argument. The regenerated spec differs only in those three parameters. Reported upstream separately.
- **Write tools with all-optional body fields send `{}` instead of no body.** FastMCP sends no request body when no body arguments are given, and Portainer's bare `json.Decoder` rejects that with `400 Invalid request payload: EOF`. New `json_body.JsonBodyDirector` sends an empty object whenever the route declares an `application/json` body; `build_server()` swaps it onto every OpenAPI tool before `SelectArgTransform` wraps them. Routes without a declared body still send nothing, so the proxy tools are unaffected. The hygiene guide's `Prune: false` decoy is gone.

Also: CLAUDE.md gains the director in the architecture list and the new mitigation in the spec re-audit list (stale-check tell: the "before version 1.18.0" wording leaving the upstream description).

## Test plan

- [x] `uv run pytest`: 303 passed
- [x] New tests: `endpointId` flip on the three operations, other operations untouched, `{}` sent on empty body, supplied body unchanged, no body on body-less routes
- [x] Startup smoke with the bundled 2.45.0 spec: director installed on 233 OpenAPI tools, `select` invariant intact on all 236

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
